### PR TITLE
Add clangd to default settings

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -1,36 +1,48 @@
 {
-   "clients": {
-   		"pyls": {
-   			"command": ["pyls"],
-   			"scopes": ["source.python"],
-   			"syntaxes": ["Packages/Python/Python.sublime-syntax"],
-   			"languageId": "python"
-   		},
-   		"jsts": {
-   			"command": ["javascript-typescript-stdio"],
-   			"scopes": ["source.ts", "source.tsx"],
-   			"syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage", "Packages/TypeScript-TmLanguage/TypeScriptReact.tmLanguage"],
-   			"languageId": "typescript"
-   		},
-   		"rls": {
-   			"command": ["rustup", "run", "nightly", "rls"],
-   			"scopes": ["source.rust"],
-   			"syntaxes": ["Packages/Rust/Rust.sublime-syntax"],
-   			"languageId": "rust"
-   		},
-   		"dotty": {
-   			"command": ["coursier", "launch", "ch.epfl.lamp:dotty-language-server_0.2:0.2.0-RC1", "-M", "dotty.tools.languageserver.Main", "--", "-stdio"],
-   			"scopes": ["source.scala"],
-   			"syntaxes": ["Packages/Scala/Scala.sublime-syntax"],
-   			"languageId": "scala"
-   		},
-   		"mscpp": {
-   			"command": ["/Users/tomv/.vscode/extensions/ms-vscode.cpptools-0.12.0/bin/Microsoft.VSCode.CPP.Extension.darwin"],
-   			"scopes": ["source.c++"],
-   			"syntaxes": ["Packages/C++/C++.sublime-syntax"],
-   			"languageId": "cpp"
-   		}
-   },
-   "show_status_messages": true,
-   "show_view_status": true
+  "clients":
+  {
+      "pyls":
+      {
+        "command": ["pyls"],
+        "scopes": ["source.python"],
+        "syntaxes": ["Packages/Python/Python.sublime-syntax"],
+        "languageId": "python"
+      },
+      "jsts":
+      {
+        "command": ["javascript-typescript-stdio"],
+        "scopes": ["source.ts", "source.tsx"],
+        "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage", "Packages/TypeScript-TmLanguage/TypeScriptReact.tmLanguage"],
+        "languageId": "typescript"
+      },
+      "rls":
+      {
+        "command": ["rustup", "run", "nightly", "rls"],
+        "scopes": ["source.rust"],
+        "syntaxes": ["Packages/Rust/Rust.sublime-syntax"],
+        "languageId": "rust"
+      },
+      "dotty":
+      {
+        "command": ["coursier", "launch", "ch.epfl.lamp:dotty-language-server_0.2:0.2.0-RC1", "-M", "dotty.tools.languageserver.Main", "--", "-stdio"],
+        "scopes": ["source.scala"],
+        "syntaxes": ["Packages/Scala/Scala.sublime-syntax"],
+        "languageId": "scala"
+      },
+      // "mscpp": {
+      //   "command": ["/Users/tomv/.vscode/extensions/ms-vscode.cpptools-0.12.0/bin/Microsoft.VSCode.CPP.Extension.darwin"],
+      //   "scopes": ["source.c++"],
+      //   "syntaxes": ["Packages/C++/C++.sublime-syntax"],
+      //   "languageId": "cpp"
+      // },
+      "clangd":
+      {
+        "command": ["clangd"],
+        "scopes": ["source.c", "source.c++", "source.objc", "source.objc++"],
+        "syntaxes": ["Packages/C++/C.sublime-syntax", "Packages/C++/C++.sublime-syntax", "Packages/Objective-C/Objective-C.sublime-syntax", "Packages/Objective-C/Objective-C++.sublime-syntax"],
+        "languageId": "c-family"
+      }
+  },
+  "show_status_messages": true,
+  "show_view_status": true
 }


### PR DESCRIPTION
I've commented out the mscpp server because its path is hardcoded. I'm also unsure how the plugin responds to multiple servers being able to handle the same language. How would that work?