### PR TITLE
Improve highlighting for diagnostics

### DIFF
--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -1,7 +1,13 @@
 %YAML 1.2
 ---
+# [Subl]: https://www.sublimetext.com/docs/3/syntax.html
+# [LSP]: https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
 hidden: true
 scope: output.lsp.diagnostics
+
+variables:
+  start_of_diag_body: ^\s+(?=\d)
+  filename_and_colon: ^(.*)(:)$
 
 contexts:
   main:
@@ -9,41 +15,53 @@ contexts:
     - include: diagnostic-body
 
   diagnostic-preamble:
-    - match: ^(.*)(:)$
+    - match: '{{filename_and_colon}}'
       captures:
         0: meta.diagnostic.preamble.lsp
         1: string.unquoted.lsp
         2: punctuation.separator.lsp
 
   diagnostic-body:
-    - match: ^\s+(?=\d)
+    - match: '{{start_of_diag_body}}'
       push:
-        - meta_scope: meta.diagnostic.body.lsp
-        - include: pop-at-end
-        - match: (\d+)(?:(:)(\d+))?
-          captures:
-            1: constant.numeric.integer.decimal.lsp
-            2: punctuation.separator.lsp
-            3: constant.numeric.integer.decimal.lsp
-          push:
-            - include: pop-at-end
-            - match: '[^\s]+'
-              scope: comment.line.lsp
-              push:
-                - include: pop-at-end
-                - match: \berror\b
-                  scope: markup.deleted.lsp markup.error.lsp
-                  push: after-diagnostic-type-token
-                - match: \bwarning\b
-                  scope: markup.heading.lsp markup.warning.lsp
-                  push: after-diagnostic-type-token
-                - match: \binfo\b
-                  scope: markup.inserted.lsp markup.info.lsp
-                  push: after-diagnostic-type-token
+        - ensure-diag-meta-scope
+        - expect-diag-message
+        - expect-diag-type
+        - expect-linter-type
+        - expect-line-maybe-column
 
-  after-diagnostic-type-token:
-    - include: pop-at-end
+  ensure-diag-meta-scope:
+    - meta_scope: meta.diagnostic.body.lsp
+    - match: ""  # match the empty string
+      pop: true
 
-  pop-at-end:
+  expect-diag-message:
+    # Various server-specific tokens may get special treatment here in the diag message.
     - match: $
+      pop: true
+
+  expect-diag-type:
+    # See: https://github.com/sublimehq/Packages/issues/1036
+    # We use old markup scopes too so that old color schemes can catch up.
+    - match: \berror\b
+      scope: markup.error.lsp markup.deleted.lsp
+      pop: true
+    - match: \bwarning\b
+      scope: markup.warning.lsp markup.heading.lsp
+      pop: true
+    - match: \binfo\b
+      scope: markup.info.lsp markup.inserted.lsp
+      pop: true
+
+  expect-linter-type:
+    - match: \S+
+      scope: comment.line.lsp
+      pop: true
+
+  expect-line-maybe-column:
+    - match: (\d+)(?:(:)(\d+))?
+      captures:
+        1: constant.numeric.integer.decimal.lsp
+        2: punctuation.separator.lsp
+        3: constant.numeric.integer.decimal.lsp
       pop: true

--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -1,21 +1,49 @@
 %YAML 1.2
 ---
 hidden: true
-scope: diagnostics
+scope: output.lsp.diagnostics
 
 contexts:
   main:
-    - match: ^(.*):$
-      scope: keyword.other.diagnostics.file
-    - match: ^\s*([0-9]+:?[0-9]+)\s*(.*)\s*(error)\s*(.*)$
+    - include: diagnostic-preamble
+    - include: diagnostic-body
+
+  diagnostic-preamble:
+    - match: ^(.*)(:)$
       captures:
-        1: punctuation.comment.diagnostics.location
-        2: comment.source.item.diagnostics
-        3: sublimelinter.mark.error
-        4: meta.diagnostics.message
-    - match: ^\s*([0-9]+:?[0-9]+)\s*(.*)\s*(warning)\s*(.*)$
-      captures:
-        1: punctuation.comment.diagnostics.location
-        2: comment.source.item.diagnostics
-        3: sublimelinter.mark.warning
-        4: meta.diagnostics.message
+        0: meta.diagnostic.preamble.lsp
+        1: string.unquoted.lsp
+        2: punctuation.separator.lsp
+
+  diagnostic-body:
+    - match: ^\s+(?=\d)
+      push:
+        - meta_scope: meta.diagnostic.body.lsp
+        - include: pop-at-end
+        - match: (\d+)(?:(:)(\d+))?
+          captures:
+            1: constant.numeric.integer.decimal.lsp
+            2: punctuation.separator.lsp
+            3: constant.numeric.integer.decimal.lsp
+          push:
+            - include: pop-at-end
+            - match: '[^\s]+'
+              scope: comment.line.lsp
+              push:
+                - include: pop-at-end
+                - match: \berror\b
+                  scope: markup.deleted.lsp markup.error.lsp
+                  push: after-diagnostic-type-token
+                - match: \bwarning\b
+                  scope: markup.heading.lsp markup.warning.lsp
+                  push: after-diagnostic-type-token
+                - match: \binfo\b
+                  scope: markup.inserted.lsp markup.info.lsp
+                  push: after-diagnostic-type-token
+
+  after-diagnostic-type-token:
+    - include: pop-at-end
+
+  pop-at-end:
+    - match: $
+      pop: true

--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -37,12 +37,12 @@ contexts:
 
   expect-diag-message:
     # Various server-specific tokens may get special treatment here in the diag message.
-    - match: $
-      pop: true
+    - include: pop-at-end
 
   expect-diag-type:
     # See: https://github.com/sublimehq/Packages/issues/1036
     # We use old markup scopes too so that old color schemes can catch up.
+    - include: pop-at-end
     - match: \berror\b
       scope: markup.error.lsp markup.deleted.lsp
       pop: true
@@ -54,14 +54,20 @@ contexts:
       pop: true
 
   expect-linter-type:
+    - include: pop-at-end
     - match: \S+
       scope: comment.line.lsp
       pop: true
 
   expect-line-maybe-column:
+    - include: pop-at-end
     - match: (\d+)(?:(:)(\d+))?
       captures:
         1: constant.numeric.integer.decimal.lsp
         2: punctuation.separator.lsp
         3: constant.numeric.integer.decimal.lsp
+      pop: true
+
+  pop-at-end:
+    - match: $
       pop: true


### PR DESCRIPTION
Somewhat more structured syntax for diagnostics:

<img width="961" alt="schermafbeelding 2017-08-18 om 16 16 43" src="https://user-images.githubusercontent.com/2431823/29462751-b5b1aa50-8430-11e7-9d20-9fd97e77db36.png">

You could consider highlighting the Exxx and Dxxx numbers at this point, but that seems to be too python-specific. I'm wondering if a per-server syntax would be beneficial.