### PR TITLE
Improve visual settings of output panels

### DIFF
--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -7,7 +7,7 @@ scope: output.lsp.diagnostics
 
 variables:
   start_of_diag_body: ^\s+(?=\d)
-  filename_and_colon: ^(.*)(:)$
+  filename_and_colon: ^\s*(\S)\s+(.*)(:)$
 
 contexts:
   main:
@@ -18,8 +18,9 @@ contexts:
     - match: '{{filename_and_colon}}'
       captures:
         0: meta.diagnostic.preamble.lsp
-        1: string.unquoted.lsp
-        2: punctuation.separator.lsp
+        1: punctuation.section.diagnostics.preample.lsp
+        2: string.unquoted.lsp
+        3: punctuation.separator.lsp
 
   diagnostic-body:
     - match: '{{start_of_diag_body}}'

--- a/main.py
+++ b/main.py
@@ -996,7 +996,7 @@ def is_at_word(view: sublime.View, event) -> bool:
         return False
 
 
-OUTPUT_SETTINGS = {
+OUTPUT_PANEL_SETTINGS = {
     "auto_indent": False,
     "draw_indent_guides": False,
     "draw_white_space": "None",
@@ -1015,7 +1015,7 @@ OUTPUT_SETTINGS = {
 def create_output_panel(window: sublime.Window, name: str) -> sublime.View:
     panel = window.create_output_panel(name)
     settings = panel.settings()
-    for key, value in OUTPUT_SETTINGS.items():
+    for key, value in OUTPUT_PANEL_SETTINGS.items():
         settings.set(key, value)
     return panel
 

--- a/main.py
+++ b/main.py
@@ -996,33 +996,27 @@ def is_at_word(view: sublime.View, event) -> bool:
         return False
 
 
+OUTPUT_SETTINGS = {
+    "auto_indent": False,
+    "draw_indent_guides": False,
+    "draw_white_space": "None",
+    "gutter": False,
+    'is_widget': True,
+    "line_numbers": False,
+    "margin": 3,
+    "match_brackets": False,
+    "scroll_past_end": False,
+    "tab_size": 4,
+    "translate_tabs_to_spaces": False,
+    "word_wrap": False
+}
+
+
 def create_output_panel(window: sublime.Window, name: str) -> sublime.View:
     panel = window.create_output_panel(name)
     settings = panel.settings()
-    # Don't mess with my indenting Sublime!
-    settings.set("auto_indent", False)
-    # Don't draw indent guide lines
-    settings.set("draw_indent_guides", False)
-    # Don't draw white space dots
-    settings.set("draw_white_space", "None")
-    # Don't need gutter or line numbers
-    settings.set("gutter", False)
-    # Let all plugins no to leave this view alone
-    settings.set('is_widget', True)
-    # Don't show line numbers
-    settings.set("line_numbers", False)
-    # Don't need extra spacing
-    settings.set("margin", 3)
-    # Don't highlight matching brackets
-    settings.set("match_brackets", False)
-    # Don't make output panel seem empty
-    settings.set("scroll_past_end", False)
-    # Set a tab size wich may result in best table view
-    settings.set("tab_size", 4)
-    # Don't translate anything
-    settings.set("translate_tabs_to_spaces", False)
-    # Don't Wrap too long lines
-    settings.set("word_wrap", False)
+    for key, value in OUTPUT_SETTINGS.items():
+        settings.set(key, value)
     return panel
 
 
@@ -1070,6 +1064,7 @@ class LspSymbolReferencesCommand(sublime_plugin.TextCommand):
 
         if (len(references)) > 0:
             panel = ensure_references_panel(window)
+            panel.settings().set("result_base_dir", base_dir)
             panel.set_read_only(False)
             panel.run_command("lsp_clear_panel")
             panel.run_command('append', {
@@ -1238,6 +1233,7 @@ def update_diagnostics_panel(window):
     if window.id() in window_file_diagnostics:
         active_panel = window.active_panel()
         is_active_panel = (active_panel == "output.diagnostics")
+        panel.settings().set("result_base_dir", base_dir)
         panel.set_read_only(False)
         panel.run_command("lsp_clear_panel")
         file_diagnostics = window_file_diagnostics[window.id()]

--- a/main.py
+++ b/main.py
@@ -822,7 +822,7 @@ def format_diagnostic(diagnostic: Diagnostic) -> str:
     line, column = diagnostic.range.start
     location = "{:>8}:{:<4}".format(line + 1, column + 1)
     message = diagnostic.message.replace("\n", " ").replace("\r", "")
-    return "{}\t{:<12}\t{:<10}\t{}".format(
+    return " {}\t{:<12}\t{:<10}\t{}".format(
         location, diagnostic.source, format_severity(diagnostic.severity), message)
 
 

--- a/main.py
+++ b/main.py
@@ -1252,7 +1252,6 @@ def update_diagnostics_panel(window):
         panel.set_read_only(True)
 
 
-
 def append_diagnostics(panel, file_path, origin_diagnostics):
     panel.run_command('append',
                       {'characters':  " ◌ {}:\n".format(file_path),

--- a/main.py
+++ b/main.py
@@ -819,11 +819,11 @@ def format_severity(severity: int) -> str:
 
 
 def format_diagnostic(diagnostic: Diagnostic) -> str:
-    (line, character) = diagnostic.range.start
-    location = "{}:{}".format(line + 1, character + 1)
-    formattedMessage = diagnostic.message.replace("\n", "").replace("\r", "")
-    return "\t{:<8}\t{:<8}\t{:<8}\t{}".format(
-        location, diagnostic.source, format_severity(diagnostic.severity), formattedMessage)
+    line, column = diagnostic.range.start
+    location = "{:>8}:{:<4}".format(line + 1, column + 1)
+    message = diagnostic.message.replace("\n", " ").replace("\r", "")
+    return "{}\t{:<12}\t{:<10}\t{}".format(
+        location, diagnostic.source, format_severity(diagnostic.severity), message)
 
 
 class LspSymbolRenameCommand(sublime_plugin.TextCommand):
@@ -1001,18 +1001,28 @@ def create_output_panel(window: sublime.Window, name: str) -> sublime.View:
     settings = panel.settings()
     # Don't mess with my indenting Sublime!
     settings.set("auto_indent", False)
+    # Don't draw indent guide lines
+    settings.set("draw_indent_guides", False)
+    # Don't draw white space dots
+    settings.set("draw_white_space", "None")
     # Don't need gutter or line numbers
     settings.set("gutter", False)
-    # Don't draw indent guide lines
-    settings.set("indent_guide_options", [])
     # Let all plugins no to leave this view alone
     settings.set('is_widget', True)
+    # Don't show line numbers
+    settings.set("line_numbers", False)
+    # Don't need extra spacing
+    settings.set("margin", 3)
+    # Don't highlight matching brackets
+    settings.set("match_brackets", False)
+    # Don't make output panel seem empty
+    settings.set("scroll_past_end", False)
     # Set a tab size wich may result in best table view
-    settings.set("tab_size", 8)
-    # Don't translate anything.
+    settings.set("tab_size", 4)
+    # Don't translate anything
     settings.set("translate_tabs_to_spaces", False)
-    base_dir = get_project_path(window)
-    settings.set("result_base_dir", base_dir)
+    # Don't Wrap too long lines
+    settings.set("word_wrap", False)
     return panel
 
 

--- a/main.py
+++ b/main.py
@@ -1212,7 +1212,7 @@ class LspShowDiagnosticsPanelCommand(sublime_plugin.WindowCommand):
 
 def create_diagnostics_panel(window):
     panel = create_output_panel(window, "diagnostics")
-    panel.settings().set("result_file_regex", r"^(.*):$")
+    panel.settings().set("result_file_regex", r"^\s*\S\s+(\S.*):$")
     panel.settings().set("result_line_regex", r"^\s+([0-9]+):?([0-9]+).*$")
     panel.assign_syntax("Packages/" + PLUGIN_NAME +
                         "/Syntaxes/Diagnostics.sublime-syntax")
@@ -1252,9 +1252,10 @@ def update_diagnostics_panel(window):
         panel.set_read_only(True)
 
 
+
 def append_diagnostics(panel, file_path, origin_diagnostics):
     panel.run_command('append',
-                      {'characters': file_path + ":\n",
+                      {'characters':  " ◌ {}:\n".format(file_path),
                        'force': True})
     for origin, diagnostics in origin_diagnostics.items():
         for diagnostic in diagnostics:


### PR DESCRIPTION
I found some further settings to improve the look and feel of the output panel yesterday, which I forgot to push to the recently merged branch. So here it is as another PR

- formatting `line:column` to ensure the colons being aligned
- (hopefully) provide enough space for each column so the tab_size can be reduced to 4 which makes the output look more compact
- added a bunch of settings to ensure to make the output panel look nicer for everyone removing unnecessary stuff
- removed the `base_dir` setting as it not used anywhere and would possibly not make sense to as it is created once but might change during lifetime of the panel, if the open project is changed on the fly. 