### PR TITLE
Scope naming

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -41,5 +41,5 @@
   "show_view_status": true,
   "auto_show_diagnostics_panel": true,
   "show_diagnostics_phantoms": true,
-  "diagnostic_error_region_scope": "markup.error sublimelinter.mark.error"
+  "diagnostic_error_region_scope": "markup.error.lsp sublimelinter.mark.error"
 }

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -41,5 +41,5 @@
   "show_view_status": true,
   "auto_show_diagnostics_panel": true,
   "show_diagnostics_phantoms": true,
-  "diagnostic_error_region_scope": "sublimelinter.mark.error"
+  "diagnostic_error_region_scope": "markup.error sublimelinter.mark.error"
 }

--- a/main.py
+++ b/main.py
@@ -19,12 +19,12 @@ except ImportError:
 
 PLUGIN_NAME = 'LSP'
 SUBLIME_WORD_MASK = 515
-SUBLIME_LINTER_MARK_ERROR = 'sublimelinter.mark.error'
+MARKUP_ERROR = 'markup.error sublimelinter.mark.error'
 show_status_messages = True
 show_view_status = True
 auto_show_diagnostics_panel = True
 show_diagnostics_phantoms = True
-diagnostic_error_region_scope = SUBLIME_LINTER_MARK_ERROR  # 'markup.deleted.diff'
+diagnostic_error_region_scope = MARKUP_ERROR
 
 configs = []  # type: List[ClientConfig]
 
@@ -258,7 +258,7 @@ def load_settings():
     show_view_status = settings_obj.get("show_view_status", True)
     auto_show_diagnostics_panel = settings_obj.get("auto_show_diagnostics_panel", True)
     show_diagnostics_phantoms = settings_obj.get("show_diagnostics_phantoms", True)
-    diagnostic_error_region_scope = settings_obj.get("diagnostic_error_region_scope", SUBLIME_LINTER_MARK_ERROR)
+    diagnostic_error_region_scope = settings_obj.get("diagnostic_error_region_scope", MARKUP_ERROR)
     settings_obj.add_on_change("_on_new_settings", load_settings)
 
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ except ImportError:
 
 PLUGIN_NAME = 'LSP'
 SUBLIME_WORD_MASK = 515
-MARKUP_ERROR = 'markup.error sublimelinter.mark.error'
+MARKUP_ERROR = 'markup.error.lsp sublimelinter.mark.error'
 show_status_messages = True
 show_view_status = True
 auto_show_diagnostics_panel = True
@@ -1138,7 +1138,7 @@ def update_diagnostics_in_view(view: sublime.View, diagnostics: 'List[Diagnostic
         # TODO: split between warning and error
         if (len(regions)) > 0:
             # TODO: stop stealing SublimeLinter's coloring.
-            view.add_regions("errors", regions, diagnostic_error_region_scope,
+            view.add_regions("lsp_errors", regions, diagnostic_error_region_scope,
                              "dot",
                              sublime.DRAW_SQUIGGLY_UNDERLINE | UNDERLINE_FLAGS)
         else:


### PR DESCRIPTION
We should consistently use `markup.error.lsp` to scope errors and `markup.warning.lsp` later for warnings as they are considered (new) RFC. `sublimelinter.mark.error` is kept for backward compatibility with older color schemes.

Region names should always contain or better start with the package name as they must be unique.