### PR TITLE
Apply scopes from diagnostics t references output panel highlighting

### DIFF
--- a/Syntaxes/References.sublime-syntax
+++ b/Syntaxes/References.sublime-syntax
@@ -1,14 +1,29 @@
 %YAML 1.2
 ---
 hidden: true
-scope: references
+scope: output.lsp.references
 
 contexts:
   main:
-    - match: ^(.*):$
-      scope: keyword.other.references.file
-    - match: ^\s+(.*)\s+(\d*+:\d+)$
-      captures:
-        1: meta.references.message
-        2: punctuation.comment.references.location
+    - include: references-preamble
+    - include: references-body
 
+  references-preamble:
+    # References to "function" at path\file.py:
+    - match: ^(.*)(:)$
+      captures:
+        0: meta.references.preamble.lsp
+        1: string.unquoted.lsp
+        2: punctuation.separator.lsp
+
+  references-body:
+    # Examples:
+    #    c:\path name\file name.py 423:32
+    #    /unixpath/file.py 815:1
+    - match: ^\s+(\S.+)\s+(\d+)(?:(:)(\d+))?$
+      captures:
+        0: meta.references.body.lsp
+        1: meta.path.file.lsp
+        2: constant.numeric.integer.decimal.lsp
+        3: punctuation.separator.lsp
+        4: constant.numeric.integer.decimal.lsp

--- a/Syntaxes/References.sublime-syntax
+++ b/Syntaxes/References.sublime-syntax
@@ -17,13 +17,18 @@ contexts:
         2: punctuation.separator.lsp
 
   references-body:
+    # Must match the
+    #    - "result_file_regex" setting
+    #    - reference output format
     # Examples:
-    #    c:\path name\file name.py 423:32
-    #    /unixpath/file.py 815:1
-    - match: ^\s+(\S.+)\s+(\d+)(?:(:)(\d+))?$
+    #    ◌ c:\path name\file name.py 423:32
+    #    ◌ /unixpath/file.py 815:1
+    - match: ^\s+(\S)\s+((\S.+)\s+(\d+)(?:(:)(\d+))?)$
       captures:
         0: meta.references.body.lsp
-        1: meta.path.file.lsp
-        2: constant.numeric.integer.decimal.lsp
-        3: punctuation.separator.lsp
+        1: punctuation.section.path.reference.lsp
+        2: meta.path.reference.lsp
+        3: entity.name.file.lsp
         4: constant.numeric.integer.decimal.lsp
+        5: punctuation.separator.lsp
+        6: constant.numeric.integer.decimal.lsp

--- a/main.py
+++ b/main.py
@@ -1023,7 +1023,7 @@ def ensure_references_panel(window: sublime.Window):
 def create_references_panel(window: sublime.Window):
     panel = create_output_panel(window, "references")
     panel.settings().set("result_file_regex",
-                         r"^\s+(\S*)\s+([0-9]+):?([0-9]+)$")
+                         r"^\s+\S\s+(\S.+)\s+(\d+):?(\d+)$")
     panel.assign_syntax("Packages/" + PLUGIN_NAME +
                         "/Syntaxes/References.sublime-syntax")
     return panel
@@ -1086,7 +1086,7 @@ def format_reference(reference, base_dir):
     start = reference.get('range').get('start')
     file_path = uri_to_filename(reference.get("uri"))
     relative_file_path = os.path.relpath(file_path, base_dir)
-    return "\t{} {}:{}".format(
+    return " ◌ {} {}:{}".format(
         relative_file_path,
         start.get('line') + 1,
         start.get('character') + 1

--- a/main.py
+++ b/main.py
@@ -1086,7 +1086,7 @@ def format_reference(reference, base_dir):
     start = reference.get('range').get('start')
     file_path = uri_to_filename(reference.get("uri"))
     relative_file_path = os.path.relpath(file_path, base_dir)
-    return "\t{}\t{}:{}".format(
+    return "\t{} {}:{}".format(
         relative_file_path,
         start.get('line') + 1,
         start.get('character') + 1


### PR DESCRIPTION
The references output is quite static so multiple pushes may make things too complicated here.
The scope names are applied the same way we did for diagnostics.

The tab between file path and location is changed into a normal whitespace as tab does not align correctly if the file paths' length in the list differs too much. It looks better with fixed distance.

We may or may not scope the preamble more detailed, but I find a more minimalistic scoping better at the moment.