### PR TITLE
Improve compatibility with flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -1466,6 +1466,10 @@ class HoverHandler(sublime_plugin.ViewEventListener):
 
     def handle_response(self, response, point):
         debug(response)
+        if response is None:
+            # Flow returns None sometimes
+            # See: https://github.com/flowtype/flow-language-server/issues/51
+            return
         contents = response.get('contents')
         if len(contents) < 1:
             return
@@ -1474,21 +1478,21 @@ class HoverHandler(sublime_plugin.ViewEventListener):
 
     def show_hover(self, point, contents):
         formatted = []
-        if isinstance(contents, str):
-            formatted.append(contents)
-        else:
-            for item in contents:
-                value = ""
-                language = None
-                if isinstance(item, str):
-                    value = item
-                else:
-                    value = item.get("value")
-                    language = item.get("language")
-                if language:
-                    formatted.append("```{}\n{}\n```".format(language, value))
-                else:
-                    formatted.append(value)
+        if not isinstance(contents, list):
+            contents = [contents]
+
+        for item in contents:
+            value = ""
+            language = None
+            if isinstance(item, str):
+                value = item
+            else:
+                value = item.get("value")
+                language = item.get("language")
+            if language:
+                formatted.append("```{}\n{}\n```".format(language, value))
+            else:
+                formatted.append(value)
 
         mdpopups.show_popup(
             self.view,


### PR DESCRIPTION
Nice package! :)

I tried to integrate flow (see [this](https://github.com/flowtype/flow-language-server) LSP library) with this ST package and found some issues with the hover support.

One issue was that the code didn't comply with the specification for the hover payload. The contents attribute can look like this `contents: MarkedString | MarkedString[];` (see [here](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_hover)), however it was implemented to only accept `contents: string | MarkedString[];`.

Another issue was that flow sometimes returns null instead of a MarkedString (array). This is flow's fault, but checking for that doesn't do any harm, I think.

The actual flow integration can be done by installing [this](https://github.com/flowtype/flow-language-server) package and adding the following to the config:

```
"flow":
      {
        "command": ["flow-language-server", "--stdio"],
        "scopes": ["source.js"],
        "syntaxes": ["Packages/Babel/JavaScript (Babel).sublime-syntax", "Packages/JavaScript/JavaScript.sublime-syntax"],
        "languageId": "javascript"
      },
```