### PR TITLE
Turn most default logging off, add settings to re-enable

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -41,5 +41,9 @@
   "show_view_status": true,
   "auto_show_diagnostics_panel": true,
   "show_diagnostics_phantoms": true,
-  "diagnostic_error_region_scope": "markup.error.lsp sublimelinter.mark.error"
+  "diagnostic_error_region_scope": "markup.error.lsp sublimelinter.mark.error",
+  "log_debug": false,
+  "log_server": true,
+  "log_stderr": false
+
 }


### PR DESCRIPTION
Adds flags as requested in issue #15:

log_debug: (off) logs outgoing requests, responses, etc.
log_server: (on) log entries received from the server through `window/logMessage`
log_stderr: (off) some servers write logging output here.

Removes UTF-8 decoding from stderr stream as client is likely not obliged to send utf-8 and can cause errors like issue #12