### PR TITLE
Use urllib to translate between url and filename

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,20 +1,24 @@
-import sublime_plugin
-import sublime
-import subprocess
-import threading
+import html
 import json
 import os
+import subprocess
 import sys
-import urllib.request as urllib
-from urllib.parse import urljoin
+import threading
 from collections import OrderedDict
-import html
-import mdpopups
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+from urllib.request import pathname2url
+from urllib.request import url2pathname
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional
     assert Any and List and Dict and Tuple and Callable and Optional
 except ImportError:
     pass
+
+import sublime_plugin
+import sublime
+
+import mdpopups
 
 
 PLUGIN_NAME = 'LSP'
@@ -564,14 +568,11 @@ unsubscribe_initialize_on_activated = None
 
 
 def filename_to_uri(path: str) -> str:
-    return urljoin('file:', urllib.pathname2url(path))
+    return urljoin('file:', pathname2url(path))
 
 
 def uri_to_filename(uri: str) -> str:
-    if os.name == 'nt':
-        return urllib.url2pathname(uri.replace("file://", ""))
-    else:
-        return urllib.url2pathname(uri).replace("file://", "")
+    return url2pathname(urlparse(uri).path)
 
 
 def client_for_view(view: sublime.View) -> 'Optional[Client]':


### PR DESCRIPTION
This commit basically contains some results of my investigation on python-language-server issues, yesterday. I've created a module uri.py, which handles the job. The client should use the same standard functions to translate between url and filename to avoid OS specific code.

As the main.py is quite large, I would suggest to just import the urllib and use the functions with full path. This is a bit more expressive and it is easier to see where the functions come from.

I use the opportunity to group and sort the imports as suggested by several official sources

First sorting level (groups):

1. standard library imports
2. sublime text default imports
3. dependencies packages imports
4. private imports (not yet used)

Second sorting level:

1. import
2. from ... import

Third sorting level:

Sort alphabetically

see also: https://packagecontrol.io/packages/Python%20Fix%20Imports