### PR TITLE
Add error/warning/info regions and disable phantoms by default.

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -40,11 +40,9 @@
   "show_status_messages": true,
   "show_view_status": true,
   "auto_show_diagnostics_panel": true,
-  "show_diagnostics_phantoms": true,
+  "show_diagnostics_phantoms": false,
   "show_diagnostics_in_view_status": true,
-  "diagnostic_error_region_scope": "markup.error.lsp sublimelinter.mark.error",
   "log_debug": false,
   "log_server": true,
   "log_stderr": false
-
 }

--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -42,16 +42,16 @@ contexts:
 
   expect-diag-type:
     # See: https://github.com/sublimehq/Packages/issues/1036
-    # We use old markup scopes too so that old color schemes can catch up.
+    # We use sublimelinter markup scopes too so that old color schemes can catch up.
     - include: pop-at-end
     - match: \berror\b
-      scope: markup.error.lsp markup.deleted.lsp
+      scope: markup.error.lsp sublimelinter.mark.error
       pop: true
     - match: \bwarning\b
-      scope: markup.warning.lsp markup.heading.lsp
+      scope: markup.warning.lsp sublimelinter.mark.warning
       pop: true
     - match: \binfo\b
-      scope: markup.info.lsp markup.inserted.lsp
+      scope: markup.info.lsp sublimelinter.gutter-mark
       pop: true
 
   expect-linter-type:

--- a/Syntaxes/Diagnostics.sublime-syntax
+++ b/Syntaxes/Diagnostics.sublime-syntax
@@ -45,13 +45,13 @@ contexts:
     # We use sublimelinter markup scopes too so that old color schemes can catch up.
     - include: pop-at-end
     - match: \berror\b
-      scope: markup.error.lsp sublimelinter.mark.error
+      scope: markup.deleted.lsp sublimelinter.mark.error markup.error.lsp
       pop: true
     - match: \bwarning\b
-      scope: markup.warning.lsp sublimelinter.mark.warning
+      scope: markup.changed.lsp sublimelinter.mark.warning markup.warning.lsp
       pop: true
     - match: \binfo\b
-      scope: markup.info.lsp sublimelinter.gutter-mark
+      scope: markup.inserted.lsp sublimelinter.gutter-mark markup.info.lsp
       pop: true
 
   expect-linter-type:

--- a/main.py
+++ b/main.py
@@ -1166,11 +1166,11 @@ def update_diagnostics_phantoms(view: sublime.View, diagnostics: 'List[Diagnosti
     global phantom_sets_by_buffer
 
     buffer_id = view.buffer_id()
-    if show_diagnostics_phantoms and not view.is_dirty():
+    if not show_diagnostics_phantoms or view.is_dirty():
+        phantoms = None
+    else:
         phantoms = list(
             create_phantom(view, diagnostic) for diagnostic in diagnostics)
-    else:
-        phantoms = None  # type: ignore
     if phantoms:
         phantom_set = phantom_sets_by_buffer.get(buffer_id)
         if not phantom_set:
@@ -1184,7 +1184,7 @@ def update_diagnostics_phantoms(view: sublime.View, diagnostics: 'List[Diagnosti
 def update_diagnostics_regions(view: sublime.View, diagnostics: 'List[Diagnostic]', severity: int):
     region_name = "lsp_" + format_severity(severity)
     if show_diagnostics_phantoms and not view.is_dirty():
-        regions = None  # type: ignore
+        regions = None
     else:
         regions = list(create_region(view, diagnostic) for diagnostic in diagnostics
                        if diagnostic.severity == severity)

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ SUBLIME_WORD_MASK = 515
 show_status_messages = True
 show_view_status = True
 auto_show_diagnostics_panel = True
-show_diagnostics_phantoms = True
+show_diagnostics_phantoms = False
 show_diagnostics_in_view_status = True
 log_debug = True
 log_server = True
@@ -50,10 +50,10 @@ diagnostic_severity_names = {
 }
 
 diagnostic_severity_scopes = {
-    DiagnosticSeverity.Error: 'markup.error.lsp sublimelinter.mark.error',
-    DiagnosticSeverity.Warning: 'markup.warning.lsp sublimelinter.mark.warning',
-    DiagnosticSeverity.Information: 'markup.info.lsp sublimelinter.gutter-mark',
-    DiagnosticSeverity.Hint: 'markup.info.suggestion.lsp sublimelinter.gutter-mark'
+    DiagnosticSeverity.Error: 'markup.deleted.lsp sublimelinter.mark.error markup.error.lsp',
+    DiagnosticSeverity.Warning: 'markup.changed.lsp sublimelinter.mark.warning markup.warning.lsp',
+    DiagnosticSeverity.Information: 'markup.inserted.lsp sublimelinter.gutter-mark markup.info.lsp',
+    DiagnosticSeverity.Hint: 'markup.inserted.lsp sublimelinter.gutter-mark markup.info.suggestion.lsp'
 }
 
 
@@ -278,7 +278,7 @@ def update_settings(settings_obj: sublime.Settings):
     show_status_messages = settings_obj.get("show_status_messages", True)
     show_view_status = settings_obj.get("show_view_status", True)
     auto_show_diagnostics_panel = settings_obj.get("auto_show_diagnostics_panel", True)
-    show_diagnostics_phantoms = settings_obj.get("show_diagnostics_phantoms", True)
+    show_diagnostics_phantoms = settings_obj.get("show_diagnostics_phantoms", False)
     show_diagnostics_in_view_status = settings_obj.get("show_diagnostics_in_view_status", True)
     log_debug = settings_obj.get("log_debug", False)
     log_server = settings_obj.get("log_server", True)


### PR DESCRIPTION
Had a look into the regions and phantoms stuff a little bit with more attention to the regions right now. 

1. I'd suggest to disable phantoms by default at the moment as they make files with many issues unreadable at the moment.

2. Errors/Warnings/Infos are added with different scopes so they can have different colors. Scopes are synced with diagnostics syntax. Decided to use sublimelinter scopes in diagnostics panel for now. But we may discuss which solution is better. I am not sure.

For details, please see commit messages.