### PR TITLE
Show diagnostics in status bar

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -41,6 +41,7 @@
   "show_view_status": true,
   "auto_show_diagnostics_panel": true,
   "show_diagnostics_phantoms": true,
+  "show_diagnostics_in_view_status": true,
   "diagnostic_error_region_scope": "markup.error.lsp sublimelinter.mark.error",
   "log_debug": false,
   "log_server": true,


### PR DESCRIPTION
As requested in issue #19, adds a third option for displaying diagnostics besides hovers and phantoms.

<img width="734" alt="screen shot 2017-08-22 at 01 21 01" src="https://user-images.githubusercontent.com/4395832/29542009-5dd6d17a-86d8-11e7-9495-c77aba808583.png">
