### PR TITLE
Initialize the active window's active view at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -496,6 +496,15 @@ def plugin_loaded():
     Events.subscribe("view.on_activated_async", initialize_on_open)
     if show_status_messages:
         sublime.status_message("LSP initialized")
+    start_active_view()
+
+
+def start_active_view():
+    window = sublime.active_window()
+    if window:
+        view = window.active_view()
+        if view and is_supported_view(view):
+            initialize_on_open(view)
 
 
 def check_window_unloaded():


### PR DESCRIPTION
For #18, where already-open views do not trigger the language server to startup (only toggling events or opening other views works).

In limited testing on OS-X, the non-active window had an activated event fired on its view once I changed to it, so only the active_window's active_view needed a manual startup.