### PR TITLE
Create LspSettings class to manage cached settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,8 @@ import sublime
 
 import mdpopups
 
+from .modules.settings import ClientConfig
+from .modules.settings import lsp_settings
 
 PLUGIN_NAME = 'LSP'
 SUBLIME_WORD_MASK = 515
@@ -228,68 +230,6 @@ class Diagnostic(object):
 
     def to_lsp(self):
         return self._lsp_diagnostic
-
-
-class ClientConfig(object):
-
-    def __init__(self, name, data):
-        self.name = name
-        self.command = data.get("command") or []
-        self.scopes = data.get("scopes") or []
-        self.syntaxes = data.get("syntaxes") or []
-        self.languageId = data.get("languageId") or ""
-
-    def __hash__(self):
-        return hash(self.name)
-
-
-class LspSettings(object):
-
-    # template of handled settings and their failsafe defaults.
-    LSP_SETTINGS = {
-        "show_status_messages": True,
-        "show_view_status": True,
-        "auto_show_diagnostics_panel": True,
-        "show_diagnostics_phantoms": True,
-        "show_diagnostics_in_view_status": True,
-        "log_debug": False,
-        "log_server": True,
-        "log_stderr": False
-    }
-
-    def __init__(self):
-        self.clients = set()
-        self.settings = None  # type: ignore
-        # initialize defaults until self.load() is called
-        for key, default in self.LSP_SETTINGS.items():
-            setattr(self, key, default)
-
-    def __del__(self):
-        if self.settings:
-            self.settings.clear_on_change("LspSettings.update")
-
-    def load(self):
-        if not self.settings:
-            self.settings = sublime.load_settings("LSP.sublime-settings")
-            self.settings.add_on_change(
-                "LspSettings.update", lambda: self.on_change(self))
-        self.update()
-
-    @staticmethod
-    def on_change(obj):
-        obj.update()
-
-    def update(self):
-        """Update class attributes from sublime.Settings object."""
-        for key, default in self.LSP_SETTINGS.items():
-            setattr(self, key, self.settings.get(key, default))
-        self.clients.clear()
-        client_configs = self.settings.get("clients", {})
-        for client_name, client_config in client_configs.items():
-            self.clients.add(ClientConfig(client_name, client_config))
-
-
-lsp_settings = LspSettings()
 
 
 def format_request(payload: 'Dict[str, Any]'):

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -1,0 +1,65 @@
+import sublime
+
+try:
+    from typing import Set
+    assert Set
+except ImportError:
+    pass
+
+
+class ClientConfig(object):
+
+    def __init__(self, name, data):
+        self.name = name
+        self.command = data.get("command") or []
+        self.scopes = set(data.get("scopes") or [])
+        self.syntaxes = set(data.get("syntaxes") or [])
+        self.languageId = data.get("languageId") or ""
+
+    def __hash__(self):
+        return hash(self.name)
+
+
+class LSPSettings(object):
+
+    # template of handled settings and their failsafe defaults.
+    lookup = {
+        "show_status_messages": True,
+        "show_view_status": True,
+        "auto_show_diagnostics_panel": True,
+        "show_diagnostics_phantoms": True,
+        "show_diagnostics_in_view_status": True,
+        "log_debug": False,
+        "log_server": True,
+        "log_stderr": False
+    }
+
+    def __init__(self):
+        self.clients = set()    # type: Set
+        self.settings = None    # type: sublime.Settings
+        # initialize defaults until self.load() is called
+        for key, default in self.lookup.items():
+            self.__setattr__(key, default)
+
+    def __del__(self):
+        if self.settings:
+            self.settings.clear_on_change("LSP.update")
+
+    def load(self):
+        if not self.settings:
+            self.settings = sublime.load_settings("LSP.sublime-settings")
+            self.settings.add_on_change("LSP.update", lambda: self.update())
+        self.update()
+
+    def update(self):
+        """Update class attributes from sublime.Settings object."""
+        print("LSP: reloading settings")
+        for key, default in self.lookup.items():
+            self.__setattr__(key, self.settings.get(key, default))
+        self.clients.clear()
+        client_configs = self.settings.get("clients", {})
+        for client_name, client_config in client_configs.items():
+            self.clients.add(ClientConfig(client_name, client_config))
+
+
+lsp_settings = LSPSettings()


### PR DESCRIPTION
With respect to object oriented programming which is already used for most of the language-server-protocol based stuff, the configuration of the LSP package should follow this approach, if it is intended to cache the settings.

Therefore a `class LspSettings` is created, which uses a template `LSP_SETTINGS` to initialize the object attributes at startup. In `plugin_loaded()` callback the real values from the _LSP.sublime-settings_ are loaded, mapped to the object attributes and kept up to date by the subscribed the `on_change()` event.

The one and only place to define settings to handle is the `LSP_SETTINGS` dictionary.

All managed settings can be accessed (read-only) as normal attribute by calling
```
   lsp_settings.my_setting_from_lsp_sublime_settings
```
The only drawback is mypy which complains about class attributes not found. Therefore several `# type: ignore` statements need to be added.