### PR TITLE
Simplify print functions

### DIFF
--- a/main.py
+++ b/main.py
@@ -1334,7 +1334,7 @@ def start_server(server_binary_args, working_dir):
         return Client(process)
 
     except Exception as err:
-        print(err)
+        printf(err)
 
 
 def get_document_range(view: sublime.View) -> 'Any':

--- a/main.py
+++ b/main.py
@@ -451,22 +451,12 @@ def debug(*args):
 
 
 def server_log(binary, *args):
-    print(binary + ": ", end='')
-
-    for arg in args:
-        print(arg, end=' ')
-
-    print()
+    printf(args, prefix=binary)
 
 
-def printf(*args):
+def printf(*args, prefix=PLUGIN_NAME):
     """Print args to the console, prefixed by the plugin name."""
-    print(PLUGIN_NAME + ': ', end='')
-
-    for arg in args:
-        print(arg, end=' ')
-
-    print()
+    print(prefix + ":", args)
 
 
 def get_project_path(window: sublime.Window) -> 'Optional[str]':

--- a/main.py
+++ b/main.py
@@ -451,12 +451,12 @@ def debug(*args):
 
 
 def server_log(binary, *args):
-    printf(args, prefix=binary)
+    printf(*args, prefix=binary)
 
 
 def printf(*args, prefix=PLUGIN_NAME):
     """Print args to the console, prefixed by the plugin name."""
-    print(prefix + ":", args)
+    print(prefix + ":", *args)
 
 
 def get_project_path(window: sublime.Window) -> 'Optional[str]':


### PR DESCRIPTION
I noticed the print functions were somewhat convoluted so I simplified them.

Also, there was a lonely built-in print used for printing an exception on line 1347.