### PR TITLE
Always show symbol information popup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1497,7 +1497,7 @@ class HoverHandler(sublime_plugin.ViewEventListener):
         mdpopups.show_popup(
             self.view,
             "\n".join(formatted),
-            css=".mdpopups .lsp_hover { margin: 4px; }",
+            css=".mdpopups .lsp_hover { margin: 4px; } .mdpopups p { margin: 0.1rem; }",
             md=True,
             flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
             location=point,
@@ -1639,7 +1639,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                 mdpopups.show_popup(
                     self.view,
                     "\n".join(formatted),
-                    css=".mdpopups .lsp_signature { margin: 4px; }",
+                    css=".mdpopups .lsp_signature { margin: 4px; } .mdpopups p { margin: 0.1rem; }",
                     md=True,
                     flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
                     location=point,

--- a/main.py
+++ b/main.py
@@ -1436,6 +1436,9 @@ class HoverHandler(sublime_plugin.ViewEventListener):
             self.request_symbol_hover(point, hover_zone)
 
     def request_symbol_hover(self, point, hover_zone):
+        filter = 'comment, constant, keyword, storage, string'
+        if self.view.match_selector(point, filter):
+            return
         client = client_for_view(self.view)
         if client and client.has_capability('hoverProvider'):
             word_at_sel = self.view.classify(point)

--- a/main.py
+++ b/main.py
@@ -1453,6 +1453,8 @@ class HoverHandler(sublime_plugin.ViewEventListener):
             return
         contents = "No description available."
         if isinstance(response, dict):
+            # Flow returns None sometimes
+            # See: https://github.com/flowtype/flow-language-server/issues/51
             contents = response.get('contents') or contents
         self.show_hover(point, contents)
 


### PR DESCRIPTION
This PR addresses issue #36 and intends to display tooltip even if language-server doesn't offer a description. A basic filter is used to statically exclude some scopes which a language server will most likely not have something to offer for.