### PR TITLE
Enable full completions

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -42,6 +42,7 @@
   "auto_show_diagnostics_panel": true,
   "show_diagnostics_phantoms": false,
   "show_diagnostics_in_view_status": true,
+  "complete_all_chars": true,
   "log_debug": false,
   "log_server": true,
   "log_stderr": false

--- a/main.py
+++ b/main.py
@@ -1427,7 +1427,7 @@ class HoverHandler(sublime_plugin.ViewEventListener):
     @classmethod
     def is_applicable(cls, settings):
         syntax = settings.get('syntax')
-        return is_supported_syntax(syntax)
+        return syntax and is_supported_syntax(syntax)
 
     def on_hover(self, point, hover_zone):
         if hover_zone != sublime.HOVER_TEXT or self.view.is_popup_visible():
@@ -1533,7 +1533,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
     @classmethod
     def is_applicable(cls, settings):
         syntax = settings.get('syntax')
-        return is_supported_syntax(syntax)
+        return syntax and is_supported_syntax(syntax)
 
     def initialize(self):
         self.initialized = True
@@ -1641,7 +1641,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
     @classmethod
     def is_applicable(cls, settings):
         syntax = settings.get('syntax')
-        return is_supported_syntax(syntax)
+        return syntax and is_supported_syntax(syntax)
 
     def initialize_triggers(self):
         client = client_for_view(self.view)
@@ -1892,7 +1892,7 @@ class DiagnosticsCursorListener(sublime_plugin.ViewEventListener):
     def is_applicable(cls, settings):
         syntax = settings.get('syntax')
         global show_diagnostics_in_view_status
-        return show_diagnostics_in_view_status and is_supported_syntax(syntax)
+        return show_diagnostics_in_view_status and syntax and is_supported_syntax(syntax)
 
     def on_selection_modified_async(self):
         pos = self.view.sel()[0].begin()
@@ -1918,7 +1918,7 @@ class DocumentSyncListener(sublime_plugin.ViewEventListener):
     @classmethod
     def is_applicable(cls, settings):
         syntax = settings.get('syntax')
-        return is_supported_syntax(syntax)
+        return syntax and is_supported_syntax(syntax)
 
     @classmethod
     def applies_to_primary_view_only(cls):

--- a/main.py
+++ b/main.py
@@ -1604,7 +1604,7 @@ class CompletionHandler2(sublime_plugin.ViewEventListener):
             insertText = item.get("insertText")
         if insertText[0] == '$':  # sublime needs leading '$' escaped.
             insertText = '\$' + insertText[1:]
-        return ["{}\t{}".format(label, detail), insertText]
+        return "{}\t{}".format(label, detail), insertText
 
     def handle_response(self, response):
         if self.state == CompletionState.REQUESTING:

--- a/main.py
+++ b/main.py
@@ -1563,7 +1563,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
                 self.do_request(prefix, locations)
                 self.completions = []  # type: List[Tuple[str, str]]
 
-            elif self.state == CompletionState.REQUESTING or self.state == CompletionState.CANCELLING:
+            elif self.state in (CompletionState.REQUESTING, CompletionState.CANCELLING):
                 debug('replacing request')
                 self.next_request = (prefix, locations)
                 self.state = CompletionState.CANCELLING


### PR DESCRIPTION
For issue #25, where all completion requests (even manual) were ignored unless the cursor followed a trigger character.

The following improvements were made:
* No more filtering on trigger chars (ctrl+space no longer ignored)
* Switch to ViewEventListener (easier to disable, less risk with shared state)
* Track completion states so we can discard and request new completions as the user keeps typing

To do:
- [x] verify only_complete_on_trigger_characters and make it a setting
- [x] also disable listener if server has no completionProvider
- [x] clean up debug logging
- [x] rename to CompletionHandler