### PR TITLE
Exclude some stuff from sublime-package files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Stuff not being exported to ZIP and therefore
+# prevented from being packed into LSP.sublime-package
+
+## git
+.github/          export-ignore
+gh-pages/         export-ignore
+*.git             export-ignore
+*.gitignore       export-ignore
+*.gitattributes   export-ignore
+
+## unit testing
+tests/            export-ignore
+unittesting.json  export-ignore
+
+## other configs
+stubs/            export-ignore
+.travis.yml       export-ignore
+*.ini             export-ignore
+*.cfg             export-ignore


### PR DESCRIPTION
Some of the files and folders of the repository are meant for development only and don't need to be part of a sublime-package file. We may therefore add an .gitattributes file to exclude them from being archived/exported. This may reduce the package size somewhat and makes the package content look clean.