### PR TITLE
Add Reason/OCaml lsp settings

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -35,6 +35,13 @@
         "scopes": ["source.c", "source.c++", "source.objc", "source.objc++"],
         "syntaxes": ["Packages/C++/C.sublime-syntax", "Packages/C++/C++.sublime-syntax", "Packages/Objective-C/Objective-C.sublime-syntax", "Packages/Objective-C/Objective-C++.sublime-syntax"],
         "languageId": "c-family"
+      },
+      "reason":
+      {
+        "command": ["ocaml-language-server", "--stdio"],
+        "scopes": ["source.reason", "source.ocaml"],
+        "syntaxes": ["Packages/sublime-reason/Reason.tmLanguage"],
+        "languageId": "reason"
       }
   },
   "show_status_messages": true,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features:
 * Diagnostics
 * Code Actions
 
-Tested against language servers for javascript/typescript, python, c/c++ (clangd), scala (dotty), rust. See [langserver.org](http://langserver.org) for available implementations
+Tested against language servers for javascript/typescript, python, c/c++ (clangd), scala (dotty), rust, reason. See [langserver.org](http://langserver.org) for available implementations
 
 ## Screenshots
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,18 +153,7 @@ You will need to build from source, see [instructions](https://clang.llvm.org/ex
 
 ### Ocaml/Reason<a name="reason"></a>
 
-See [github:freebroccolo/ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server)
-
-You will need to install the `sublime-reason` package to get the syntax listed below:
-
-```
-"reason": {
-  "command": ["ocaml-language-server", "--stdio"],
-  "scopes": ["source.reason"]
-  "syntaxes": ["Packages/User/sublime-reason/Reason.tmLanguage"],
-  "languageId": "reason"
-}
-```
+You will need to install the [sublime-reason](https://github.com/reasonml-editor/sublime-reason) package. That repo also contains the other necessary installations, such as [ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server).
 
 ### Other<a name="other"></a>
 


### PR DESCRIPTION
I'm not sure why this doesn't activate for ocaml files (ocaml-language-server works for reason and both, so it shouldn't be that side's error), but for reason files this works.

Test:

```
git clone https://github.com/freebroccolo/ocaml-language-server.git
cd ocaml-language-server
npm install
npm install -g .
```

Then use this diff and open up a foo.re file and write

```reason
let a: int="hi";
```

And see the correct error at the bottom