### PR TITLE
Use one project path instead of common prefix

### DIFF
--- a/main.py
+++ b/main.py
@@ -579,10 +579,10 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
 def get_common_parent(paths: 'List[str]') -> str:
     """
     Get the common parent directory of multiple paths.
-    """
-    if 'commonpath' in dir(os.path):
-        return os.path.commonpath(paths)
 
+    Python 3.5+ includes os.path.commonpath which does this, however Sublime
+    currently embeds Python 3.3.
+    """
     return os.path.commonprefix([path + '/' for path in paths]).rstrip('/')
 
 

--- a/main.py
+++ b/main.py
@@ -576,12 +576,33 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
         return None
 
 
+def get_common_parent(paths: 'List[str]') -> str:
+    """
+    Get the common parent of multiple paths. Attempts to use native method
+    if available.
+    """
+    try:
+        return os.path.commonpath(paths)
+    except:
+        pass
+
+    groups = [s.split(os.path.sep) for s in paths]
+    min_len = min(len(group) for group in groups)
+    common = []
+    for i in range(min_len):
+        bits = set(group[i] for group in groups)
+        if len(bits) != 1:
+            break
+        common.append(bits.pop())
+    return os.path.sep.join(common)
+
+
 def is_in_workspace(window: sublime.Window, file_path: str) -> bool:
     workspace_path = get_project_path(window)
     if workspace_path is None:
         return False
 
-    common_dir = os.path.commonpath([workspace_path, file_path])
+    common_dir = get_common_parent([workspace_path, file_path])
     return workspace_path == common_dir
 
 

--- a/main.py
+++ b/main.py
@@ -578,23 +578,14 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
 
 def get_common_parent(paths: 'List[str]') -> str:
     """
-    Get the common parent of multiple paths. Attempts to use native method
-    if available.
+    Get the common parent directory of multiple paths.
     """
     try:
         return os.path.commonpath(paths)
     except:
         pass
 
-    groups = [s.split(os.path.sep) for s in paths]
-    min_len = min(len(group) for group in groups)
-    common = []
-    for i in range(min_len):
-        bits = set(group[i] for group in groups)
-        if len(bits) != 1:
-            break
-        common.append(bits.pop())
-    return os.path.sep.join(common)
+    return os.path.commonprefix([path + '/' for path in paths]).rstrip('/')
 
 
 def is_in_workspace(window: sublime.Window, file_path: str) -> bool:

--- a/main.py
+++ b/main.py
@@ -580,10 +580,8 @@ def get_common_parent(paths: 'List[str]') -> str:
     """
     Get the common parent directory of multiple paths.
     """
-    try:
+    if 'commonpath' in dir(os.path):
         return os.path.commonpath(paths)
-    except:
-        pass
 
     return os.path.commonprefix([path + '/' for path in paths]).rstrip('/')
 

--- a/main.py
+++ b/main.py
@@ -570,7 +570,7 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
     """
     if len(window.folders()):
         folder_paths = window.folders()
-        return os.path.commonprefix(folder_paths)
+        return folder_paths[0]
     else:
         debug("Couldn't determine project directory")
         return None

--- a/main.py
+++ b/main.py
@@ -581,7 +581,7 @@ def is_in_workspace(window: sublime.Window, file_path: str) -> bool:
     if workspace_path is None:
         return False
 
-    common_dir = os.path.commonprefix([workspace_path, file_path])
+    common_dir = os.path.commonpath([workspace_path, file_path])
     return workspace_path == common_dir
 
 


### PR DESCRIPTION
Fixes #79.

This changes from using the common prefix (which could be a partial directory name) to using only the first folder in a project. Additionally, it fixes the `is_in_workspace` check to avoid the same problem.

This removes support for multiple folders (in a way; it will now only index one folder instead of the common parent of all folders), so probably warrants a major version bump.