### PR TITLE
Rewrite native goto definition

### DIFF
--- a/Menus/Context.sublime-menu
+++ b/Menus/Context.sublime-menu
@@ -5,10 +5,6 @@
         "caption": "Find Symbol References"
     },
     {
-        "command": "lsp_symbol_definition",
-        "caption": "Go To Symbol Definition"
-    },
-    {
         "command": "lsp_symbol_rename",
         "caption": "Rename Symbol"
     },

--- a/main.py
+++ b/main.py
@@ -1558,6 +1558,19 @@ class Events:
             for listener in cls.listener_dict[key]:
                 listener(*args)
 
+def is_applicable(settings):
+    syntax = settings.get('syntax')
+    return syntax and is_supported_syntax(syntax)
+
+class DefinitionHandler(sublime_plugin.EventListener):
+    def on_text_command(self, view, command_name, args):
+        if not is_applicable(view.settings()):
+            return None
+
+        if command_name != 'context_goto_definition':
+            return None
+
+        return ('lsp_symbol_definition', args)
 
 class HoverHandler(sublime_plugin.ViewEventListener):
     def __init__(self, view):
@@ -1565,8 +1578,7 @@ class HoverHandler(sublime_plugin.ViewEventListener):
 
     @classmethod
     def is_applicable(cls, settings):
-        syntax = settings.get('syntax')
-        return syntax and is_supported_syntax(syntax)
+        return is_applicable(settings)
 
     def on_hover(self, point, hover_zone):
         if hover_zone != sublime.HOVER_TEXT or self.view.is_popup_visible():


### PR DESCRIPTION
Fixes #78.

Rather than having a custom Go To Definition for LSP, this overrides the default for views that we support.

This only operates on the context menu item, the menu item (Goto -> Goto Definition) and keyboard shortcut run the `goto_definition` window (not view) command instead, but not sure the best way to translate the cursor position into our desired command yet.

(Given that #78 is still open, I figured this was desired, but wanted to check before I invest more time into fixing up the rest.)