### PR TITLE
Update diagnostic panel atomically

### DIFF
--- a/main.py
+++ b/main.py
@@ -1435,35 +1435,32 @@ def update_diagnostics_panel(window):
         is_active_panel = (active_panel == "output.diagnostics")
         panel.settings().set("result_base_dir", base_dir)
         panel.set_read_only(False)
-        panel.run_command("lsp_clear_panel")
         file_diagnostics = window_file_diagnostics[window.id()]
         if file_diagnostics:
+            to_render = []
             for file_path, source_diagnostics in file_diagnostics.items():
                 relative_file_path = os.path.relpath(file_path, base_dir) if base_dir else file_path
                 if source_diagnostics:
-                    append_diagnostics(panel, relative_file_path, source_diagnostics)
+                    to_render.append(format_diagnostics(relative_file_path, source_diagnostics))
+            panel.run_command("lsp_update_panel", {"characters": "\n".join(to_render)})
             if auto_show_diagnostics_panel and not active_panel:
                 window.run_command("show_panel",
                                    {"panel": "output.diagnostics"})
         else:
+            panel.run_command("lsp_clear_panel")
             if auto_show_diagnostics_panel and is_active_panel:
                 window.run_command("hide_panel",
                                    {"panel": "output.diagnostics"})
         panel.set_read_only(True)
 
 
-def append_diagnostics(panel, file_path, origin_diagnostics):
-    panel.run_command('append',
-                      {'characters':  " ◌ {}:\n".format(file_path),
-                       'force': True})
+def format_diagnostics(file_path, origin_diagnostics):
+    content = " ◌ {}:\n".format(file_path)
     for origin, diagnostics in origin_diagnostics.items():
         for diagnostic in diagnostics:
             item = format_diagnostic(diagnostic)
-            panel.run_command('append', {
-                'characters': item + "\n",
-                'force': True,
-                'scroll_to_end': True
-            })
+            content += item + "\n"
+    return content
 
 
 def start_client(window: sublime.Window, config: ClientConfig):

--- a/main.py
+++ b/main.py
@@ -1293,6 +1293,11 @@ class LspUpdatePanelCommand(sublime_plugin.TextCommand):
     def run(self, edit, characters):
         self.view.replace(edit, sublime.Region(0, self.view.size()), characters)
 
+        # Move cursor to the end
+        selection = self.view.sel()
+        selection.clear()
+        selection.add(sublime.Region(self.view.size(), self.view.size()))
+
 
 UNDERLINE_FLAGS = (sublime.DRAW_SQUIGGLY_UNDERLINE
                    | sublime.DRAW_NO_OUTLINE

--- a/main.py
+++ b/main.py
@@ -1285,6 +1285,15 @@ class LspClearPanelCommand(sublime_plugin.TextCommand):
         self.view.erase(edit, sublime.Region(0, self.view.size()))
 
 
+class LspUpdatePanelCommand(sublime_plugin.TextCommand):
+    """
+    A update_panel command to update the error panel with new text.
+    """
+
+    def run(self, edit, characters):
+        self.view.replace(edit, sublime.Region(0, self.view.size()), characters)
+
+
 UNDERLINE_FLAGS = (sublime.DRAW_SQUIGGLY_UNDERLINE
                    | sublime.DRAW_NO_OUTLINE
                    | sublime.DRAW_NO_FILL


### PR DESCRIPTION
Fixes #84.

Rather than appending to the panel once per line, this instead builds the entire string once, then replaces all the content at once. It also avoids calling `erase` at all. With this, there's now no flickering at all during redraws:

![lsp-diag-fixed](https://user-images.githubusercontent.com/21655/30257334-baccc6ba-96f4-11e7-969d-de96e8d8380a.gif)

This also adds a `lsp_update_panel` text command; as far as I can see, there's no built-in command to do this, but happy to be wrong on that!