### PR TITLE
Resolve completions for snippets

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -66,6 +66,8 @@
   // highlight style of code diagnostics: "underline" or "box"
   "diagnostics_highlight_style": "underline",
   "complete_all_chars": true,
+  "only_show_lsp_completions": false,
+  "resolve_completion_for_snippets": false,
   "log_debug": false,
   "log_server": true,
   "log_stderr": false

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 
 * `complete_all_chars` `true` *request completions for all characters, not just trigger characters*
 * `only_show_lsp_completions` `false` *disable sublime word completion and snippets from autocomplete lists*
+* `resolve_completion_for_snippets` `false` *resolve completions and apply snippet if received*
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
 * `auto_show_diagnostics_panel` `true` *open and close the diagnostics panel automatically*


### PR DESCRIPTION
Some language servers can provide rich completion items (including documentation and snippet formatting) but at a great cost. To defer this cost, we can resolve extra details for completion items only when necessary through `completionItem/resolve`.

This strategy can be seen in action in VS Code, where only the selected completion item displays documentation etc.

Sublime Text provides no API to detect which completion item is currently selected in the list.
To still enjoy snippet support, we need to detect the inserted completion item label, resolve the completion, and insert the snippet in its place.

This PR demonstrates it can be done in a performant manner.

>  An alternative solution is to resolve all received completions (only functions/methods?) if less than MAX_RESOLVE_COUNT async and update them.

Update: The only information used from resolved completions so far is snippets, so resolving completions ahead of time will be investigated once there is a use for it.
