### PR TITLE
Add setting to hide diagnostics received from open files that aren't open 

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ show_view_status = True
 auto_show_diagnostics_panel = True
 show_diagnostics_phantoms = False
 show_diagnostics_in_view_status = True
+only_show_diagnostics_for_open_files = False
 only_show_lsp_completions = False
 diagnostics_highlight_style = "underline"
 complete_all_chars = False
@@ -350,6 +351,7 @@ def update_settings(settings_obj: sublime.Settings):
     global show_diagnostics_in_view_status
     global only_show_lsp_completions
     global diagnostics_highlight_style
+    global only_show_diagnostics_for_open_files
     global complete_all_chars
     global log_debug
     global log_server
@@ -374,6 +376,8 @@ def update_settings(settings_obj: sublime.Settings):
     show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
     diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
     only_show_lsp_completions = read_bool_setting(settings_obj, "only_show_lsp_completions", False)
+    only_show_diagnostics_for_open_files = read_bool_setting(settings_obj,
+                                                             "only_show_diagnostics_for_open_files", False)
     complete_all_chars = read_bool_setting(settings_obj, "complete_all_chars", True)
     log_debug = read_bool_setting(settings_obj, "log_debug", False)
     log_server = read_bool_setting(settings_obj, "log_server", True)
@@ -1422,13 +1426,15 @@ def handle_diagnostics(update: 'Any'):
         debug("Skipping diagnostics for file", file_path,
               " it is not in the workspace")
         return
+    elif only_show_diagnostics_for_open_files:
+        if window.find_open_file(file_path) is None:
+            debug("Skipping diagnostics for file", file_path,
+                  "it is not open")
 
     diagnostics = list(
         Diagnostic.from_lsp(item) for item in update.get('diagnostics', []))
 
     view = window.find_open_file(file_path)
-
-    # diagnostics = update.get('diagnostics')
 
     update_diagnostics_in_view(view, diagnostics)
 


### PR DESCRIPTION
For language servers that provide full-project diagnostics at eg. startup, (eg. the julia language server as reported in #67)

TODO:
- [ ] verify this improves the experience
- [ ] document setting