### PR TITLE
need a space before concatting "Could not start " + config.name

### DIFF
--- a/main.py
+++ b/main.py
@@ -1518,8 +1518,8 @@ def start_client(window: sublime.Window, config: ClientConfig):
 
         client = start_server(expanded_args, project_path)
         if not client:
-            window.status_message("Could not start" + config.name + ", disabling")
-            debug("Could not start", config.binary_args, ", disabling")
+            window.status_message("Could not start " + config.name + ", disabling")
+            debug("Could not start ", config.binary_args, ", disabling")
             return
 
         initializeParams = {

--- a/main.py
+++ b/main.py
@@ -1519,7 +1519,7 @@ def start_client(window: sublime.Window, config: ClientConfig):
         client = start_server(expanded_args, project_path)
         if not client:
             window.status_message("Could not start " + config.name + ", disabling")
-            debug("Could not start ", config.binary_args, ", disabling")
+            debug("Could not start", config.binary_args, ", disabling")
             return
 
         initializeParams = {


### PR DESCRIPTION
If a server cannot start, there is no space between the message and the name of the server, resulting in, e.g., `Could not startjsts` instead of `Could not start jsts`