### PR TITLE
Remove redundant text from doc.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -163,8 +163,6 @@ You will need to install [sublime-reason](https://github.com/reasonml-editor/sub
 
 See: [github:palantir/sourcegraphgo-langserver](https://github.com/sourcegraph/go-langserver)
 
-Please note that install alongside [github:DisposaBoy/GoSublime](https://github.com/DisposaBoy/GoSublime) package is not working.
-
 Client configuration:
 ```
 "golsp":


### PR DESCRIPTION
- Retested it with the [github:DisposaBoy/GoSublime](https://github.com/DisposaBoy/GoSublime) package installed and it works.