### PR TITLE
Gives phantoms the same nubbin as build errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -1518,8 +1518,8 @@ def start_client(window: sublime.Window, config: ClientConfig):
 
         client = start_server(expanded_args, project_path)
         if not client:
-            window.status_message("Could not start" + config.name + ", disabling")
-            debug("Could not start", config.binary_args, ", disabling")
+            window.status_message("Could not start " + config.name + ", disabling")
+            debug("Could not start ", config.binary_args, ", disabling")
             return
 
         initializeParams = {

--- a/main.py
+++ b/main.py
@@ -987,20 +987,28 @@ def handle_initialize_result(result, client, window, config):
 
 stylesheet = '''
             <style>
+                div.error-arrow {
+                    border-top: 0.4rem solid transparent;
+                    border-left: 0.5rem solid color(var(--redish) blend(var(--background) 30%));
+                    width: 0;
+                    height: 0;
+                }
                 div.error {
                     padding: 0.4rem 0 0.4rem 0.7rem;
-                    margin: 0.2rem 0;
-                    border-radius: 2px;
+                    margin: 0 0 0.2rem;
+                    border-radius: 0 0.2rem 0.2rem 0.2rem;
                 }
+
                 div.error span.message {
                     padding-right: 0.7rem;
                 }
+
                 div.error a {
                     text-decoration: inherit;
                     padding: 0.35rem 0.7rem 0.45rem 0.8rem;
                     position: relative;
                     bottom: 0.05rem;
-                    border-radius: 0 2px 2px 0;
+                    border-radius: 0 0.2rem 0.2rem 0;
                     font-weight: bold;
                 }
                 html.dark div.error a {
@@ -1016,6 +1024,7 @@ stylesheet = '''
 def create_phantom_html(text: str) -> str:
     global stylesheet
     return """<body id=inline-error>{}
+                <div class="error-arrow"></div>
                 <div class="error">
                     <span class="message">{}</span>
                     <a href="code-actions">Code Actions</a>

--- a/main.py
+++ b/main.py
@@ -1519,7 +1519,7 @@ def start_client(window: sublime.Window, config: ClientConfig):
         client = start_server(expanded_args, project_path)
         if not client:
             window.status_message("Could not start " + config.name + ", disabling")
-            debug("Could not start ", config.binary_args, ", disabling")
+            debug("Could not start", config.binary_args, ", disabling")
             return
 
         initializeParams = {


### PR DESCRIPTION
This is just a very simple copy-paste from Default's exec.py to sync the styling of LSP phantoms with build errors.

before 
<img width="669" alt="screen shot 2017-09-17 at 21 47 44" src="https://user-images.githubusercontent.com/2543659/30524348-574cd5e6-9bf2-11e7-8025-14f5fedb7454.png">

after
<img width="675" alt="screen shot 2017-09-17 at 21 46 45" src="https://user-images.githubusercontent.com/2543659/30524349-5c300d1c-9bf2-11e7-9a74-e3d0f216eb3e.png">

The docs suggest giving the phantoms a package specific `id` to help targeting style customisation. However, I think the idea here is to match the built-in phantoms so it's good as is at least for now. It's a shame these styles aren't easily shared. It's also not guaranteed to get out of sync.. ¯\_(ツ)_/¯ 
