### PR TITLE
show non api completions when only_show_lsp_completions is False

### DIFF
--- a/main.py
+++ b/main.py
@@ -1930,9 +1930,8 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
         self.view.run_command(
             "auto_complete", {
                 'disable_auto_insert': True,
-                'api_completions_only': True,
-                'next_completion_if_showing': False,
-                'auto_complete_commit_on_tab': True,
+                'api_completions_only': only_show_lsp_completions,
+                'next_completion_if_showing': False
             })
 
 


### PR DESCRIPTION
Word completion and snippets cannot be shown if it is true.

Also, `auto_complete_commit_on_tab` should be set by the view settings.