### PR TITLE
Strip leading and tailing whitespace from function documentations.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1734,8 +1734,9 @@ class HoverHandler(sublime_plugin.ViewEventListener):
 
 def preserve_whitespace(contents: str) -> str:
     """Preserve empty lines and whitespace for markdown conversion."""
-    contents = contents.replace('\t', '&nbsp' * 4)
-    contents = contents.replace('  ', '\a\a')
+    contents = contents.strip(' \t\r\n')
+    contents = contents.replace('\t', '&nbsp;' * 4)
+    contents = contents.replace('  ', '&nbsp;' * 2)
     contents = contents.replace('\n\n', '\n&nbsp;\n')
     return contents
 


### PR DESCRIPTION
Some python docstrings contain multiple newlines at the end, which results in an empty line being displayed in the tooltip for such docstrings. To avoid this issue, `preserve_whitespace` now strips whitespace from the beginning and the end of the content to display in a popup.

For consistency the replacement of multiple spaces was modified, too. Without functional effect.
