### PR TITLE
show other completions even when CompletionState is idle

### DIFF
--- a/main.py
+++ b/main.py
@@ -1887,7 +1887,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
 
             return (
                 self.completions,
-                0 if self.state == CompletionState.IDLE and not only_show_lsp_completions
+                0 if not only_show_lsp_completions
                 else sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS
             )
 


### PR DESCRIPTION
Actually, I don't understand why we should inhibit word completions and `.sublime-completion` completions when CompletionState is idle. Firstly, some servers (e.g. julia server) are really slow to respond, if we inhibit word completions and the server doesn't respond fast enough or encounters an error while handling a completion request, it will essentially stop the entire auto-completion functionality. Secondly, if the reason was to prevent flickers, then I argue that `.sublime-snippet` should be also inhibited. Otherwise, there would still be flickers. (AFAIK, there is no way to stop snippet completions).