### PR TITLE
Fixed a bug where the last message from the server doesn't get read when the server terminates.

### DIFF
--- a/main.py
+++ b/main.py
@@ -469,13 +469,17 @@ class Client(object):
         """
         ContentLengthHeader = b"Content-Length: "
 
-        while self.process.poll() is None:
+        while True:
             try:
 
                 in_headers = True
                 content_length = 0
                 while in_headers:
-                    header = self.process.stdout.readline().strip()
+                    header = self.process.stdout.readline()
+                    if header == '':
+                        break
+                    else:
+                        header = header.strip()
                     if (len(header) == 0):
                         in_headers = False
 
@@ -491,7 +495,7 @@ class Client(object):
                         payload = json.loads(content)
                         limit = min(len(content), 200)
                         if payload.get("method") != "window/logMessage":
-                            debug("got json: ", content[0:limit])
+                            debug("got json: ", content[0:limit], "...")
                     except IOError:
                         printf("Got a non-JSON payload: ", content)
                         continue
@@ -499,7 +503,7 @@ class Client(object):
                     try:
                         if "error" in payload:
                             error = payload['error']
-                            debug("got error: ", error)
+                            printf("Got error from server: ", error)
                             sublime.status_message(error.get('message'))
                         elif "method" in payload:
                             if "id" in payload:
@@ -526,10 +530,12 @@ class Client(object):
         """
         Reads any errors from the LSP process.
         """
-        while self.process.poll() is None:
+        while True:
             try:
                 content = self.process.stderr.readline()
-                if log_stderr and len(content) > 0:
+                if len(content) == 0:
+                    break
+                if log_stderr:
                     printf("(stderr): ", content.strip())
             except IOError:
                 printf("LSP stderr process ending due to exception: ",


### PR DESCRIPTION
You were right that it doesn't print the last error message. Basically calling `subprocess.poll()` to check if the process has terminated, and if it isn't, read from stdout/stderr is a race condition. It's better to terminate the loop after `EOF` has reached directly from the pipes.

Additionally, made it so that it prints the error message even when debug logging isn't on, which is consistent with other fatal error conditions.

This fixes https://github.com/tomv564/LSP/issues/116