### PR TITLE
Added a fallback in the case where there is no project folder.

### DIFF
--- a/main.py
+++ b/main.py
@@ -610,6 +610,7 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
         else:
             debug("Couldn't determine project directory since no folders are open",
                   "and the current file isn't saved on the disk.")
+            return None
 
 
 def get_common_parent(paths: 'List[str]') -> str:
@@ -1537,7 +1538,7 @@ def format_diagnostics(file_path, origin_diagnostics):
     return content
 
 
-def start_client(window: sublime.Window, config: ClientConfig) -> 'Optional[Client]':
+def start_client(window: sublime.Window, config: ClientConfig):
     project_path = get_project_path(window)
     if project_path is None:
         return None
@@ -1553,7 +1554,7 @@ def start_client(window: sublime.Window, config: ClientConfig) -> 'Optional[Clie
     if not client:
         window.status_message("Could not start " + config.name + ", disabling")
         debug("Could not start", config.binary_args, ", disabling")
-        return
+        return None
 
     initializeParams = {
         "processId": client.process.pid,

--- a/main.py
+++ b/main.py
@@ -605,7 +605,7 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
         if filename:
             project_path = os.path.dirname(filename)
             debug("Couldn't determine project directory since no folders are open!",
-              "Using", project_path, "as a fallback.")
+                  "Using", project_path, "as a fallback.")
             return project_path
         else:
             debug("Couldn't determine project directory since no folders are open",


### PR DESCRIPTION
If there is no project folder, it considers the directory containing the file as a fallback case. Whether this is a grokkable by the language servers is their business, but at least it allows them to be able to handle the case, if they so wish.

I tested that by default, RLS can do code completion even if the project folder isn't set right.