### PR TITLE
Add inline type annotations and function argument hinting for Rust

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@
 
 For any of these components it is important that Sublime Text can find the language server executable through the path, especially when using virtual environments.
 
-For autocomplete to trigger on eg. `.` or `->`, you may need to add the listed `autocomplete_triggers` to your User or Syntax-specific settings.
+For autocomplete to trigger on eg. `.` or `->`, you may need to add the listed `auto_complete_triggers` to your User or Syntax-specific settings.
 
 The default LSP.sublime-settings contains some default LSP client configuration that may not work for you. See [Client Config](#client-config) for explanations for the available settings.
 
@@ -40,6 +40,8 @@ See: [github:sourcegraph/javascript-typescript-langserver](https://github.com/so
 On windows you will need to override client config to launch `javascript-typescript-stdio.cmd` instead.
 
 See: [github](https://github.com/sourcegraph/javascript-typescript-langserver)
+
+Autocomplete triggers: in User or Syntax-specific settings, add:
 
 ```
 "auto_complete_triggers": [
@@ -76,7 +78,7 @@ Client configuration:
 
 See: [github:palantir/python-language-server](https://github.com/palantir/python-language-server)
 
-Autocomplete triggers:
+Autocomplete triggers: in User or Syntax-specific settings, add:
 
 ```
 "auto_complete_triggers": [ {"selector": "source.python", "characters": "."} ],
@@ -126,7 +128,7 @@ Requires Rust Nightly.
 
 See [github:rust-lang-nursery/rls](https://github.com/rust-lang-nursery/rls) for up-to-date installation instructions.
 
-Autocomplete triggers:
+Autocomplete triggers: in User or Syntax-specific settings, add:
 
 ```
 "auto_complete_triggers": [ {"selector": "source.rust", "characters": ".:"} ]
@@ -149,6 +151,8 @@ Then the LSP plugin should launch as configured in LSP.sublime-settings using co
 ### C/C++ (Clangd)<a name="clang"></a>
 
 You will need to build from source, see [instructions](https://clang.llvm.org/extra/clangd.html)
+
+Autocomplete triggers: in User or Syntax-specific settings, add:
 
 ```
 "auto_complete_triggers": [ {"selector": "source.c++", "characters": ".>:" }]

--- a/main.py
+++ b/main.py
@@ -1904,7 +1904,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
 
             return (
                 self.completions,
-                0 if self.state == CompletionState.IDLE and not only_show_lsp_completions
+                0 if not only_show_lsp_completions
                 else sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS
             )
 

--- a/main.py
+++ b/main.py
@@ -2061,7 +2061,7 @@ class TypeAnnotator(object):
             # we only want the first line of the doc string
             formatted_str = formatted_str.split("\n")[0]
 
-        docs = ""
+        docs = []
         if category == "fn":
             text = formatted_str.split("\n")
             docs = text[:-1]

--- a/main.py
+++ b/main.py
@@ -1989,6 +1989,7 @@ class TypeAnnotator(object):
             phantoms_to_generate -= 1
             return
 
+        formatted_str = re.sub("<[a-zA-Z0-9_]*>", "", formatted_str)
         formatted_str = re.sub("[^& <]*::", "", formatted_str)
 
         region = self.view.word(point)

--- a/main.py
+++ b/main.py
@@ -1723,13 +1723,21 @@ class HoverHandler(sublime_plugin.ViewEventListener):
 
         mdpopups.show_popup(
             self.view,
-            "\n".join(formatted),
+            preserve_whitespace("\n".join(formatted)),
             css=".mdpopups .lsp_hover { margin: 4px; } .mdpopups p { margin: 0.1rem; }",
             md=True,
             flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
             location=point,
             wrapper_class="lsp_hover",
             max_width=800)
+
+
+def preserve_whitespace(contents: str) -> str:
+    """Preserve empty lines and whitespace for markdown conversion."""
+    contents = contents.replace('\t', '&nbsp' * 4)
+    contents = contents.replace('  ', '\a\a')
+    contents = contents.replace('\n\n', '\n&nbsp;\n')
+    return contents
 
 
 class CompletionState(object):
@@ -2005,7 +2013,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
 
                 mdpopups.show_popup(
                     self.view,
-                    "\n".join(formatted),
+                    preserve_whitespace("\n".join(formatted)),
                     css=".mdpopups .lsp_signature { margin: 4px; } .mdpopups p { margin: 0.1rem; }",
                     md=True,
                     flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,

--- a/main.py
+++ b/main.py
@@ -983,6 +983,24 @@ def annotate_visible_types(view: sublime.View):
         var_text = var_text[:-2]
         var_start = var.begin() + var_text.rfind(" ") + 1
         annotator.request_symbol_annotate(var_start)
+    tuple_vars = view.find_all('\\blet\\b *\(([a-zA-Z0-9_, ]*)\)', 0)
+    for var in tuple_vars:
+        if var is None or var.begin() == -1:
+            continue
+        var_text = view.substr(var)
+        var_start = var.begin() + var_text.find('(') + 1
+        var_text = re.sub("let *\(", "", var_text)
+        var_text = var_text[:-1]
+        tp_vars = var_text.split(",")
+        print("variable:", var_text, view.rowcol(var_start))
+        first = True
+        for var in tp_vars:
+            annotator.request_symbol_annotate(var_start)
+            print("tuple var:", view.rowcol(var_start))
+            if first:
+                first = False
+                var_start += 1
+            var_start += 1 + len(var)
     iter_vars = view.find_all('\\bfor\\b *([a-zA-Z_][a-zA-Z0-9_]*)', 0)
     for var in iter_vars:
         if var is None or var.begin() == -1:

--- a/main.py
+++ b/main.py
@@ -1880,7 +1880,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
 
     def is_after_trigger_character(self, location):
         if location > 0:
-            prev_char = self.view.substr()
+            prev_char = self.view.substr(location - 1)
             return prev_char in self.trigger_chars
 
     def on_query_completions(self, prefix, locations):

--- a/main.py
+++ b/main.py
@@ -1926,10 +1926,10 @@ class TypeAnnotator(object):
         formatted = fn_name + re.sub(" *fn *", "", formatted)
         offset = 0
         if "&mut self" in formatted:
-            formatted = "&mut self." + formatted.replace("&mut self, ", "", 1).replace("(, ", "", 1)
+            formatted = "&mut self." + formatted.replace("&mut self", "", 1).replace("(, ", "", 1)
             offset = len("&mut self.")
         elif "&self" in formatted:
-            formatted = "&self." + formatted.replace("&self, ", "", 1).replace("(, ", "", 1)
+            formatted = "&self." + formatted.replace("&self", "", 1).replace("(, ", "", 1)
             offset = len("&self.")
         elif "self" in formatted:
             formatted = "self." + formatted.replace("self", "", 1).replace("(, ", "", 1)

--- a/main.py
+++ b/main.py
@@ -978,8 +978,6 @@ def notify_did_change(view: sublime.View):
         point = view.sel()[0].begin()
         if view.substr(point - 1) == '(':
             sublime.set_timeout_async(lambda: annotate_types(view, True), 100)
-        else:
-            print("no function call")
 
 
 document_sync_initialized = False

--- a/main.py
+++ b/main.py
@@ -1738,8 +1738,9 @@ class HoverHandler(sublime_plugin.ViewEventListener):
 
 def preserve_whitespace(contents: str) -> str:
     """Preserve empty lines and whitespace for markdown conversion."""
-    contents = contents.replace('\t', '&nbsp' * 4)
-    contents = contents.replace('  ', '\a\a')
+    contents = contents.strip(' \t\r\n')
+    contents = contents.replace('\t', '&nbsp;' * 4)
+    contents = contents.replace('  ', '&nbsp;' * 2)
     contents = contents.replace('\n\n', '\n&nbsp;\n')
     return contents
 

--- a/main.py
+++ b/main.py
@@ -1448,8 +1448,13 @@ phantom_sets_by_buffer = {}  # type: Dict[int, sublime.PhantomSet]
 
 
 def update_diagnostics_phantoms(view: sublime.View, diagnostics: 'List[Diagnostic]'):
-    return
     global phantom_sets_by_buffer
+
+    # disable the normal LSP phantoms when using a Rust document,
+    # since these interfere with the enhanced Rust phantoms
+    syntax = view.settings().get('syntax')
+    if "Rust" in syntax:
+        return
 
     buffer_id = view.buffer_id()
     if not show_diagnostics_phantoms or view.is_dirty():

--- a/main.py
+++ b/main.py
@@ -1991,7 +1991,6 @@ class TypeAnnotator(object):
             if var is None or var.begin() == -1:
                 continue
             var_text = view.substr(var)
-            print("var:", var_text)
             var_start = var.begin() + var_text.find('{') + 1
             var_text = re.sub("use *[a-zA-Z0-9_:]*{", "", var_text)
             var_text = re.sub("} *;", "", var_text)
@@ -2102,10 +2101,11 @@ class TypeAnnotator(object):
         region = self.view.word(point)
         fn_name = self.view.substr(region)
         formatted = fn_name + re.sub(" *fn *", "", formatted)
-        self_decl = re.search("&{0,1}('[a-zA-Z0-9]){0,1} *(mut){0,1} *self[^:]", formatted)
+        formatted = re.sub(", *> *", ">", formatted)
+        self_decl = re.search("&{0,1}('[a-zA-Z0-9]){0,1} *(mut){0,1} *self *[^:]", formatted)
         offset = 0
         if self_decl is not None:
-            self_decl_str = self_decl.group(0)
+            self_decl_str = self_decl.group(0)[:-1].rstrip()
             formatted = formatted.replace(self_decl_str, "", 1).replace("(, ", "(", 1)
             offset = len(self_decl_str) + 1
             if "'" in self_decl_str:

--- a/main.py
+++ b/main.py
@@ -1453,7 +1453,7 @@ def update_diagnostics_phantoms(view: sublime.View, diagnostics: 'List[Diagnosti
     # disable the normal LSP phantoms when using a Rust document,
     # since these interfere with the enhanced Rust phantoms
     syntax = view.settings().get('syntax')
-    if "Rust" in syntax: # type: ignore
+    if "Rust" in syntax:  # type: ignore
         return
 
     buffer_id = view.buffer_id()
@@ -1822,14 +1822,14 @@ def wait_on_RLS():
         time.sleep(0.05)
 
 
-type_phantoms = [] # type: ignore
+type_phantoms = []  # type: ignore
 phantoms_to_generate = 0
 
 
 def annotate_types(view: sublime.View, current_function: bool):
     global type_phantoms, phantoms_to_generate
     syntax = view.settings().get('syntax')
-    if "Rust" not in syntax: # type: ignore
+    if "Rust" not in syntax:  # type: ignore
         return 1
     wait_on_RLS()
     phantoms_to_generate = 0

--- a/main.py
+++ b/main.py
@@ -1913,6 +1913,9 @@ class TypeAnnotator(object):
             tp_vars = var_text.split(",")
             first = True
             for var in tp_vars:
+                if var.startswith(" "):
+                    var_start += 1
+                    var = var[1:]
                 if var.startswith("mut "):
                     var_start += 4
                     var = var[4:]

--- a/main.py
+++ b/main.py
@@ -1790,7 +1790,7 @@ def annotate_types(view: sublime.View, current_function: bool):
     global type_phantoms
     syntax = view.settings().get('syntax')
     if "Rust" not in syntax:
-        return
+        return 1
     type_phantoms = []
     annotator = TypeAnnotator(view)
     annotator.annotate_var_decl(view)
@@ -1926,13 +1926,13 @@ class TypeAnnotator(object):
         formatted = fn_name + re.sub(" *fn *", "", formatted)
         offset = 0
         if "&mut self" in formatted:
-            formatted = "&mut self." + formatted.replace("&mut self, ", "", 1)
+            formatted = "&mut self." + formatted.replace("&mut self, ", "", 1).replace("(, ", "", 1)
             offset = len("&mut self.")
         elif "&self" in formatted:
-            formatted = "&self." + formatted.replace("&self, ", "", 1)
+            formatted = "&self." + formatted.replace("&self, ", "", 1).replace("(, ", "", 1)
             offset = len("&self.")
         elif "self" in formatted:
-            formatted = "self." + formatted.replace("self, ", "", 1)
+            formatted = "self." + formatted.replace("self", "", 1).replace("(, ", "", 1)
             offset = len("self.")
         region = Range(
             Point.from_text_point(self.view, region.begin() - offset),

--- a/main.py
+++ b/main.py
@@ -2073,7 +2073,7 @@ class TypeAnnotator(object):
             return
 
         formatted_str = re.sub("<[a-zA-Z0-9_]*>", "", formatted_str)
-        formatted_str = re.sub("[^& <]*::", "", formatted_str)
+        formatted_str = re.sub("[^(& <]*::", "", formatted_str)
         if formatted_str.startswith("[closure@"):
             category = "fn"
             formatted_str = re.sub("@.*:[0-9]+", ", captures ", formatted_str)

--- a/main.py
+++ b/main.py
@@ -864,7 +864,7 @@ def notify_did_open(view: sublime.View):
                 }
             }
             client.send_notification(Notification.didOpen(params))
-            sublime.set_timeout_async(lambda: sublime.set_timeout_async(lambda: annotate_visible_types(view), 4000) if (annotate_visible_types(view) == 0) else None, 1000)
+            sublime.set_timeout_async(lambda: sublime.set_timeout_async(lambda: annotate_visible_types(view), 4000) if (annotate_visible_types(view) == 0) else None, 100)
 
 
 def notify_did_close(view: sublime.View):
@@ -972,7 +972,7 @@ def annotate_visible_types(view: sublime.View):
     annotator = TypeAnnotator(view)
     visible = view.visible_region()
     lines = view.lines(visible)
-    all_vars = view.find_all('\\blet\\b *([a-zA-Z_][a-zA-Z0-9_]*)..', 0)
+    all_vars = view.find_all('\\blet\\b *mut *([a-zA-Z_][a-zA-Z0-9_]*)..', 0)
     for var in all_vars:
         if var is None or var.begin() == -1:
             continue
@@ -995,6 +995,9 @@ def annotate_visible_types(view: sublime.View):
         print("variable:", var_text, view.rowcol(var_start))
         first = True
         for var in tp_vars:
+            if var.startswith("mut "):
+                var_start += 4
+                var = var[4:]
             annotator.request_symbol_annotate(var_start)
             print("tuple var:", view.rowcol(var_start))
             if first:

--- a/main.py
+++ b/main.py
@@ -979,7 +979,6 @@ def annotate_visible_types(view: sublime.View):
         var_text = view.substr(var)
         if ":" in var_text:
             continue
-        print("variable:", var_text)
         var_text = var_text[:-2]
         var_start = var.begin() + var_text.rfind(" ") + 1
         annotator.request_symbol_annotate(var_start)
@@ -992,14 +991,12 @@ def annotate_visible_types(view: sublime.View):
         var_text = re.sub("let *\(", "", var_text)
         var_text = var_text[:-1]
         tp_vars = var_text.split(",")
-        print("variable:", var_text, view.rowcol(var_start))
         first = True
         for var in tp_vars:
             if var.startswith("mut "):
                 var_start += 4
                 var = var[4:]
             annotator.request_symbol_annotate(var_start)
-            print("tuple var:", view.rowcol(var_start))
             if first:
                 first = False
                 var_start += 1
@@ -1010,14 +1007,12 @@ def annotate_visible_types(view: sublime.View):
             continue
         var_text = view.substr(var)
         var_text = var_text[:-3]
-        print("variable:", var_text)
         var_start = var.begin() + var_text.rfind(" ") + 1
         annotator.request_symbol_annotate(var_start)
     sublime.set_timeout_async(lambda: show_type_phantoms(view), 1000)
     return len(type_phantoms)
 
 def show_type_phantoms(view: sublime.View):
-    print("number of phantoms:", len(type_phantoms))
     buffer_id = view.buffer_id()
     phantom_set = sublime.PhantomSet(view, "lsp_annotations")
     phantom_sets_by_buffer[buffer_id] = phantom_set

--- a/main.py
+++ b/main.py
@@ -2127,7 +2127,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
             insertText = label
         if insertText[0] == '$':  # sublime needs leading '$' escaped.
             insertText = '\$' + insertText[1:]
-        return "{}\t{}".format(label, detail) if detail else label, insertText
+        return "{}\t   {}".format(label, detail) if detail else label, insertText
 
     def handle_response(self, response):
         global resolvable_completion_items

--- a/main.py
+++ b/main.py
@@ -188,6 +188,8 @@ class Request:
         r["method"] = self.method
         if self.params is not None:
             r["params"] = self.params
+        else:
+            r["params"] = dict()
         return r
 
 
@@ -234,6 +236,8 @@ class Notification:
         r["method"] = self.method
         if self.params is not None:
             r["params"] = self.params
+        else:
+            r["params"] = dict()
         return r
 
 

--- a/main.py
+++ b/main.py
@@ -494,7 +494,7 @@ class Client(object):
                     payload = None
                     try:
                         payload = json.loads(content)
-                        limit = min(len(content), 2000)
+                        limit = min(len(content), 200)
                         if payload.get("method") != "window/logMessage":
                             debug("got json: ", content[0:limit], "...")
                     except IOError:

--- a/main.py
+++ b/main.py
@@ -469,13 +469,17 @@ class Client(object):
         """
         ContentLengthHeader = b"Content-Length: "
 
-        while self.process.poll() is None:
+        while True:
             try:
 
                 in_headers = True
                 content_length = 0
                 while in_headers:
-                    header = self.process.stdout.readline().strip()
+                    header = self.process.stdout.readline()
+                    if header == '':
+                        break
+                    else:
+                        header = header.strip()
                     if (len(header) == 0):
                         in_headers = False
 
@@ -491,7 +495,7 @@ class Client(object):
                         payload = json.loads(content)
                         limit = min(len(content), 200)
                         if payload.get("method") != "window/logMessage":
-                            debug("got json: ", content[0:limit])
+                            debug("got json: ", content[0:limit], "...")
                     except IOError:
                         printf("Got a non-JSON payload: ", content)
                         continue
@@ -499,7 +503,7 @@ class Client(object):
                     try:
                         if "error" in payload:
                             error = payload['error']
-                            debug("got error: ", error)
+                            printf("Got error from server: ", error)
                             sublime.status_message(error.get('message'))
                         elif "method" in payload:
                             if "id" in payload:
@@ -526,10 +530,12 @@ class Client(object):
         """
         Reads any errors from the LSP process.
         """
-        while self.process.poll() is None:
+        while True:
             try:
                 content = self.process.stderr.readline()
-                if log_stderr and len(content) > 0:
+                if len(content) == 0:
+                    break
+                if log_stderr:
                     printf("(stderr): ", content.strip())
             except IOError:
                 printf("LSP stderr process ending due to exception: ",

--- a/main.py
+++ b/main.py
@@ -1453,7 +1453,7 @@ def update_diagnostics_phantoms(view: sublime.View, diagnostics: 'List[Diagnosti
     # disable the normal LSP phantoms when using a Rust document,
     # since these interfere with the enhanced Rust phantoms
     syntax = view.settings().get('syntax')
-    if "Rust" in syntax:
+    if "Rust" in syntax: # type: ignore
         return
 
     buffer_id = view.buffer_id()
@@ -1822,14 +1822,14 @@ def wait_on_RLS():
         time.sleep(0.05)
 
 
-type_phantoms = []
+type_phantoms = [] # type: ignore
 phantoms_to_generate = 0
 
 
 def annotate_types(view: sublime.View, current_function: bool):
     global type_phantoms, phantoms_to_generate
     syntax = view.settings().get('syntax')
-    if "Rust" not in syntax:
+    if "Rust" not in syntax: # type: ignore
         return 1
     wait_on_RLS()
     phantoms_to_generate = 0

--- a/main.py
+++ b/main.py
@@ -972,7 +972,7 @@ def annotate_visible_types(view: sublime.View):
     annotator = TypeAnnotator(view)
     visible = view.visible_region()
     lines = view.lines(visible)
-    all_vars = view.find_all('\\blet\\b *mut *([a-zA-Z_][a-zA-Z0-9_]*)..', 0)
+    all_vars = view.find_all('\\blet\\b *(mut){0,1} *([a-zA-Z_][a-zA-Z0-9_]*)..', 0)
     for var in all_vars:
         if var is None or var.begin() == -1:
             continue

--- a/main.py
+++ b/main.py
@@ -1001,11 +1001,12 @@ def annotate_visible_types(view: sublime.View):
                 first = False
                 var_start += 1
             var_start += 1 + len(var)
-    iter_vars = view.find_all('\\bfor\\b *([a-zA-Z_][a-zA-Z0-9_]*)', 0)
+    iter_vars = view.find_all('\\bfor\\b *([a-zA-Z_][a-zA-Z0-9_]*) in', 0)
     for var in iter_vars:
         if var is None or var.begin() == -1:
             continue
         var_text = view.substr(var)
+        var_text = var_text[:-3]
         print("variable:", var_text)
         var_start = var.begin() + var_text.rfind(" ") + 1
         annotator.request_symbol_annotate(var_start)

--- a/main.py
+++ b/main.py
@@ -601,8 +601,16 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
         folder_paths = window.folders()
         return folder_paths[0]
     else:
-        debug("Couldn't determine project directory")
-        return None
+        filename = window.active_view().file_name()
+        if filename:
+            project_path = os.path.dirname(filename)
+            debug("Couldn't determine project directory since no folders are open!",
+                  "Using", project_path, "as a fallback.")
+            return project_path
+        else:
+            debug("Couldn't determine project directory since no folders are open",
+                  "and the current file isn't saved on the disk.")
+            return None
 
 
 def get_common_parent(paths: 'List[str]') -> str:
@@ -1532,47 +1540,49 @@ def format_diagnostics(file_path, origin_diagnostics):
 
 def start_client(window: sublime.Window, config: ClientConfig):
     project_path = get_project_path(window)
-    if project_path:
-        if show_status_messages:
-            window.status_message("Starting " + config.name + "...")
-        debug("starting in", project_path)
+    if project_path is None:
+        return None
 
-        variables = window.extract_variables()
-        expanded_args = list(sublime.expand_variables(os.path.expanduser(arg), variables) for arg in config.binary_args)
+    if show_status_messages:
+        window.status_message("Starting " + config.name + "...")
+    debug("starting in", project_path)
 
-        client = start_server(expanded_args, project_path)
-        if not client:
-            window.status_message("Could not start " + config.name + ", disabling")
-            debug("Could not start", config.binary_args, ", disabling")
-            return
+    variables = window.extract_variables()
+    expanded_args = list(sublime.expand_variables(os.path.expanduser(arg), variables) for arg in config.binary_args)
 
-        initializeParams = {
-            "processId": client.process.pid,
-            "rootUri": filename_to_uri(project_path),
-            "rootPath": project_path,
-            "capabilities": {
-                "textDocument": {
-                    "completion": {
-                        "completionItem": {
-                            "snippetSupport": True
-                        }
-                    },
-                    "synchronization": {
-                        "didSave": True
+    client = start_server(expanded_args, project_path)
+    if not client:
+        window.status_message("Could not start " + config.name + ", disabling")
+        debug("Could not start", config.binary_args, ", disabling")
+        return None
+
+    initializeParams = {
+        "processId": client.process.pid,
+        "rootUri": filename_to_uri(project_path),
+        "rootPath": project_path,
+        "capabilities": {
+            "textDocument": {
+                "completion": {
+                    "completionItem": {
+                        "snippetSupport": True
                     }
                 },
-                "workspace": {
-                    "applyEdit": True
+                "synchronization": {
+                    "didSave": True
                 }
+            },
+            "workspace": {
+                "applyEdit": True
             }
         }
-        if config.init_options:
-            initializeParams['initializationOptions'] = config.init_options
+    }
+    if config.init_options:
+        initializeParams['initializationOptions'] = config.init_options
 
-        client.send_request(
-            Request.initialize(initializeParams),
-            lambda result: handle_initialize_result(result, client, window, config))
-        return client
+    client.send_request(
+        Request.initialize(initializeParams),
+        lambda result: handle_initialize_result(result, client, window, config))
+    return client
 
 
 def get_window_client(view: sublime.View, config: ClientConfig) -> Client:

--- a/main.py
+++ b/main.py
@@ -1926,13 +1926,13 @@ class TypeAnnotator(object):
         formatted = fn_name + re.sub(" *fn *", "", formatted)
         offset = 0
         if "&mut self" in formatted:
-            formatted = "&mut self." + formatted.replace("&mut self", "", 1).replace("(, ", "", 1)
+            formatted = "&mut self." + formatted.replace("&mut self", "", 1).replace("(, ", "(", 1)
             offset = len("&mut self.")
         elif "&self" in formatted:
-            formatted = "&self." + formatted.replace("&self", "", 1).replace("(, ", "", 1)
+            formatted = "&self." + formatted.replace("&self", "", 1).replace("(, ", "(", 1)
             offset = len("&self.")
         elif "self" in formatted:
-            formatted = "self." + formatted.replace("self", "", 1).replace("(, ", "", 1)
+            formatted = "self." + formatted.replace("self", "", 1).replace("(, ", "(", 1)
             offset = len("self.")
         region = Range(
             Point.from_text_point(self.view, region.begin() - offset),


### PR DESCRIPTION
Last night, I just got really carried away with wanting Sublime Text to offer an experience to rival that of IntelliJ Rust, so I implemented a couple of big features last night and today.

I tried to be careful to make sure this PR won't affect non-Rust RLS support at all. Let me know what you think!

function parameter hinting:
![function parameter hinting](https://user-images.githubusercontent.com/726063/30933117-8dea3024-a397-11e7-85ff-cda779bc3852.png)

variable type hinting:
![screenshot_2017-09-27_15-20-49](https://user-images.githubusercontent.com/726063/30933115-8de1e2e8-a397-11e7-9784-6f53caa2c4bd.png)

for loop iterator variable type hinting:
![screenshot_2017-09-27_15-20-14](https://user-images.githubusercontent.com/726063/30933116-8de325b8-a397-11e7-96dd-17472a8f9120.png)

In the case of variable type hinting, it will refrain from inserting a phantom if it detects that the type has been manually specified, so it only annotates types for variables where the type is inferred.

I'm sure parts of this could probably be reused for other languages that rely heavily on type inference too! Go would be a fine candidate, but I understand the Go RLS support is maybe a little problematic, according to the docs.