### PR TITLE
Add support for per language-server environment variables

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -6,7 +6,14 @@
       "command": ["pyls"],
       "scopes": ["source.python"],
       "syntaxes": ["Packages/Python/Python.sublime-syntax"],
-      "languageId": "python"
+      "languageId": "python",
+      "environment": {
+        "PYTHONPATH": [
+            "${sublime_libs}",
+            "${packages}",
+            "${project_path}"
+        ]
+      }
     },
     "jsts":
     {

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -7,12 +7,7 @@
       "scopes": ["source.python"],
       "syntaxes": ["Packages/Python/Python.sublime-syntax"],
       "languageId": "python",
-      "environment": {
-        "PYTHONPATH": [
-            "${sublime_libs}",
-            "${packages}",
-            "${project_path}"
-        ]
+      "env": {
       }
     },
     "jsts":

--- a/main.py
+++ b/main.py
@@ -817,8 +817,6 @@ def apply_window_settings(client_config: 'ClientConfig', view: 'sublime.View') -
     if client_config.name in window_config:
         overrides = window_config[client_config.name]
         debug('window has override for', client_config.name, overrides)
-        merged_init_options = dict(client_config.init_options)
-        merged_init_options.update(overrides.get("initializationOptions", dict()))
         return ClientConfig(
             client_config.name,
             overrides.get("command", client_config.binary_args),
@@ -826,8 +824,10 @@ def apply_window_settings(client_config: 'ClientConfig', view: 'sublime.View') -
             overrides.get("syntaxes", client_config.syntaxes),
             overrides.get("languageId", client_config.languageId),
             overrides.get("enabled", client_config.enabled),
-            merged_init_options,
-            overrides.get("settings", dict()))
+            overrides.get("initializationOptions", client_config.init_options),
+            overrides.get("settings", client_config.settings),
+            overrides.get("env", client_config.env)
+        )
     else:
         return client_config
 

--- a/main.py
+++ b/main.py
@@ -337,7 +337,7 @@ def read_client_config(name, client_config):
         client_config.get("enabled", True),
         client_config.get("initializationOptions", dict()),
         client_config.get("settings", dict()),
-        client_config.get("environment", dict())
+        client_config.get("env", dict())
     )
 
 
@@ -458,7 +458,7 @@ def update_settings(settings_obj: sublime.Settings):
 
 class ClientConfig(object):
     def __init__(self, name, binary_args, scopes, syntaxes, languageId,
-                 enabled=True, init_options=dict(), settings=dict(), environ=dict()):
+                 enabled=True, init_options=dict(), settings=dict(), env=dict()):
         self.name = name
         self.binary_args = binary_args
         self.scopes = scopes
@@ -467,7 +467,7 @@ class ClientConfig(object):
         self.enabled = enabled
         self.init_options = init_options
         self.settings = settings
-        self.environ = environ
+        self.env = env
 
 
 def format_request(payload: 'Dict[str, Any]'):
@@ -1777,8 +1777,6 @@ def start_client(window: sublime.Window, config: ClientConfig):
 
     # Create a dictionary of Sublime Text variables
     variables = window.extract_variables()
-    variables["sublime_path"] = os.path.dirname(sublime.executable_path())
-    variables["sublime_libs"] = ';'.join(sys.path)
 
     # Expand language server command line environment variables
     expanded_args = list(
@@ -1787,16 +1785,16 @@ def start_client(window: sublime.Window, config: ClientConfig):
     )
 
     # Merge/expand OS environment variables
-    environ = os.environ.copy()
-    for var, value in config.environ.items():
+    env = os.environ.copy()
+    for var, value in config.env.items():
         # Merge vars (e.g.: PATH=$PATH;mypath)
         # For ease of editing, allow lists for each environment variable
         if isinstance(value, list):
-            value = ';'.join(value)
+            value = ''.join(value)
         # Expand both, ST and OS environment variables
-        environ[var] = os.path.expandvars(sublime.expand_variables(value, variables))
+        env[var] = os.path.expandvars(sublime.expand_variables(value, variables))
 
-    client = start_server(expanded_args, project_path, environ)
+    client = start_server(expanded_args, project_path, env)
     if not client:
         window.status_message("Could not start " + config.name + ", disabling")
         debug("Could not start", config.binary_args, ", disabling")
@@ -1847,7 +1845,7 @@ def get_window_client(view: sublime.View, config: ClientConfig) -> Client:
     return client
 
 
-def start_server(server_binary_args, working_dir, environ):
+def start_server(server_binary_args, working_dir, env):
     debug("starting " + str(server_binary_args))
     si = None
     if os.name == "nt":
@@ -1860,7 +1858,7 @@ def start_server(server_binary_args, working_dir, environ):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=working_dir,
-            env=environ,
+            env=env,
             startupinfo=si)
         return Client(process, working_dir)
 

--- a/main.py
+++ b/main.py
@@ -1784,14 +1784,10 @@ def start_client(window: sublime.Window, config: ClientConfig):
         for arg in config.binary_args
     )
 
-    # Merge/expand OS environment variables
+    # Override OS environment variables
     env = os.environ.copy()
     for var, value in config.env.items():
-        # Merge vars (e.g.: PATH=$PATH;mypath)
-        # For ease of editing, allow lists for each environment variable
-        if isinstance(value, list):
-            value = ''.join(value)
-        # Expand both, ST and OS environment variables
+        # Expand both ST and OS environment variables
         env[var] = os.path.expandvars(sublime.expand_variables(value, variables))
 
     client = start_server(expanded_args, project_path, env)


### PR DESCRIPTION
With this PR a user can add a dictionary to each client-configuration.

    "environment": {
        "PATH": "$PATH;${project_path};/opt/libs"
        "PYTHONPATH": [
            "${sublime_libs}",   feature removed by request
            "${packages}",
            "${project_path}"
        ]
    }

This dictionary lists environment variables to add or set to the global
environment variables `os.environ` provided by Sublime Text.

The language server will see the merged set of environment variables.

Notes about the dictionary:

1. Each variable can be either a simple string or a list of strings.
2. If a variable is a list, it is merged to a string separated by ;
   This enables easier setup of larger sets of values such as paths.
3. Each variable replaces the global environment variable.
4. Shell variables such as $PATH are expanded.
5. Point 3. and 4. allow merging of global and local variables (see $PATH)
6. The following Sublime Text variables can be added as value and will
   be expanded on assignment as well:

```
    ${packages}              // Sublime Text Packages path
    ${platform}              // Operating system
    ${project}               // Full path to project file
    ${project_base_name}     // Project name without extension
    ${project_name}          // The name of the project
    ${project_path}          // Folder in which the open Project is located

// Removed by request
//    ${sublime_libs}          // sys.path as known by Sublime Text
//    ${sublime_path}          // install path of Sublime Text
```

7. The values of a global setting are replaced by user or project settings
   as this is the default behavior of dict.update().