### PR TITLE
Fix endless loop after language-server termination.

### DIFF
--- a/main.py
+++ b/main.py
@@ -528,20 +528,18 @@ class Client(object):
         """
         ContentLengthHeader = b"Content-Length: "
 
-        while True:
+        running = True
+        while running:
+            running = self.process.poll() is None
+
             try:
-
-                in_headers = True
                 content_length = 0
-                while in_headers:
+                while True:
                     header = self.process.stdout.readline()
-                    if header == '':
-                        break
-                    else:
+                    if header:
                         header = header.strip()
-                    if (len(header) == 0):
-                        in_headers = False
-
+                    if not header:
+                        break
                     if header.startswith(ContentLengthHeader):
                         content_length = int(header[len(ContentLengthHeader):])
 
@@ -589,10 +587,13 @@ class Client(object):
         """
         Reads any errors from the LSP process.
         """
-        while True:
+        running = True
+        while running:
+            running = self.process.poll() is None
+
             try:
                 content = self.process.stderr.readline()
-                if len(content) == 0:
+                if not content:
                     break
                 if log_stderr:
                     printf("(stderr): ", content.strip())


### PR DESCRIPTION
Fixes Issue #132

With commit 8beb41e the `self.process.poll()` function was removed, which checks, whether the subprocess (language-server) was terminated.

Therefore the `read_stdout()` and `read_stderr()` methonds of Client never exit and run without any sleep time after the process exits.

This commit reintroduces `self.process.poll()` but makes sure the already sent stdout/stderr content is still read and processed by LSP.

Furthermore the output checks of `stderr.readline()` / `stdout.readline()` are simplified as using `len()` is not the best solution here. It will fail if the passed string is None.