### PR TITLE
Fix exception when handling empty signature parameters.

### DIFF
--- a/main.py
+++ b/main.py
@@ -2246,14 +2246,13 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                 formatted = []
                 formatted.append(
                     "```{}\n{}\n```".format(config.languageId, signature.get('label')))
-                # TODO: fallback to params for pyls, create issue?
-                params = signature.get('parameters') or signature.get('params') or {}
-                debug("params", params)
-                for parameter in params:
-                    paramDocs = parameter.get('documentation')
-                    if paramDocs:
-                        formatted.append("**{}**\n".format(parameter.get('label')))
-                        formatted.append("* *{}*\n".format(paramDocs))
+                params = signature.get('parameters')
+                if params:
+                    for parameter in params:
+                        paramDocs = parameter.get('documentation')
+                        if paramDocs:
+                            formatted.append("**{}**\n".format(parameter.get('label')))
+                            formatted.append("* *{}*\n".format(paramDocs))
 
                 formatted.append(signature.get('documentation'))
 

--- a/main.py
+++ b/main.py
@@ -2246,9 +2246,8 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                 formatted = []
                 formatted.append(
                     "```{}\n{}\n```".format(config.languageId, signature.get('label')))
-                params = signature.get('parameters')
-                if params is None:  # for pyls TODO create issue?
-                    params = signature.get('params')
+                # TODO: fallback to params for pyls, create issue?
+                params = signature.get('parameters') or signature.get('params') or {}
                 debug("params", params)
                 for parameter in params:
                     paramDocs = parameter.get('documentation')


### PR DESCRIPTION
Prior to this commit an exception is raised if the function signature returned by a language server does neither contain a `parameters` nor `params` field.

The error message was:

```
   LSP: active signature {'label': 'active_window()', 'documentation': ''}
   LSP: params None
   LSP: error handling response 10
   LSP: Error handling server content: 'NoneType' object is not iterable
```

This commit fixes this issue by a fallback to an empty dictionary.