### PR TITLE
Fix crash when clicking diagnostics hover "Code Action" link

### DIFF
--- a/main.py
+++ b/main.py
@@ -1954,7 +1954,7 @@ class HoverHandler(sublime_plugin.ViewEventListener):
             location=point,
             wrapper_class="lsp_hover",
             max_width=800,
-            on_navigate=lambda href: self.on_diagnostics_navigate(self, href, point, diagnostics))
+            on_navigate=lambda href: self.on_diagnostics_navigate(href, point, diagnostics))
 
     def on_diagnostics_navigate(self, href, point, diagnostics):
         # TODO: don't mess with the user's cursor.


### PR DESCRIPTION
Fixes following traceback:

Traceback (most recent call last):
  File "C:\Apps\Sublime\Data\Packages\LSP\main.py", line 1965, in <lambda>
    on_navigate=lambda href: self.on_diagnostics_navigate(self, href, point, diagnostics))
TypeError: on_diagnostics_navigate() takes 4 positional arguments but 5 were given


![screenshot](https://user-images.githubusercontent.com/16542113/31078996-7dab0a44-a784-11e7-8e13-61783c2897fa.png)
