### PR TITLE
Add support for PackageDev settings tooltips

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -139,8 +139,8 @@
   // Show in-line diagnostics using phantoms for unchanged files.
   "show_diagnostics_phantoms": false,
 
-  // Show diagnostics description in status bar
-  // if the cursor hovers complained code.
+  // Show the diagnostics description of the code
+  // under the cursor in status bar if available.
   "show_diagnostics_in_view_status": true,
 
   // Highlighting style of code diagnostics.

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -1,21 +1,48 @@
 {
+  // User clients configuration can be used to
+  // - override single settings of "default_clients"
+  // - create add new user specified clients
+  //
+  // "clients":
+  // {
+  //   // Each new client must have the following structure.
+  //   "client_name":
+  //   {
+  //     # Must-have settings (for new clients):
+  //
+  //     // The command line required to run the server.
+  //     "command": ["pyls"],
+  //
+  //     // Use: "Show Scope Name" from Sublime's Developer menu
+  //     "scopes": ["source.python"],
+  //
+  //     // Run: view.settings().get("syntax") in console
+  //     "syntaxes": ["Packages/Python/Python.sublime-syntax"],
+  //
+  //     // See: https://github.com/Microsoft/language-server-protocol/issues/213
+  //     "languageId": "python",
+  //
+  //     # Optional settings (key-value pairs):
+  //
+  //     // Sent to server once using workspace/didConfigurationChange notification
+  //     "settings": { },
+  //
+  //     // Sent once to server in initialize request
+  //     "initializationOptions": { },
+  //
+  //     // Extra variables to override/add to language server's environment.
+  //     "env": { },
+  //   }
+  // }
+  "clients": {
+
+  },
+
+  // Default clients configuration
+  // DO NOT MODIFY THIS SETTING!
+  // Use "clients" to override settings instead!
   "default_clients":
   {
-    // "client_name":
-    // {
-    //   Must-have settings:
-    //
-    //   "command": ["pyls"],
-    //   "scopes": ["source.python"], Use: "Show Scope Name" from Sublime's Developer menu
-    //   "syntaxes": ["Packages/Python/Python.sublime-syntax"], Run: sublime.active_window().active_view().settings().get("syntax") in console
-    //   "languageId": "python", See: https://github.com/Microsoft/language-server-protocol/issues/213
-    //
-    //   Optional settings (key-value pairs):
-    //
-    //   "settings": { }, Sent to server once using workspace/didConfigurationChange notification
-    //   "initializationOptions": { }, Sent once to server in initialize request
-    //   "env": { }, Extra variables to override/add to language server's environment.
-    // },
     "pyls":
     {
       "command": ["pyls"],
@@ -97,19 +124,49 @@
       "languageId": "java"
     },
   },
+
+  // Show activity messages in the status bar for a few seconds.
+  // Example: Starting pyls ...
   "show_status_messages": true,
+
+  // Show permanent language server status in the status bar.
   "show_view_status": true,
+
+  // Open and close the diagnostics panel automatically,
+  // depending on available diagnostics.
   "auto_show_diagnostics_panel": true,
+
+  // Show in-line diagnostics using phantoms for unchanged files.
   "show_diagnostics_phantoms": false,
+
+  // Show diagnostics description in status bar
+  // if the cursor hovers complained code.
   "show_diagnostics_in_view_status": true,
-  // highlight style of code diagnostics: "underline" or "box"
+
+  // Highlighting style of code diagnostics.
+  // Valid values are "underline" or "box"
   "diagnostics_highlight_style": "underline",
-  // gutter marker for code diagnostics: "dot", "circle", "bookmark", "cross" or ""
+
+  // Gutter marker for code diagnostics.
+  // Valid values are "bookmark", "circle", "cross", "dot" or ""
   "diagnostics_gutter_marker": "dot",
+
+  // Request completions for all characters if set to true,
+  // or just after trigger characters only otherwise.
   "complete_all_chars": true,
+
+  // Disable Sublime Text's explicit and word completion.
   "only_show_lsp_completions": false,
+
+  // Resolve completions and apply snippet if received.
   "resolve_completion_for_snippets": false,
+
+  // Show verbose debug messages in the sublime console.
   "log_debug": false,
+
+  // Show notifications from language servers in the console.
   "log_server": true,
+
+  // Show language server stderr output in the console.
   "log_stderr": false
 }


### PR DESCRIPTION
PackageDev uses the comments above each setting to display a tooltip, if the cursor is hovered over an existing setting.

![screenshot](https://user-images.githubusercontent.com/16542113/31082330-ee881f4a-a78e-11e7-98a3-c1b9a63b12ca.png)


This commit adds required comments to the LSP.sublime-settings file.

An empty "clients" object was added to prevent PackageDev's linter from highlighting the key as unknown.

The template for user defined clients is moved to the "clients" setting and a warning was added to the comment of "default_clients" to prevent a user from accidentally manipulating the wrong setting to do overrides.

The template was formatted to hopefully display well in the tooltip for most users.