### PR TITLE
Fix word completions not displayed in completions panel

### DIFF
--- a/main.py
+++ b/main.py
@@ -2233,7 +2233,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
         if insert_text[0] == '$':  # sublime needs leading '$' escaped.
             insert_text = '\$' + insert_text[1:]
         # only return label with a hint if available
-        return " \t ".join((label, hint)) if hint else label, insert_text
+        return "\t  ".join((label, hint)) if hint else label, insert_text
 
     def handle_response(self, response):
         global resolvable_completion_items


### PR DESCRIPTION
fixes #158

The format of the "trigger" of the completions returned by a plugin seems to influence the way Sublime Text merges them with word completions.

The extra spaces added to the "trigger" value, which make sure the hints are displayed with enough distance to the label, cause Sublime Text not to correctly merge in word completions.

To solve the issue, the `\t` is moved to the very left to prevent a space to be appended to the label in the returned value.