### PR TITLE
Fix &nbsp; being displayed in toolip code blocks

### DIFF
--- a/main.py
+++ b/main.py
@@ -2040,9 +2040,9 @@ class HoverHandler(sublime_plugin.ViewEventListener):
 def preserve_whitespace(contents: str) -> str:
     """Preserve empty lines and whitespace for markdown conversion."""
     contents = contents.strip(' \t\r\n')
-    contents = contents.replace('\t', '&nbsp;' * 4)
-    contents = contents.replace('  ', '&nbsp;' * 2)
-    contents = contents.replace('\n\n', '\n&nbsp;\n')
+    contents = contents.replace('\t', '\u00A0' * 4)
+    contents = contents.replace('  ', '\u00A0' * 2)
+    contents = contents.replace('\n\n', '\n\u00A0\n')
     return contents
 
 


### PR DESCRIPTION
fixes #159

Directly replacing whitespace with `&nbps;` works only, if the result is passed to mdpopups as html directly.

The solution is to use `\u00A0` as fixed whitespace instead, which mdpopups is designed to use for markdown as well.