### PR TITLE
Implement textDocument/rangeFormatting

### DIFF
--- a/Commands/Default.sublime-commands
+++ b/Commands/Default.sublime-commands
@@ -37,6 +37,11 @@
     	"args": {}
     },
     {
+        "caption": "LSP: Format Selection",
+        "command": "lsp_format_document_range",
+        "args": {}
+    },
+    {
         "caption": "LSP: Restart Servers",
         "command": "lsp_restart_client",
         "args": {}

--- a/Menus/Context.sublime-menu
+++ b/Menus/Context.sublime-menu
@@ -20,5 +20,9 @@
         "command": "lsp_format_document",
         "caption": "Format Document"
     },
+    {
+        "command": "lsp_format_document_range",
+        "caption": "Format Selection"
+    },
     { "caption": "-", "id": "lsp_end"}
 ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -259,6 +259,7 @@ Any fields in a client configuration can be overridden by adding an LSP settings
     * Recommendation: Override `f12` (built-in goto definition),
     * LSP falls back to ST3's built-in goto definition command in case LSP fails.
 * Format Document: UNBOUND
+* Format Selection: UNBOUND
 * Document Symbols: UNBOUND
 
 **Workspace actions**


### PR DESCRIPTION
There might be race bugs when using this with multiple selections.

When this is invoked with multiple selections, I try to send requests from "highest range" to "lowest range", so that local edits don't affect other local edits.

I'm not too worried about this at the moment.