### PR TITLE
Fix exception with signature help after project change

### DIFF
--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -41,7 +41,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
             signatureHelpProvider = client.get_capability(
                 'signatureHelpProvider')
             if signatureHelpProvider:
-                self.signature_help_triggers = signatureHelpProvider.get(
+                self._signature_help_triggers = signatureHelpProvider.get(
                     'triggerCharacters')
 
         config = config_for_scope(self.view)
@@ -57,8 +57,8 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         if not self._initialized:
             self.initialize()
 
-        if self.signature_help_triggers:
-            if last_char in self.signature_help_triggers:
+        if self._signature_help_triggers:
+            if last_char in self._signature_help_triggers:
                 client = client_for_view(self.view)
                 if client:
                     purge_did_change(self.view.buffer_id())


### PR DESCRIPTION
This commit fixes an issue with LSP throwing an exception after opening another project within the self window using project switcher or ProjectManager plugin.

The traceback:
```
LSP: pyls not available for view None in window 3
Traceback (most recent call last):
  File "C:\Apps\Sublime\sublime_plugin.py", line 417, in run_async_view_listener_callback
    vel.__class__.__dict__[name](vel)
  File "C:\Apps\Sublime\Data\Packages\LSP\plugin\signature_help.py", line 60, in on_modified_async
    if self.signature_help_triggers:
AttributeError: 'SignatureHelpListener' object has no attribute 'signature_help_triggers'
```