### PR TITLE
New whitespace / layout / styling PR

### DIFF
--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -116,9 +116,6 @@ unsupported_syntax_template = """
 Visit [langserver.org](https://langserver.org) to find out if a language server exists for this language."""
 
 
-setup_css = ".mdpopups .lsp_documentation { margin: 20px; font-family: sans-serif; font-size: 1.2rem; line-height: 2}"
-
-
 class LspSetupLanguageServerCommand(sublime_plugin.WindowCommand):
     def run(self):
         view = self.window.active_view()
@@ -137,7 +134,16 @@ class LspSetupLanguageServerCommand(sublime_plugin.WindowCommand):
         mdpopups.show_popup(
             view,
             "\n".join([title, content]),
-            css=setup_css,
+            css='''
+                .lsp_documentation {
+                    margin: 1rem 1rem 0.5rem 1rem;
+                    font-family: system;
+                }
+                .lsp_documentation h1,
+                .lsp_documentation p {
+                    margin: 0 0 0.5rem 0;
+                }
+            ''',
             md=True,
             wrapper_class="lsp_documentation",
             max_width=800,

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -13,4 +13,7 @@ popup_css = '''
         padding: 0 0.5rem;
         font-family: system;
     }
+    .lsp_popup li {
+        font-family: system;
+    }
 '''

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -1,0 +1,25 @@
+popup_class = "lsp_popup"
+
+popup_css = '''
+    .lsp_popup {
+        margin: 0.5rem 0.5rem 0 0.5rem;
+    }
+    .lsp_popup .highlight {
+        border-width: 0;
+        border-radius: 0;
+    }
+    .lsp_popup p {
+        margin-bottom: 0.5rem;
+        padding: 0 0.5rem;
+        font-family: system;
+    }
+'''
+
+
+def preserve_whitespace(contents: str) -> str:
+    """Preserve empty lines and whitespace for markdown conversion."""
+    contents = contents.strip(' \t\r\n')
+    contents = contents.replace('\r\n', '\n')
+    contents = contents.replace('\t', '\u00A0' * 4)
+    contents = contents.replace('  ', '\u00A0' * 2)
+    return contents

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -17,7 +17,7 @@ popup_css = '''
 
 
 def preserve_whitespace(contents: str) -> str:
-    """Preserve empty lines and whitespace for markdown conversion."""
+    """Preserve indentation in (non-markdown) ascii docstrings (e.g. pyls)"""
     contents = contents.replace('\t', '\u00A0' * 4)
     contents = contents.replace('  ', '\u00A0' * 2)
     return contents

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -18,8 +18,6 @@ popup_css = '''
 
 def preserve_whitespace(contents: str) -> str:
     """Preserve empty lines and whitespace for markdown conversion."""
-    contents = contents.strip(' \t\r\n')
-    contents = contents.replace('\r\n', '\n')
     contents = contents.replace('\t', '\u00A0' * 4)
     contents = contents.replace('  ', '\u00A0' * 2)
     return contents

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -14,10 +14,3 @@ popup_css = '''
         font-family: system;
     }
 '''
-
-
-def preserve_whitespace(contents: str) -> str:
-    """Preserve indentation in (non-markdown) ascii docstrings (e.g. pyls)"""
-    contents = contents.replace('\t', '\u00A0' * 4)
-    contents = contents.replace('  ', '\u00A0' * 2)
-    return contents

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -106,4 +106,3 @@ class HoverHandler(sublime_plugin.ViewEventListener):
             location=point,
             wrapper_class=popup_class,
             max_width=800)
-

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -8,7 +8,7 @@ from .core.clients import client_for_view
 from .core.protocol import Request
 from .core.documents import get_document_position
 from .core.logging import debug
-from .core.popups import preserve_whitespace, popup_css, popup_class
+from .core.popups import popup_css, popup_class
 
 SUBLIME_WORD_MASK = 515
 NO_HOVER_SCOPES = 'comment, constant, keyword, storage, string'
@@ -95,7 +95,7 @@ class HoverHandler(sublime_plugin.ViewEventListener):
             if language:
                 formatted.append("```{}\n{}\n```\n".format(language, value))
             else:
-                formatted.append(preserve_whitespace(value))
+                formatted.append(value)
 
         mdpopups.show_popup(
             self.view,

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -8,7 +8,7 @@ from .core.clients import client_for_view
 from .core.protocol import Request
 from .core.documents import get_document_position
 from .core.logging import debug
-
+from .core.popups import preserve_whitespace, popup_css, popup_class
 
 SUBLIME_WORD_MASK = 515
 NO_HOVER_SCOPES = 'comment, constant, keyword, storage, string'
@@ -62,11 +62,11 @@ class HoverHandler(sublime_plugin.ViewEventListener):
         mdpopups.show_popup(
             self.view,
             "\n".join(formatted),
-            css=".mdpopups .lsp_hover { margin: 4px; }",
+            css=popup_css,
             md=True,
             flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
             location=point,
-            wrapper_class="lsp_hover",
+            wrapper_class=popup_class,
             max_width=800,
             on_navigate=lambda href: self.on_diagnostics_navigate(href, point, diagnostics))
 
@@ -93,25 +93,17 @@ class HoverHandler(sublime_plugin.ViewEventListener):
                 value = item.get("value")
                 language = item.get("language")
             if language:
-                formatted.append("```{}\n{}\n```".format(language, value))
+                formatted.append("```{}\n{}\n```\n".format(language, value))
             else:
-                formatted.append(value)
+                formatted.append(preserve_whitespace(value))
 
         mdpopups.show_popup(
             self.view,
-            preserve_whitespace("\n".join(formatted)),
-            css=".mdpopups .lsp_hover { margin: 4px; } .mdpopups p { margin: 0.1rem; }",
+            "\n".join(formatted),
+            css=popup_css,
             md=True,
             flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
             location=point,
-            wrapper_class="lsp_hover",
+            wrapper_class=popup_class,
             max_width=800)
 
-
-def preserve_whitespace(contents: str) -> str:
-    """Preserve empty lines and whitespace for markdown conversion."""
-    contents = contents.strip(' \t\r\n')
-    contents = contents.replace('\t', '&nbsp;' * 4)
-    contents = contents.replace('  ', '&nbsp;' * 2)
-    contents = contents.replace('\n\n', '\n&nbsp;\n')
-    return contents

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -14,12 +14,10 @@ from .core.documents import get_document_position, purge_did_change
 from .core.configurations import is_supported_syntax, config_for_scope
 from .core.protocol import Request
 from .core.logging import debug
+from .core.popups import preserve_whitespace, popup_css, popup_class
 
 
 class SignatureHelpListener(sublime_plugin.ViewEventListener):
-
-    css = ".mdpopups .lsp_signature { margin: 4px; } .mdpopups p { margin: 0.1rem; }"
-    wrapper_class = "lsp_signature"
 
     def __init__(self, view):
         self.view = view
@@ -90,11 +88,11 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
             if len(self._signatures) > 0:
                 mdpopups.show_popup(self.view,
                                     self._build_popup_content(),
-                                    css=self.__class__.css,
+                                    css=popup_css,
                                     md=True,
                                     flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
                                     location=point,
-                                    wrapper_class=self.__class__.wrapper_class,
+                                    wrapper_class=popup_class,
                                     max_width=800,
                                     on_hide=self._on_hide)
                 self._visible = True
@@ -118,9 +116,9 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                 self._active_signature = new_index
                 mdpopups.update_popup(self.view,
                                       self._build_popup_content(),
-                                      css=self.__class__.css,
+                                      css=popup_css,
                                       md=True,
-                                      wrapper_class=self.__class__.wrapper_class)
+                                      wrapper_class=popup_class)
 
             return True  # We handled this keybinding.
 
@@ -132,11 +130,11 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         formatted = []
 
         if len(self._signatures) > 1:
-            signature_navigation = "**{}** of **{}** overloads (use the arrow keys to navigate):\n".format(
+            signature_navigation = "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
                 str(self._active_signature + 1), str(len(self._signatures)))
             formatted.append(signature_navigation)
 
-        label = "```{}\n{}\n```".format(self._language_id, signature.get('label'))
+        label = "```{}\n{}\n```\n".format(self._language_id, signature.get('label'))
         formatted.append(label)
 
         params = signature.get('parameters')
@@ -150,12 +148,3 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         if sigDocs:
             formatted.append(sigDocs)
         return preserve_whitespace("\n".join(formatted))
-
-
-def preserve_whitespace(contents: str) -> str:
-    """Preserve empty lines and whitespace for markdown conversion."""
-    contents = contents.strip(' \t\r\n')
-    contents = contents.replace('\t', '&nbsp;' * 4)
-    contents = contents.replace('  ', '&nbsp;' * 2)
-    contents = contents.replace('\n\n', '\n&nbsp;\n')
-    return contents

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -14,7 +14,7 @@ from .core.documents import get_document_position, purge_did_change
 from .core.configurations import is_supported_syntax, config_for_scope
 from .core.protocol import Request
 from .core.logging import debug
-from .core.popups import preserve_whitespace, popup_css, popup_class
+from .core.popups import popup_css, popup_class
 
 
 class SignatureHelpListener(sublime_plugin.ViewEventListener):
@@ -147,4 +147,4 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         sigDocs = signature.get('documentation', None)
         if sigDocs:
             formatted.append(sigDocs)
-        return preserve_whitespace("\n".join(formatted))
+        return "\n".join(formatted)


### PR DESCRIPTION
Replaces #168 after the codebase was split. Please refer to that PR for the epic ride towards the new good looking popups with code highlighting. It was pretty much impossible to rebase or merge this so I decided to re-implement.

Fixes #105 and fixes #82, pretty sure it also fixes #159

Please also note we should [update our dependencies](https://github.com/tomv564/LSP/pull/168#issuecomment-336130644)

Before: 

<img width="766" alt="screen shot 2017-10-16 at 14 21 29" src="https://user-images.githubusercontent.com/2543659/31611668-59f31e8a-b27d-11e7-84b7-9de3163dce76.png">


After:

<img width="723" alt="screen shot 2017-10-16 at 14 19 54" src="https://user-images.githubusercontent.com/2543659/31611637-2f423388-b27d-11e7-8aba-739458144d4a.png">
