### PR TITLE
Fix wrong usage of message_dialog().

### DIFF
--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -104,7 +104,7 @@ def handle_initialize_result(result, client, window, config):
         lambda params: handle_diagnostics(params))
     client.on_notification(
         "window/showMessage",
-        lambda params: sublime.active_window().message_dialog(params.get("message")))
+        lambda params: sublime.message_dialog(params.get("message")))
     if settings.log_server:
         client.on_notification(
             "window/logMessage",


### PR DESCRIPTION
According to the API reference
  https://www.sublimetext.com/docs/3/api_reference.html
the `message_dialog()` function is directly on the `sublime` module, not on the `Window` class.