### PR TITLE
fix looking up document state in notify_did_save

### DIFF
--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -160,8 +160,9 @@ def notify_did_close(view: sublime.View):
 
 def notify_did_save(view: sublime.View):
     file_name = view.file_name()
-    if file_name:
-        if file_name in document_states:
+    window = view.window()
+    if window and file_name:
+        if has_document_state(window, file_name):
             client = client_for_view(view)
             if client:
                 params = {"textDocument": {"uri": filename_to_uri(file_name)}}


### PR DESCRIPTION
was trying to lookup a file in the window ids map. pretty certain should be using this function instead

map is keyed on int as per https://github.com/dten/LSP/blob/0f8b8b0feb40878330953ea66a3b579caa7b1bcd/plugin/core/documents.py#L53