### PR TITLE
Show result (once) in status bar when workpace or document edits are applied

### DIFF
--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -36,7 +36,7 @@ class LspSymbolRenameCommand(sublime_plugin.TextCommand):
             changes = response.get('changes')
             if len(changes) > 0:
                 self.view.window().run_command('lsp_apply_workspace_edit',
-                                               {'changes': response})
+                                               {'changes': changes})
 
     def want_event(self):
         return True


### PR DESCRIPTION
For #190, should display how many documents (for workspace edits) or how many regions (for document edits) in the status bar were edited.