### PR TITLE
Set languageId to objc++ for the clangd server

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -76,7 +76,7 @@
       "command": ["clangd"],
       "scopes": ["source.c", "source.c++", "source.objc", "source.objc++"],
       "syntaxes": ["Packages/C++/C.sublime-syntax", "Packages/C++/C++.sublime-syntax", "Packages/Objective-C/Objective-C.sublime-syntax", "Packages/Objective-C/Objective-C++.sublime-syntax"],
-      "languageId": "c-family"
+      "languageId": "objc++"
     },
     "reason":
     {


### PR DESCRIPTION
I thought we fixed this... Anyway, this should be set to `objc++` to get mdpopups highlighting.