### PR TITLE
fix: inserted spaces get undone

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -249,11 +249,6 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
             if self.has_resolve_provider:
                 resolvable_completion_items = items
 
-            # if insert_best_completion was just ran, undo it before presenting new completions.
-            prev_char = self.view.substr(self.view.sel()[0].begin() - 1)
-            if prev_char.isspace():
-                self.view.run_command("undo")
-
             self.state = CompletionState.APPLYING
             self.view.run_command("hide_auto_complete")
             self.run_auto_complete()


### PR DESCRIPTION
inserted spaces get undone as mentioned at https://github.com/tomv564/LSP/pull/180#issuecomment-338468746

remove these two lines because the bug #152 seems to be fixed even without
undoing the previous insertion.