### PR TITLE
add julia language server

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -123,6 +123,14 @@
       "syntaxes": ["Packages/Java/Java.sublime-syntax"],
       "languageId": "java"
     },
+    "julials":
+    {
+      "command": ["bash", "PATH_TO_JULIA_SERVER/LanguageServer/contrib/languageserver.sh"],
+      "languageId": "julia",
+      "scopes": ["source.julia"],
+      "syntaxes": ["Packages/Julia/Julia.sublime-syntax"],
+      "settings": {"runlinter": true}
+    }
   },
 
   // Show activity messages in the status bar for a few seconds.


### PR DESCRIPTION
only works on unix/mac though.

PC users may use (untested)

```
"command": ["julia", "--startup-file=no", "--history-file=no", "-e", "using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, false); run(server);"]
```