### PR TITLE
is_in_workspace to check for member in all project folders

### DIFF
--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -29,6 +29,25 @@ def get_project_path(window: sublime.Window) -> 'Optional[str]':
             return None
 
 
+def get_project_folders(window: sublime.Window) -> 'List[str]':
+    """
+    Returns a list of all the open folders in a window
+    """
+    if len(window.folders):
+        return window.folders()
+    else:
+        filename = window.active_view().file_name()
+        if filename:
+            project_path = os.path.dirname(filename)
+            debug("Couldn't determine project directory since no folders are open!",
+                  "Using", project_path, "as a fallback.")
+            return project_path
+        else:
+            debug("Couldn't determine project directory since no folders are open",
+                  "and the current file isn't saved on the disk.")
+            return None
+
+
 def get_common_parent(paths: 'List[str]') -> str:
     """
     Get the common parent directory of multiple paths.
@@ -40,12 +59,12 @@ def get_common_parent(paths: 'List[str]') -> str:
 
 
 def is_in_workspace(window: sublime.Window, file_path: str) -> bool:
-    workspace_path = get_project_path(window)
-    if workspace_path is None:
-        return False
+    workspace_paths = get_project_folders(window)
+    for workspace_path in workspace_paths:
+        common_dir = get_common_parent([workspace_path, file_path])
+        return workspace_path == common_dir
 
-    common_dir = get_common_parent([workspace_path, file_path])
-    return workspace_path == common_dir
+    return False
 
 
 def enable_in_project(window, config_name: str) -> None:


### PR DESCRIPTION
This should allow diagnostics to be run for files that are not in the primary
project folder. I have not made the effort to adapt other parts of the plugin
that should take into account multiple project folders