### PR TITLE
Handle 'null' result in JSON RPC

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -157,9 +157,8 @@ class Client(object):
 
     def response_handler(self, response):
         handler_id = int(response.get("id"))  # dotty sends strings back :(
-        error = response.get('error', None)
-        result = response.get('result', None)
-        if result is not None:
+        if 'result' in response and 'error' not in response:
+            result = response['result']
             if settings.log_payloads:
                 debug('     ' + str(result))
 
@@ -167,7 +166,8 @@ class Client(object):
                 self._response_handlers[handler_id](result)
             else:
                 debug("No handler found for id" + response.get("id"))
-        elif error:
+        elif 'error' in response and 'result' not in response:
+            error = response.get('result')
             if settings.log_payloads:
                 debug('     ' + str(error))
             if handler_id in self._error_handlers:
@@ -175,7 +175,7 @@ class Client(object):
             else:
                 sublime.status_message(error.get('message'))
         else:
-            debug('incomplete response payload', response)
+            debug('invalid response payload', response)
 
     def on_request(self, request_method: str, handler: 'Callable'):
         self._request_handlers[request_method] = handler


### PR DESCRIPTION
A few methods in the Language Server Protocol can return `null`.
The Python library maps the JSON value `null` to `None`. So far,
rpc.py was unable to distinguish between `{result: null}` and a missing
result field. It reported both of them as protocol violation.

Due to this, it was not possible to restart the python-language-server
cleanly. Trying to execute `Restart Servers` always resulted in an
`incomplete response payload` error since the `shutdown` request always
returns `null`.

This commit adapts rpc.py so that it accepts `{result: null}`. In case
both `result` and a non-empty `error` are received, we treat that as an
error response.

Also, a response of the form of `{result: null, error: {code: 123,
message: "error"}}` is treated as invalid. According to the JSON-RPC spec,
it is invalid.

----

Tested with the python-language-server. With this change, `restart servers` runs smoothly