### PR TITLE
Treat a capability announced as `False` as unsupported

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -43,7 +43,7 @@ class Client(object):
         return self.project_path
 
     def has_capability(self, capability):
-        return capability in self.capabilities
+        return capability in self.capabilities and self.capabilities[capability] is not False
 
     def get_capability(self, capability):
         return self.capabilities.get(capability)


### PR DESCRIPTION
So far, the presence of a capability's key in ServerCapabilities was treated as if the server supported that capability.
E.g., `{"codeActionProvider": false}` was interpreted as if the server supported code actions.

While not clearly stated in the LSP spec, the intent of such a `false` capability is rather to explicitly state that the server does *not* support the capability.

I was running into this while experimenting with my own dummy language server implementation