### PR TITLE
Add polymer-ide to the default_clients list in settings.

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -147,7 +147,7 @@
         "Packages/JavaScript/JavaScript.sublime-syntax",
         "Packages/JavaScript/JSON.sublime-syntax"
       ],
-      "languageId": "polymer",
+      "languageId": "javascript",
       "settings": {
         "polymer-ide": {
           "analyzeWholePackage": false,

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -139,7 +139,8 @@
         "text.html",
         "source.html",
         "source.js",
-        "source.css"
+        "source.css",
+        "source.json"
       ],
       "syntaxes": [
         "Packages/HTML/HTML.sublime-syntax",

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -130,6 +130,30 @@
       "scopes": ["source.julia"],
       "syntaxes": ["Packages/Julia/Julia.sublime-syntax"],
       "settings": {"runlinter": true}
+    },
+    "polymer-ide":
+    {
+      "command": ["polymer-editor-service"],
+      "scopes": [
+        "text.html.basic",
+        "text.html",
+        "source.html",
+        "source.js",
+        "source.css"
+      ],
+      "syntaxes": [
+        "Packages/HTML/HTML.sublime-syntax",
+        "Packages/CSS/CSS.sublime-syntax",
+        "Packages/JavaScript/JavaScript.sublime-syntax",
+        "Packages/JavaScript/JSON.sublime-syntax"
+      ],
+      "languageId": "polymer",
+      "settings": {
+        "polymer-ide": {
+          "analyzeWholePackage": false,
+          "fixOnSave": false
+        }
+      }
     }
   },
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -223,7 +223,7 @@ Client configuration:
 
 ### Polymer<a name="polymer"></a>
 
-    npm i -g polymer-editor-server
+    npm install -g polymer-editor-service
 
 > Note: requires an up to date version of NodeJS. v6 is the minimum supported
   version as of 2017.

--- a/docs/index.md
+++ b/docs/index.md
@@ -220,6 +220,25 @@ Client configuration:
 },
 ```
 
+
+### Polymer<a name="polymer"></a>
+
+    npm i -g polymer-editor-server
+
+> Note: requires an up to date version of NodeJS. v6 is the minimum supported
+  version as of 2017.
+
+Features:
+
+ * typeahead completions for elements, attributes, and css custom properties
+ * typeahead completions for elements, attributes, and css custom properties
+ * documentation on hover for elements and attributes
+ * jump to definition for elements, attributes, and css custom properties
+ * linting, configured through `polymer.json` at your workspace root.
+
+More info: https://github.com/Polymer/polymer-editor-service
+
+
 ### Other<a name="other"></a>
 
 Please create issues / pull requests so we can get support for more languages.


### PR DESCRIPTION
I tested it locally, the enable server command that then sets up configuration for the user is quite nice.

`npm i -g polymer-editor-service` is the prerequisite command if you'd like to test it out.

This HTML should produce an error diagnostic on the url:

```html
<link rel="import" href="./does-not-exist.html">
```
