### PR TITLE
Add "vscode" style signature help popup

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -180,6 +180,13 @@
   // Valid values are "underline" or "box"
   "diagnostics_highlight_style": "underline",
 
+  // Signature help style.
+  // Valid values are "sublime" or "vscode".
+  //
+  // - "sublime": Uses mdpopups faithfully.
+  // - "vscode": Tries to imitate VSCode.
+  "signature_help_style": "vscode",
+
   // Highlighting style of "highlights": accentuating nearby text entities that
   // are related to the one under your cursor.
   // Valid values are "underline", "stippled" or "squiggly".

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -180,12 +180,9 @@
   // Valid values are "underline" or "box"
   "diagnostics_highlight_style": "underline",
 
-  // Signature help style.
-  // Valid values are "sublime" or "vscode".
-  //
-  // - "sublime": Uses mdpopups faithfully.
-  // - "vscode": Tries to imitate VSCode.
-  "signature_help_style": "vscode",
+  // If true, highlight the active parameter of the currently active signature.
+  // Note that this disables mdpopups highlighting.
+  "highlight_active_signature_parameter": true,
 
   // Highlighting style of "highlights": accentuating nearby text entities that
   // are related to the one under your cursor.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@
 * `show_diagnostics_phantoms` `false` *show diagnostics as phantoms while the file has no changes*
 * `show_diagnostics_in_view_status` `true` *when on a diagnostic with the cursor, show the text in the status bar*
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics, `"underline"` or `"box"`*
+* `highlight_active_signature_parameter`: *highlight the active parameter of the currently active signature*
 * `diagnostics_gutter_marker` `"dot"` *gutter marker for code diagnostics: "dot", "circle", "bookmark", "cross" or ""*
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `true` *show server/logMessage notifications from language servers in the console*

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -43,6 +43,7 @@ class Settings(object):
         self.show_diagnostics_in_view_status = True
         self.only_show_lsp_completions = False
         self.diagnostics_highlight_style = "underline"
+        self.signature_help_style = "sublime"
         self.document_highlight_style = "stippled"
         self.document_highlight_scopes = {
             "unknown": "text",
@@ -66,6 +67,7 @@ class Settings(object):
         self.show_diagnostics_phantoms = read_bool_setting(settings_obj, "show_diagnostics_phantoms", False)
         self.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
         self.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
+        self.signature_help_style = read_str_setting(settings_obj, "signature_help_style", "sublime")
         self.document_highlight_style = read_str_setting(settings_obj, "document_highlight_style", "stippled")
         self.document_highlight_scopes = read_dict_setting(settings_obj, "document_highlight_scopes",
                                                            self.document_highlight_scopes)

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -43,7 +43,7 @@ class Settings(object):
         self.show_diagnostics_in_view_status = True
         self.only_show_lsp_completions = False
         self.diagnostics_highlight_style = "underline"
-        self.signature_help_style = "sublime"
+        self.highlight_active_signature_parameter = True
         self.document_highlight_style = "stippled"
         self.document_highlight_scopes = {
             "unknown": "text",
@@ -67,7 +67,8 @@ class Settings(object):
         self.show_diagnostics_phantoms = read_bool_setting(settings_obj, "show_diagnostics_phantoms", False)
         self.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
         self.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
-        self.signature_help_style = read_str_setting(settings_obj, "signature_help_style", "sublime")
+        self.highlight_active_signature_parameter = read_bool_setting(settings_obj,
+                                                                      "highlight_active_signature_parameter", True)
         self.document_highlight_style = read_str_setting(settings_obj, "document_highlight_style", "stippled")
         self.document_highlight_scopes = read_dict_setting(settings_obj, "document_highlight_scopes",
                                                            self.document_highlight_scopes)

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -223,12 +223,12 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
 
     def _replace_active_parameter(self, signature: str, parameter: str) -> str:
         if parameter[0].isalnum() and parameter[-1].isalnum():
-            pattern = r'\b{}\b'.format(parameter)
+            pattern = r'\b{}\b'.format(re.escape(parameter))
         else:
             # If the left or right boundary of the parameter string is not an alphanumeric character, the \b check will
             # never match. In this case, it's probably safe to assume the parameter string itself will be a good pattern
             # to search for.
-            pattern = parameter
+            pattern = re.escape(parameter)
         replacement = '<span style="font-weight: bold; text-decoration: underline">{}</span>'.format(parameter)
         # FIXME: This is somewhat language-specific to look for an opening parenthesis. Most languages use parentheses
         # for their parameter lists though.

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -159,14 +159,16 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
     def _on_hover_navigate(self, href):
         webbrowser.open_new_tab(href)
 
+    def _build_informational_header(self) -> str:
+        return "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
+            str(self._active_signature + 1), str(len(self._signatures)))
+
     def _build_popup_content_style_sublime(self) -> str:
         signature = self._signatures[self._active_signature]
         formatted = []
 
         if len(self._signatures) > 1:
-            signature_navigation = "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
-                str(self._active_signature + 1), str(len(self._signatures)))
-            formatted.append(signature_navigation)
+            formatted.append(self._build_informational_header())
 
         signature_label = signature.get('label')
         if len(signature_label) > 400:
@@ -208,9 +210,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         formatted = []
 
         if len(self._signatures) > 1:
-            signature_navigation = "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
-                str(self._active_signature + 1), str(len(self._signatures)))
-            formatted.append(signature_navigation)
+            formatted.append(self._build_informational_header())
 
         # Write the active signature and give special treatment to the active parameter (if found).
         # Note that this <div> class and the extra <pre> are copied from mdpopups' HTML output. When mdpopups changes

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -153,7 +153,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
     def _on_hover_navigate(self, href):
         webbrowser.open_new_tab(href)
 
-    def _build_informational_header(self) -> str:
+    def _build_overload_selector(self) -> str:
         return "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
             str(self._active_signature + 1), str(len(self._signatures)))
 
@@ -162,7 +162,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         formatted = []
 
         if len(self._signatures) > 1:
-            formatted.append(self._build_informational_header())
+            formatted.append(self._build_overload_selector())
 
         signature_label = signature.get('label')
         if len(signature_label) > 400:
@@ -204,7 +204,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         formatted = []
 
         if len(self._signatures) > 1:
-            formatted.append(self._build_informational_header())
+            formatted.append(self._build_overload_selector())
 
         # Write the active signature and give special treatment to the active parameter (if found).
         # Note that this <div> class and the extra <pre> are copied from mdpopups' HTML output. When mdpopups changes

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -147,7 +147,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
             self._visible = False
 
     def _build_popup_content(self) -> str:
-        if settings.signature_help_style == "vscode":
+        if settings.highlight_active_signature_parameter:
             return self._build_popup_content_style_vscode()
         else:
             # Default to "sublime".

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -139,12 +139,6 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                               css=popup_css,
                               md=True,
                               wrapper_class=popup_class)
-        self._visible = True
-
-    def _hide_popup(self) -> None:
-        if self._visible:
-            self.view.hide_popup()
-            self._visible = False
 
     def _build_popup_content(self) -> str:
         if settings.highlight_active_signature_parameter:

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -240,7 +240,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         replacement = '<span style="font-weight: bold; text-decoration: underline">{}</span>'.format(parameter)
         # FIXME: This is somewhat language-specific to look for an opening parenthesis. Most languages use parentheses
         # for their parameter lists though.
-        index = signature.find('(')
+        start_of_param_list_pos = signature.find('(')
         # Note that this works even when we don't find an opening parenthesis, because .find returns -1 in that case.
-        string = signature[index + 1:]
-        return signature[:index + 1] + re.sub(pattern, replacement, string, 1)
+        start_of_param_list = signature[start_of_param_list_pos + 1:]
+        return signature[:start_of_param_list_pos + 1] + re.sub(pattern, replacement, start_of_param_list, 1)

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -185,10 +185,8 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
 
     def _build_popup_content_style_vscode(self) -> str:
         # Fetch all the relevant data.
-        signature = {}  # type: Dict[str, Any]
         signature_label = ""
         signature_documentation = ""
-        parameter = {}  # type: Dict[str, Any]
         parameter_label = ""
         parameter_documentation = ""
         if self._active_signature in range(0, len(self._signatures)):


### PR DESCRIPTION
- Can switch between "sublime" style and "vscode" style in the LSP preferences.
- Tried to keep both style as similar as possible. I think only the top label is now different.

Related: https://github.com/tomv564/LSP/issues/231