### PR TITLE
TCP support

### DIFF
--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -170,10 +170,24 @@ def unload_old_clients(window: sublime.Window):
         unload_client(client, window.id(), config_name)
 
 
+clients_unloaded_handler = None  # type: Optional[Callable]
+
+
+def register_clients_unloaded_handler(handler: 'Callable'):
+    global clients_unloaded_handler
+    clients_unloaded_handler = handler
+
+
 def on_shutdown(client: Client, window_id: int, config_name: str, response):
     try:
         client.exit()
         del clients_by_window[window_id][config_name]
+
+        if not clients_by_window[window_id]:
+            debug("all clients unloaded")
+            if clients_unloaded_handler:
+                clients_unloaded_handler(window_id)
+
     except Exception as err:
         exception_log("Error exiting server", err)
 

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -2,7 +2,7 @@ import sublime
 
 from .logging import debug, exception_log
 from .configurations import config_for_scope
-from .protocol import Notification, Request
+from .protocol import Request
 from .workspace import get_project_path
 
 # typing only
@@ -12,35 +12,81 @@ assert Client and ClientConfig
 
 
 try:
-    from typing import Any, List, Dict, Tuple, Callable, Optional
-    assert Any and List and Dict and Tuple and Callable and Optional
+    from typing import Any, List, Dict, Tuple, Callable, Optional, Set
+    assert Any and List and Dict and Tuple and Callable and Optional and Set
 except ImportError:
     pass
 
 
-clients_by_window = {}  # type: Dict[int, Dict[str, Client]]
+class ClientStates(object):
+    STARTING = 0
+    READY = 1
+    STOPPING = 2
 
 
-def window_clients(window: sublime.Window) -> 'Dict[str, Client]':
+class ConfigState(object):
+
+    def __init__(self, state=ClientStates.STARTING, client=None):
+        self.state = state
+        self.client = client
+
+
+clients_by_window = {}  # type: Dict[int, Dict[str, ConfigState]]
+
+
+def window_configs(window: sublime.Window) -> 'Dict[str, ConfigState]':
     if window.id() in clients_by_window:
         return clients_by_window[window.id()]
     else:
-        # debug("no clients found for window", window.id())
+        # debug("no configs found for window", window.id())
         return {}
 
 
-def add_window_client(window: sublime.Window, config_name: str, client: 'Client'):
-    global clients_by_window
-    clients_by_window.setdefault(window.id(), {})[config_name] = client
+def is_ready_window_config(window: sublime.Window, config_name: str):
+    configs = window_configs(window)
+
+    if config_name not in configs:
+        return False
+
+    if configs[config_name].state == ClientStates.READY:
+        return True
+
+    return False
+
+
+# Startup
+
+def can_start_config(window: sublime.Window, config_name: str):
+    return config_name not in window_configs(window)
+
+
+def set_config_starting(window: sublime.Window, config_name: str):
+    clients_by_window.setdefault(window.id(), {})[config_name] = ConfigState()
+
+
+def clear_config_state(window: sublime.Window, config_name: str):
+    configs = window_configs(window)
+    del configs[config_name]
+
+
+def set_config_ready(window: sublime.Window, config_name: str, client: 'Client'):
+    window_configs(window)[config_name] = ConfigState(ClientStates.READY, client)
     debug("{} client registered for window {}".format(config_name, window.id()))
 
 
-def remove_window_client(window: sublime.Window, config_name: str):
-    del clients_by_window[window.id()][config_name]
+def set_config_stopping(window: sublime.Window, config_name: str):
+    window_configs(window)[config_name].state = ClientStates.STOPPING
+
+
+def client_for_closed_view(view: sublime.View) -> 'Optional[Client]':
+    return _client_for_view_and_window(view, sublime.active_window())
 
 
 def client_for_view(view: sublime.View) -> 'Optional[Client]':
-    window = view.window()
+    return _client_for_view_and_window(view, view.window())
+
+
+def _client_for_view_and_window(view: sublime.View, window: 'Optional[sublime.Window]') -> 'Optional[Client]':
     if not window:
         debug("no window for view", view.file_name())
         return None
@@ -50,64 +96,87 @@ def client_for_view(view: sublime.View) -> 'Optional[Client]':
         debug("config not available for view", view.file_name())
         return None
 
-    clients = window_clients(window)
-    if config.name not in clients:
+    window_config_states = window_configs(window)
+    if config.name not in window_config_states:
         debug(config.name, "not available for view",
               view.file_name(), "in window", window.id())
         return None
     else:
-        return clients[config.name]
+        config_state = window_config_states[config.name]
+        if config_state.client:
+            return config_state.client
+        else:
+            debug(config.name, "in state", config_state.state, " for view",
+                  view.file_name(), "in window", window.id())
+            return None
+
+
+# Shutdown
+
+def remove_window_client(window: sublime.Window, config_name: str):
+    del clients_by_window[window.id()][config_name]
 
 
 def unload_all_clients():
     for window in sublime.windows():
-        for client in window_clients(window).values():
-            unload_client(client)
+        for config_name, config_state in window_configs(window).items():
+            if config_state.client:
+                if config_state.state == ClientStates.STARTING:
+                    unload_client(config_state.client, window.id(), config_name)
+                else:
+                    debug('ignoring unload of config in state', config_state.state)
+            else:
+                debug('ignoring unload of config without client')
+
+
+closing_window_ids = set()  # type: Set[int]
 
 
 def check_window_unloaded():
     global clients_by_window
     open_window_ids = list(window.id() for window in sublime.windows())
     iterable_clients_by_window = clients_by_window.copy()
-    closed_windows = []
     for id, window_clients in iterable_clients_by_window.items():
-        if id not in open_window_ids:
-            debug("window closed", id)
-            closed_windows.append(id)
-    for closed_window_id in closed_windows:
+        if id not in open_window_ids and window_clients:
+            if id not in closing_window_ids:
+                closing_window_ids.add(id)
+                debug("window closed", id)
+    for closed_window_id in closing_window_ids:
         unload_window_clients(closed_window_id)
+    closing_window_ids.clear()
 
 
 def unload_window_clients(window_id: int):
-    global clients_by_window
     if window_id in clients_by_window:
-        window_clients = clients_by_window[window_id]
-        del clients_by_window[window_id]
-        for config, client in window_clients.items():
-            debug("unloading client", config, client)
-            unload_client(client)
+        window_configs = clients_by_window[window_id]
+        for config_name, state in window_configs.items():
+            window_configs[config_name].state = ClientStates.STOPPING
+            debug("unloading client", config_name, state.client)
+            unload_client(state.client, window_id, config_name)
 
 
 def unload_old_clients(window: sublime.Window):
     project_path = get_project_path(window)
-    clients_by_config = window_clients(window)
+    configs = window_configs(window)
     clients_to_unload = {}
-    for config_name, client in clients_by_config.items():
-        if client and client.get_project_path() != project_path:
-            debug('unload', config_name, 'project path changed from', client.get_project_path(), 'to', project_path)
-            clients_to_unload[config_name] = client
+    for config_name, state in configs.items():
+        if state.client and state.state == ClientStates.READY and state.client.get_project_path() != project_path:
+            debug('unload', config_name, 'project path changed from',
+                  state.client.get_project_path(), 'to', project_path)
+            clients_to_unload[config_name] = state.client
 
     for config_name, client in clients_to_unload.items():
-        del clients_by_config[config_name]
-        unload_client(client)
+        set_config_stopping(window, config_name)
+        unload_client(client, window.id(), config_name)
 
 
-def on_shutdown(client: Client, response):
+def on_shutdown(client: Client, window_id: int, config_name: str, response):
     try:
-        client.send_notification(Notification.exit())
+        client.exit()
+        del clients_by_window[window_id][config_name]
     except Exception as err:
         exception_log("Error exiting server", err)
 
 
-def unload_client(client: Client):
-    client.send_request(Request.shutdown(), lambda response: on_shutdown(client, response))
+def unload_client(client: Client, window_id: int, config_name: str):
+    client.send_request(Request.shutdown(), lambda response: on_shutdown(client, window_id, config_name, response))

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -84,6 +84,7 @@ def apply_window_settings(client_config: 'ClientConfig', view: 'sublime.View') -
             return ClientConfig(
                 client_config.name,
                 overrides.get("command", client_config.binary_args),
+                overrides.get("tcp_port", client_config.tcp_port),
                 overrides.get("scopes", client_config.scopes),
                 overrides.get("syntaxes", client_config.syntaxes),
                 overrides.get("languageId", client_config.languageId),

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -14,7 +14,7 @@ from .protocol import Notification, Point
 from .settings import settings
 from .url import filename_to_uri
 from .configurations import config_for_scope, is_supported_view, is_supported_syntax, is_supportable_syntax
-from .clients import client_for_view, window_clients, check_window_unloaded
+from .clients import client_for_view, client_for_closed_view, check_window_unloaded
 from .events import Events
 
 SUBLIME_WORD_MASK = 515
@@ -150,10 +150,8 @@ def notify_did_close(view: sublime.View):
     if window and file_name:
         if has_document_state(window, file_name):
             clear_document_state(window, file_name)
-            config = config_for_scope(view)
-            clients = window_clients(sublime.active_window())
-            if config and config.name in clients:
-                client = clients[config.name]
+            client = client_for_closed_view(view)
+            if client:
                 params = {"textDocument": {"uri": filename_to_uri(file_name)}}
                 client.send_notification(Notification.didClose(params))
 

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -18,7 +18,7 @@ from .settings import (
     ClientConfig, settings, load_settings, unload_settings
 )
 from .logging import debug, exception_log, server_log
-from .rpc import Client, attach_tcp_client
+from .rpc import attach_tcp_client, attach_stdio_client
 from .workspace import get_project_path
 from .configurations import (
     config_for_scope, is_supported_view
@@ -216,7 +216,11 @@ def start_client(window: sublime.Window, config: ClientConfig):
     if config.tcp_port is not None:
         client = attach_tcp_client(config.tcp_port, process, project_path)
     else:
-        client = Client(process, project_path)
+        client = attach_stdio_client(process, project_path)
+
+    if not client:
+        window.status_message("Could not connect to " + config.name + ", disabling")
+        return None
 
     client.set_crash_handler(lambda: handle_server_crash(window, config))
 

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -34,14 +34,20 @@ def attach_tcp_client(tcp_port, process, project_path):
     debug('connecting to {}:{}'.format(host, tcp_port))
     while time.time() - start_time < TCP_CONNECT_TIMEOUT:
         try:
-            sock = socket.create_connection((host, tcp_port), timeout=5000)
+            sock = socket.create_connection((host, tcp_port))
+            # sock.settimeout(5)
             transport = TCPTransport(sock)
-            return TransportClient(process, transport, project_path)
+            return Client(process, transport, project_path)
         except ConnectionRefusedError as e:
             pass
 
     process.kill()
     raise Exception("Timeout connecting to socket")
+
+
+def attach_stdio_client(process, project_path):
+    transport = StdioTransport(process)
+    return Client(process, transport, project_path)
 
 
 class Transport(object,  metaclass=ABCMeta):
@@ -72,20 +78,29 @@ class TCPTransport(Transport):
         self.read_thread = threading.Thread(target=self.read_socket)
         self.read_thread.start()
 
+    def close(self):
+        self.socket = None
+        self.on_closed()
+
     def read_socket(self):
         remaining_data = b""
         is_incomplete = False
         read_state = STATE_HEADERS
         content_length = 0
         while self.socket:
+            debug('socket recv')
             is_incomplete = False
             try:
                 received_data = self.socket.recv(4096)
             except Exception as err:
                 exception_log("Failure reading from socket", err)
-                self.socket = None
-                self.on_closed()
-                return
+                self.close()
+                break
+
+            if not received_data:
+                debug("no data received, closing")
+                self.close()
+                break
 
             debug("got data:" + received_data.decode("UTF-8"))
             if len(remaining_data) > 0:
@@ -94,6 +109,7 @@ class TCPTransport(Transport):
             remaining_data = b""
 
             while len(data) > 0 and not is_incomplete:
+                debug('looping through data', data.decode("UTF-8"))
                 # read headers until double newline or incomplete
                 if read_state == STATE_HEADERS:
                     headers, _sep, rest = data.partition(b"\r\n\r\n")
@@ -126,6 +142,7 @@ class TCPTransport(Transport):
     def send(self, message):
         try:
             if self.socket:
+                debug('socket send')
                 self.socket.sendall(bytes(message, 'UTF-8'))
         except Exception as err:
             exception_log("Failure writing to socket", err)
@@ -144,6 +161,10 @@ class StdioTransport(Transport):
         self.stdout_thread.start()
         # self.stderr_thread = threading.Thread(target=self.read_stderr)
         # self.stderr_thread.start()
+
+    def close(self):
+        self.process = None
+        self.on_closed()
 
     def read_stdout(self):
         """
@@ -167,36 +188,14 @@ class StdioTransport(Transport):
                         content_length = int(header[len(ContentLengthHeader):])
 
                 if (content_length > 0):
-                    content = self.process.stdout.read(content_length).decode(
-                        "UTF-8")
+                    content = self.process.stdout.read(content_length)
 
-                    payload = None
-                    try:
-                        payload = json.loads(content)
-                        # limit = min(len(content), 200)
-                        # debug("got json: ", content[0:limit], "...")
-                    except IOError as err:
-                        exception_log("got a non-JSON payload: " + content, err)
-                        continue
-
-                    try:
-                        if "method" in payload:
-                            if "id" in payload:
-                                self.request_handler(payload)
-                            else:
-                                self.notification_handler(payload)
-                        elif "id" in payload:
-                            self.response_handler(payload)
-                        else:
-                            debug("Unknown payload type: ", payload)
-                    except Exception as err:
-                        exception_log("Error handling server payload", err)
+                    self.on_receive(content.decode("UTF-8"))
 
             except IOError as err:
-                sublime.status_message("Failure reading LSP server response, exiting")
+                self.close()
                 exception_log("Failure reading stdout", err)
-                self.handle_server_crash()
-                return
+                break
 
         debug("LSP stdout process ended.")
 
@@ -229,21 +228,12 @@ class StdioTransport(Transport):
             try:
                 self.process.stdin.write(bytes(message, 'UTF-8'))
                 self.process.stdin.flush()
-            except BrokenPipeError as err:
-                sublime.status_message("Failure sending LSP server message, exiting")
-                exception_log("Failure writing payload", err)
-                self.handle_server_crash()
-
-        try:
-            if self.socket:
-                self.socket.sendall(bytes(message, 'UTF-8'))
-        except Exception as err:
-            exception_log("Failure writing to socket", err)
-            self.socket = None
-            self.on_closed()
+            except (BrokenPipeError, OSError) as err:
+                exception_log("Failure writing to stdout", err)
+                self.close()
 
 
-class TransportClient(object):
+class Client(object):
     def __init__(self, process, transport, project_path):
         self.process = process
         self.transport = transport
@@ -333,212 +323,9 @@ class TransportClient(object):
             exception_log("Error handling server payload", err)
 
     def on_transport_closed(self):
+        sublime.status_message("Communication to server closed, exiting")
         # TODO: how to know difference between normal exit and server crash?
         self.handle_server_crash()
-
-    def response_handler(self, response):
-        handler_id = int(response.get("id"))  # dotty sends strings back :(
-        if 'result' in response and 'error' not in response:
-            result = response['result']
-            if settings.log_payloads:
-                debug('     ' + str(result))
-            if handler_id in self._response_handlers:
-                self._response_handlers[handler_id](result)
-            else:
-                debug("No handler found for id" + response.get("id"))
-        elif 'error' in response and 'result' not in response:
-            error = response['error']
-            if settings.log_payloads:
-                debug('     ' + str(error))
-            if handler_id in self._error_handlers:
-                self._error_handlers[handler_id](error)
-            else:
-                sublime.status_message(error.get('message'))
-        else:
-            debug('invalid response payload', response)
-
-    def on_request(self, request_method: str, handler: 'Callable'):
-        self._request_handlers[request_method] = handler
-
-    def on_notification(self, notification_method: str, handler: 'Callable'):
-        self._notification_handlers[notification_method] = handler
-
-    def request_handler(self, request):
-        params = request.get("params")
-        method = request.get("method")
-        debug('<--  ' + method)
-        if settings.log_payloads and params:
-            debug('     ' + str(params))
-        if method in self._request_handlers:
-            try:
-                self._request_handlers[method](params)
-            except Exception as err:
-                exception_log("Error handling request " + method, err)
-        else:
-            debug("Unhandled request", method)
-
-    def notification_handler(self, notification):
-        method = notification.get("method")
-        params = notification.get("params")
-        if method != "window/logMessage":
-            debug('<--  ' + method)
-            if settings.log_payloads and params:
-                debug('     ' + str(params))
-        if method in self._notification_handlers:
-            try:
-                self._notification_handlers[method](params)
-            except Exception as err:
-                exception_log("Error handling notification " + method, err)
-        else:
-            debug("Unhandled notification:", method)
-
-
-class Client(object):
-    def __init__(self, process, project_path):
-        self.process = process
-        self.stdout_thread = threading.Thread(target=self.read_stdout)
-        self.stdout_thread.start()
-        self.stderr_thread = threading.Thread(target=self.read_stderr)
-        self.stderr_thread.start()
-        self.project_path = project_path
-        self.request_id = 0
-        self._response_handlers = {}  # type: Dict[int, Callable]
-        self._error_handlers = {}  # type: Dict[int, Callable]
-        self._request_handlers = {}  # type: Dict[str, Callable]
-        self._notification_handlers = {}  # type: Dict[str, Callable]
-        self.capabilities = {}  # type: Dict[str, Any]
-        self._crash_handler = None  # type: Optional[Callable]
-
-    def set_capabilities(self, capabilities):
-        self.capabilities = capabilities
-
-    def get_project_path(self):
-        return self.project_path
-
-    def has_capability(self, capability):
-        return capability in self.capabilities and self.capabilities[capability] is not False
-
-    def get_capability(self, capability):
-        return self.capabilities.get(capability)
-
-    def send_request(self, request: Request, handler: 'Callable', error_handler: 'Optional[Callable]' = None):
-        self.request_id += 1
-        debug(' --> ' + request.method)
-        if handler is not None:
-            self._response_handlers[self.request_id] = handler
-        if error_handler is not None:
-            self._error_handlers[self.request_id] = error_handler
-        self.send_payload(request.to_payload(self.request_id))
-
-    def send_notification(self, notification: Notification):
-        debug(' --> ' + notification.method)
-        self.send_payload(notification.to_payload())
-
-    def kill(self):
-        self.process.kill()
-        self.process = None
-
-    def set_crash_handler(self, handler: 'Callable'):
-        self._crash_handler = handler
-
-    def handle_server_crash(self):
-        if self.process:
-            try:
-                self.process.terminate()
-            except ProcessLookupError:
-                pass  # process can be terminated already
-            self.process = None
-            self._crash_handler()
-
-    def send_payload(self, payload):
-        if self.process:
-            try:
-                message = format_request(payload)
-                self.process.stdin.write(bytes(message, 'UTF-8'))
-                self.process.stdin.flush()
-            except (BrokenPipeError, OSError) as err:
-                sublime.status_message("Failure sending LSP server message, exiting")
-                exception_log("Failure writing payload", err)
-                self.handle_server_crash()
-
-    def read_stdout(self):
-        """
-        Reads JSON responses from process and dispatch them to response_handler
-        """
-        ContentLengthHeader = b"Content-Length: "
-
-        running = True
-        while running:
-            running = self.process.poll() is None
-
-            try:
-                content_length = 0
-                while self.process:
-                    header = self.process.stdout.readline()
-                    if header:
-                        header = header.strip()
-                    if not header:
-                        break
-                    if header.startswith(ContentLengthHeader):
-                        content_length = int(header[len(ContentLengthHeader):])
-
-                if (content_length > 0):
-                    content = self.process.stdout.read(content_length).decode(
-                        "UTF-8")
-
-                    payload = None
-                    try:
-                        payload = json.loads(content)
-                        # limit = min(len(content), 200)
-                        # debug("got json: ", content[0:limit], "...")
-                    except IOError as err:
-                        exception_log("got a non-JSON payload: " + content, err)
-                        continue
-
-                    try:
-                        if "method" in payload:
-                            if "id" in payload:
-                                self.request_handler(payload)
-                            else:
-                                self.notification_handler(payload)
-                        elif "id" in payload:
-                            self.response_handler(payload)
-                        else:
-                            debug("Unknown payload type: ", payload)
-                    except Exception as err:
-                        exception_log("Error handling server payload", err)
-
-            except IOError as err:
-                sublime.status_message("Failure reading LSP server response, exiting")
-                exception_log("Failure reading stdout", err)
-                self.handle_server_crash()
-                return
-
-        debug("LSP stdout process ended.")
-
-    def read_stderr(self):
-        """
-        Reads any errors from the LSP process.
-        """
-        running = True
-        while running:
-            running = self.process.poll() is None
-
-            try:
-                content = self.process.stderr.readline()
-                if not content:
-                    break
-                if settings.log_stderr:
-                    try:
-                        decoded = content.decode("UTF-8")
-                    except UnicodeDecodeError:
-                        decoded = content
-                    server_log(decoded.strip())
-            except IOError as err:
-                exception_log("Failure reading stderr", err)
-                return
-
-        debug("LSP stderr process ended.")
 
     def response_handler(self, response):
         handler_id = int(response.get("id"))  # dotty sends strings back :(

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -1,6 +1,7 @@
 import json
 import sublime
 import threading
+import socket
 
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional
@@ -19,6 +20,195 @@ def format_request(payload: 'Dict[str, Any]'):
     content_length = len(content)
     result = "Content-Length: {}\r\n\r\n{}".format(content_length, content)
     return result
+
+
+def attach_tcp_client(tcp_port, process, project_path):
+    host = "localhost"
+    debug('connecting to {}:{}'.format(host, tcp_port))
+    sock = socket.create_connection((host, tcp_port), timeout=5000)
+    return TCPClient(sock, process, project_path)
+
+
+class TCPClient(object):
+    def __init__(self, sock, process, project_path):
+        self.process = process
+        self.sock = sock
+        self.read_thread = threading.Thread(target=self.read_socket)
+        self.read_thread.start()
+        self.project_path = project_path
+        self.request_id = 0
+        self._response_handlers = {}  # type: Dict[int, Callable]
+        self._error_handlers = {}  # type: Dict[int, Callable]
+        self._request_handlers = {}  # type: Dict[str, Callable]
+        self._notification_handlers = {}  # type: Dict[str, Callable]
+        self.capabilities = {}  # type: Dict[str, Any]
+        self._crash_handler = None  # type: Optional[Callable]
+
+    def set_capabilities(self, capabilities):
+        self.capabilities = capabilities
+
+    def get_project_path(self):
+        return self.project_path
+
+    def has_capability(self, capability):
+        return capability in self.capabilities and self.capabilities[capability] is not False
+
+    def get_capability(self, capability):
+        return self.capabilities.get(capability)
+
+    def send_request(self, request: Request, handler: 'Callable', error_handler: 'Optional[Callable]' = None):
+        self.request_id += 1
+        debug(' --> ' + request.method)
+        if handler is not None:
+            self._response_handlers[self.request_id] = handler
+        if error_handler is not None:
+            self._error_handlers[self.request_id] = error_handler
+        self.send_payload(request.to_payload(self.request_id))
+
+    def send_notification(self, notification: Notification):
+        debug(' --> ' + notification.method)
+        self.send_payload(notification.to_payload())
+
+    def kill(self):
+        self.process.kill()
+        self.process = None
+
+    def set_crash_handler(self, handler: 'Callable'):
+        self._crash_handler = handler
+
+    def handle_server_crash(self):
+        if self.process:
+            try:
+                self.process.terminate()
+            except ProcessLookupError:
+                pass  # process can be terminated already
+            self.process = None
+            self._crash_handler()
+
+    def send_payload(self, payload):
+        if self.sock:
+            try:
+                message = format_request(payload)
+                self.sock.sendall(bytes(message, 'UTF-8'))
+                # self.process.stdin.write(bytes(message, 'UTF-8'))
+                # self.process.stdin.flush()
+            except BrokenPipeError as err:
+                sublime.status_message("Failure sending LSP server message, exiting")
+                exception_log("Failure writing payload", err)
+                self.handle_server_crash()
+
+    def read_socket(self):
+        """
+        Reads JSON responses from process and dispatch them to response_handler
+        """
+        ContentLengthHeader = b"Content-Length: "
+
+        running = True
+        while running:
+
+            try:
+                content_length = 0
+                while self.sock:
+                    data = self.sock.recv(4096)
+                    # debug("got data:" + data.decode("UTF-8"))
+                    headers, content = data.split(b"\r\n\r\n")
+                    header_lines = headers.split(b"\r\n")
+                    for header in header_lines:
+                        if header.startswith(ContentLengthHeader):
+                            header_value = header[len(ContentLengthHeader):]
+                            content_length = int(header_value)
+
+                    content = content.decode("UTF-8")
+
+                    while len(content) < content_length:
+                        data = self.sock.recv(4096)
+                        content = content + data.decode("UTF-8")
+
+                    payload = None
+                    try:
+                        payload = json.loads(content)
+                        # limit = min(len(content), 200)
+                        # debug("got json: ", content[0:limit], "...")
+                    except IOError as err:
+                        exception_log("got a non-JSON payload: " + content, err)
+                        continue
+
+                    try:
+                        if "method" in payload:
+                            if "id" in payload:
+                                self.request_handler(payload)
+                            else:
+                                self.notification_handler(payload)
+                        elif "id" in payload:
+                            self.response_handler(payload)
+                        else:
+                            debug("Unknown payload type: ", payload)
+                    except Exception as err:
+                        exception_log("Error handling server payload", err)
+
+            except IOError as err:
+                sublime.status_message("Failure reading LSP server response, exiting")
+                exception_log("Failure reading stdout", err)
+                self.handle_server_crash()
+                return
+
+        debug("LSP stdout process ended.")
+
+    def response_handler(self, response):
+        handler_id = int(response.get("id"))  # dotty sends strings back :(
+        if 'result' in response and 'error' not in response:
+            result = response['result']
+            if settings.log_payloads:
+                debug('     ' + str(result))
+            if handler_id in self._response_handlers:
+                self._response_handlers[handler_id](result)
+            else:
+                debug("No handler found for id" + response.get("id"))
+        elif 'error' in response and 'result' not in response:
+            error = response['error']
+            if settings.log_payloads:
+                debug('     ' + str(error))
+            if handler_id in self._error_handlers:
+                self._error_handlers[handler_id](error)
+            else:
+                sublime.status_message(error.get('message'))
+        else:
+            debug('invalid response payload', response)
+
+    def on_request(self, request_method: str, handler: 'Callable'):
+        self._request_handlers[request_method] = handler
+
+    def on_notification(self, notification_method: str, handler: 'Callable'):
+        self._notification_handlers[notification_method] = handler
+
+    def request_handler(self, request):
+        params = request.get("params")
+        method = request.get("method")
+        debug('<--  ' + method)
+        if settings.log_payloads and params:
+            debug('     ' + str(params))
+        if method in self._request_handlers:
+            try:
+                self._request_handlers[method](params)
+            except Exception as err:
+                exception_log("Error handling request " + method, err)
+        else:
+            debug("Unhandled request", method)
+
+    def notification_handler(self, notification):
+        method = notification.get("method")
+        params = notification.get("params")
+        if method != "window/logMessage":
+            debug('<--  ' + method)
+            if settings.log_payloads and params:
+                debug('     ' + str(params))
+        if method in self._notification_handlers:
+            try:
+                self._notification_handlers[method](params)
+            except Exception as err:
+                exception_log("Error handling notification " + method, err)
+        else:
+            debug("Unhandled notification:", method)
 
 
 class Client(object):

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -137,10 +137,11 @@ def unload_settings():
 
 
 class ClientConfig(object):
-    def __init__(self, name, binary_args, scopes, syntaxes, languageId,
+    def __init__(self, name, binary_args, tcp_port, scopes, syntaxes, languageId,
                  enabled=True, init_options=dict(), settings=dict(), env=dict()):
         self.name = name
         self.binary_args = binary_args
+        self.tcp_port = tcp_port
         self.scopes = scopes
         self.syntaxes = syntaxes
         self.languageId = languageId
@@ -154,6 +155,7 @@ def read_client_config(name, client_config):
     return ClientConfig(
         name,
         client_config.get("command", []),
+        client_config.get("tcp_port", None),
         client_config.get("scopes", []),
         client_config.get("syntaxes", []),
         client_config.get("languageId", ""),


### PR DESCRIPTION
For PHP on Windows (#151 and #240) and easier debugging of language servers. 

To do:
- [x] Introduce _transport_ concept in Client for handling stdio
- [x] server shutdown / startup failure handling

Because TCP ports cannot be shared, some work was done tightening state and removing overlap during client restarts:
- `starting_configs_by_window` replaced by a lookup storing ClientState.STARTING/READY/STOPPING per configuration
- Clients remain in STOPPING state until exit is posted, at which point `restarting_window_ids` is checked to see if new clients should be started for the window.

Things this won't solve:
- Port selection (you'll need to solve this with per-project configuration)