### PR TITLE
Rename R settings key to prevent it overwriting Rust settings

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -156,7 +156,7 @@
         }
       }
     },
-    "rls":
+    "rlang":
     {
       "command": ["R", "--quiet", "--slave", "-e", "languageserver::run()"],
       "languageId": "r",


### PR DESCRIPTION
Fixes #264