### PR TITLE
handle empty ids

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -315,11 +315,11 @@ class Client(object):
 
         try:
             if "method" in payload:
-                if "id" in payload:
+                if "id" in payload and payload["id"] is not None:
                     self.request_handler(payload)
                 else:
                     self.notification_handler(payload)
-            elif "id" in payload:
+            elif "id" in payload and payload["id"] is not None:
                 self.response_handler(payload)
             else:
                 debug("Unknown payload type: ", payload)


### PR DESCRIPTION
Closes #277. JSON RPC 2.0 specifies that the id field in a request/response can be null. This change bring the implementation in line with the spec