### PR TITLE
The URI conversion will sometimes fail on file:// handlers.

### DIFF
--- a/plugin/core/url.py
+++ b/plugin/core/url.py
@@ -2,6 +2,7 @@ from urllib.parse import urljoin
 from urllib.parse import urlparse
 from urllib.request import pathname2url
 from urllib.request import url2pathname
+import re
 
 
 def filename_to_uri(path: str) -> str:
@@ -9,4 +10,8 @@ def filename_to_uri(path: str) -> str:
 
 
 def uri_to_filename(uri: str) -> str:
-    return url2pathname(urlparse(uri).path)
+    prog = re.compile(r'\\[a-zA-Z]:\\.+')
+    ret = url2pathname(urlparse(uri).path)
+    if prog.match(ret):
+        ret = ret[1:]
+    return ret


### PR DESCRIPTION
Sometimes, a Windows pathname will be converted incorrectly.  This is a bandaid fix on the problem.

Previously, we would have a path that started like this: \C:\Users\...

When we tossed that path into Sublime, it would not be able to find the view associated to that file.  This bandaid fix would remove the preceding \ in that pathname.

This will mainly fix issues with diagnostics.