### PR TITLE
Send parent process id in initialization params.

### DIFF
--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -212,7 +212,7 @@ def start_client(window: sublime.Window, config: ClientConfig):
     client.set_crash_handler(lambda: handle_server_crash(window, config))
 
     initializeParams = {
-        "processId": client.process.pid if client.process else None,
+        "processId": os.getpid(),
         "rootUri": filename_to_uri(project_path),
         "rootPath": project_path,
         "capabilities": {


### PR DESCRIPTION
According to the LSP specifications, the processId field in the initialization params needs to be the parent process id.  This is so the language server can shut itself down when the parent process terminates.  This will fix bugs where when you close Sublime Text, the language server would be kept running.