### PR TITLE
Allow "" for document_highlight_style in order to disable it entirely

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -200,7 +200,8 @@
 
   // Highlighting style of "highlights": accentuating nearby text entities that
   // are related to the one under your cursor.
-  // Valid values are "underline", "stippled" or "squiggly".
+  // Valid values are "underline", "stippled", "squiggly" or "".
+  // When set to the empty string (""), no document highlighting is requested.
   "document_highlight_style": "underline",
 
   "document_highlight_scopes": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,8 @@
 * `show_diagnostics_in_view_status` `true` *when on a diagnostic with the cursor, show the text in the status bar*
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics, `"underline"` or `"box"`*
 * `highlight_active_signature_parameter`: *highlight the active parameter of the currently active signature*
+* `document_highlight_style`: *document highlight style: "underline", "stippled", "squiggly" or ""*
+* `document_highlight_scopes`: *customize your sublime text scopes for document highlighting*
 * `diagnostics_gutter_marker` `"dot"` *gutter marker for code diagnostics: "dot", "circle", "bookmark", "cross" or ""*
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `true` *show server/logMessage notifications from language servers in the console*

--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -42,7 +42,8 @@ class DocumentHighlightListener(sublime_plugin.ViewEventListener):
             self._initialize()
         if self._enabled:
             self._clear_regions()
-            self._queue()
+            if settings.document_highlight_style:
+                self._queue()
 
     def _initialize(self) -> None:
         self._initialized = True


### PR DESCRIPTION
- Add "" option for document_highlight_style
- Add document_highlight_* settings to index.md docs

closes https://github.com/tomv564/LSP/issues/286