### PR TITLE
Add ability to delay diagnostics

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+----
+
+LSP incorporates code from SublimeLinter, used under the terms of the
+MIT license:
+
+    Copyright (c) 2015 The SublimeLinter Community
+    Copyright (c) 2014 Aparajita Fishman
+    Copyright (c) 2013 Ryan Hileman
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -183,6 +183,9 @@
   // depending on available diagnostics.
   "auto_show_diagnostics_panel": true,
 
+  // Delay to show diagnostics panel after, in fractional seconds.
+  "auto_show_delay": 0,
+
   // Show in-line diagnostics using phantoms for unchanged files.
   "show_diagnostics_phantoms": false,
 

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -183,7 +183,8 @@
   // depending on available diagnostics.
   "auto_show_diagnostics_panel": true,
 
-  // Delay to show diagnostics panel after, in fractional seconds.
+  // Time (in fractional seconds) to wait after a change before showing
+  // diagnostics panel.
   "auto_show_delay": 0,
 
   // Show in-line diagnostics using phantoms for unchanged files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
 * `auto_show_diagnostics_panel` `true` *open and close the diagnostics panel automatically*
+* `auto_show_delay` `0` *time in seconds to wait after a change before showing diagnostics panel*
 * `show_diagnostics_phantoms` `false` *show diagnostics as phantoms while the file has no changes*
 * `show_diagnostics_in_view_status` `true` *when on a diagnostic with the cursor, show the text in the status bar*
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics, `"underline"` or `"box"`*

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -34,6 +34,7 @@ from .documents import (
 )
 from .diagnostics import handle_client_diagnostics, remove_diagnostics
 from .edit import apply_workspace_edit
+from .queue import unload as unload_queue
 
 
 def startup():
@@ -47,6 +48,7 @@ def startup():
 
 
 def shutdown():
+    unload_queue()
     unload_settings()
     unload_all_clients()
 

--- a/plugin/core/queue.py
+++ b/plugin/core/queue.py
@@ -1,0 +1,35 @@
+import threading
+
+
+# Map from view_id to threading.Timer objects
+timers = {}
+
+
+def debounce(callback, delay, key=None):
+    key = key or callback
+
+    try:
+        timers[key].cancel()
+    except KeyError:
+        pass
+
+    timers[key] = timer = threading.Timer(delay, callback)
+    timer.start()
+    return timer
+
+
+def cleanup(vid):
+    try:
+        timers.pop(vid).cancel()
+    except KeyError:
+        pass
+
+
+def unload():
+    while True:
+        try:
+            _vid, timer = timers.popitem()
+        except KeyError:
+            return
+        else:
+            timer.cancel()

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -32,6 +32,15 @@ def read_str_setting(settings_obj: sublime.Settings, key: str, default: str) -> 
     else:
         return default
 
+def read_float_setting(settings_obj: sublime.Settings, key: str, default: float) -> float:
+    val = settings_obj.get(key)
+    if isinstance(val, float):
+        return val
+    elif isinstance(val, int):
+        return float(val)
+    else:
+        return default
+
 
 class Settings(object):
 
@@ -39,6 +48,7 @@ class Settings(object):
         self.show_status_messages = True
         self.show_view_status = True
         self.auto_show_diagnostics_panel = True
+        self.auto_show_delay = 0.0
         self.show_diagnostics_phantoms = False
         self.show_diagnostics_in_view_status = True
         self.only_show_lsp_completions = False
@@ -64,6 +74,7 @@ class Settings(object):
         self.show_status_messages = read_bool_setting(settings_obj, "show_status_messages", True)
         self.show_view_status = read_bool_setting(settings_obj, "show_view_status", True)
         self.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", True)
+        self.auto_show_delay = read_float_setting(settings_obj, "auto_show_delay", 0.0)
         self.show_diagnostics_phantoms = read_bool_setting(settings_obj, "show_diagnostics_phantoms", False)
         self.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
         self.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -16,7 +16,7 @@ from .core.configurations import is_supported_syntax
 from .core.diagnostics import DiagnosticsUpdate, get_window_diagnostics, get_line_diagnostics
 from .core.workspace import get_project_path
 from .core.panels import create_output_panel
-from .core.queue import debounce
+from .core.queue import cleanup, debounce
 
 diagnostic_severity_names = {
     DiagnosticSeverity.Error: "error",
@@ -262,6 +262,7 @@ def update_diagnostics_panel(window: sublime.Window):
                     show_panel()
         else:
             panel.run_command("lsp_clear_panel")
+            cleanup("show:{}".format(window.id()))
             if settings.auto_show_diagnostics_panel and is_active_panel:
                 window.run_command("hide_panel",
                                    {"panel": "output.diagnostics"})

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -16,6 +16,7 @@ from .core.configurations import is_supported_syntax
 from .core.diagnostics import DiagnosticsUpdate, get_window_diagnostics, get_line_diagnostics
 from .core.workspace import get_project_path
 from .core.panels import create_output_panel
+from .core.queue import debounce
 
 diagnostic_severity_names = {
     DiagnosticSeverity.Error: "error",
@@ -253,8 +254,12 @@ def update_diagnostics_panel(window: sublime.Window):
                     to_render.append(format_diagnostics(relative_file_path, source_diagnostics))
             panel.run_command("lsp_update_panel", {"characters": "\n".join(to_render)})
             if settings.auto_show_diagnostics_panel and not active_panel:
-                window.run_command("show_panel",
-                                   {"panel": "output.diagnostics"})
+                show_panel = lambda: window.run_command("show_panel",
+                                                        {"panel": "output.diagnostics"})
+                if settings.auto_show_delay > 0:
+                    debounce(show_panel, settings.auto_show_delay, "show:{}".format(window.id()))
+                else:
+                    show_panel()
         else:
             panel.run_command("lsp_clear_panel")
             if settings.auto_show_diagnostics_panel and is_active_panel:


### PR DESCRIPTION
See #186. This adds a new `auto_show_delay` setting which can be used to debounce the `show_panel` command.

i.e. if you set it to `0.3`, it will wait 300ms after a diagnostics response before showing the panel. If another diagnostics response is received in the meantime, it will cancel the original timer and start a new one.

This allows you to avoid having the panel show up constantly while typing code. This doesn't affect panel updates, which are still instant (after receiving the diagnostics response).

For convenience, I've simply copied across the [SublimeLinter queue functionality](https://github.com/SublimeLinter/SublimeLinter/blob/8ca2a23ba4f2c6da814904dbc60814b7b576c38e/lint/queue.py) and credited it in the license file. If this is undesirable, I can remove it and write it from scratch instead.