### PR TITLE
Language handler support

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -50,13 +50,6 @@
       "syntaxes": ["Packages/Python/Python.sublime-syntax"],
       "languageId": "python"
     },
-    "jsts":
-    {
-      "command": ["javascript-typescript-stdio"],
-      "scopes": ["source.ts", "source.tsx", "source.js", "source.jsx"],
-      "syntaxes": ["Packages/TypeScript-TmLanguage/TypeScript.tmLanguage", "Packages/TypeScript-TmLanguage/TypeScriptReact.tmLanguage", "Packages/Babel/JavaScript (Babel).sublime-syntax", "Packages/JavaScript/JavaScript.sublime-syntax"],
-      "languageId": "typescript"
-    },
     "rls":
     {
       "command": ["rustup", "run", "nightly", "rls"],

--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -5,7 +5,7 @@ import webbrowser
 
 from .core.settings import ClientConfig, client_configs
 from .core.configurations import (
-    get_scope_client_config, config_for_scope, get_default_client_config, clear_window_client_configs
+    get_scope_client_config, config_for_scope, get_global_client_config, clear_window_client_configs
 )
 from .core.clients import unload_window_clients
 from .core.events import Events
@@ -15,7 +15,7 @@ from .core.workspace import enable_in_project, disable_in_project
 def detect_supportable_view(view: sublime.View):
     config = config_for_scope(view)
     if not config:
-        available_config = get_default_client_config(view)
+        available_config = get_global_client_config(view)
         if available_config:
             show_enable_config(view, available_config)
 
@@ -45,7 +45,7 @@ def start_view(view: sublime.View):
 class LspEnableLanguageServerGloballyCommand(sublime_plugin.WindowCommand):
     def run(self):
         view = self.window.active_view()
-        available_config = get_scope_client_config(view, client_configs.defaults) or get_default_client_config(view)
+        available_config = get_scope_client_config(view, client_configs.defaults) or get_global_client_config(view)
         if available_config:
             client_configs.enable(available_config.name)
             clear_window_client_configs(self.window)
@@ -61,7 +61,7 @@ class LspEnableLanguageServerInProjectCommand(sublime_plugin.WindowCommand):
         view = self.window.active_view()
 
         # if no default_config, nothing we can do.
-        default_config = get_default_client_config(view)
+        default_config = get_global_client_config(view)
         if default_config:
             enable_in_project(self.window, default_config.name)
             clear_window_client_configs(self.window)
@@ -120,7 +120,7 @@ class LspSetupLanguageServerCommand(sublime_plugin.WindowCommand):
     def run(self):
         view = self.window.active_view()
         syntax = view.settings().get("syntax")
-        available_config = get_default_client_config(view)
+        available_config = get_global_client_config(view)
 
         syntax_name = extract_syntax_name(syntax)
         title = "# Language Server for {}\n".format(syntax_name)

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -26,6 +26,11 @@ def get_scope_client_config(view: 'sublime.View', configs: 'List[ClientConfig]')
     return None
 
 
+def register_client_config(config: ClientConfig) -> None:
+    window_client_configs.clear()
+    client_configs.add_external_config(config)
+
+
 def get_global_client_config(view: sublime.View) -> 'Optional[ClientConfig]':
     return get_scope_client_config(view, client_configs.all)
 

--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -2,13 +2,16 @@ import abc
 from .settings import ClientConfig
 # from .rpc import Client
 try:
-    from typing import Any, List, Dict, Tuple, Callable, Optional, Set, Type
-    assert Any and List and Dict and Tuple and Callable and Optional and Set
+    from typing import List, Callable, Optional, Type
+    assert List and Callable and Optional and Type
 except ImportError:
     pass
 
 
 class LanguageHandler(metaclass=abc.ABCMeta):
+    on_enable = None  # type: Optional[Callable]
+    on_initialized = None  # type: Optional[Callable]
+
     @abc.abstractproperty
     def name(self) -> str:
         raise NotImplementedError
@@ -17,12 +20,6 @@ class LanguageHandler(metaclass=abc.ABCMeta):
     def config(self) -> ClientConfig:
         raise NotImplementedError
 
-    # def on_enable(self) -> None:
-    #     pass
-
-    # def on_initialized(self, client: Client) -> None:
-    #     pass
-
     @classmethod
     def instantiate_all(cls) -> 'List[LanguageHandler]':
         return list(
@@ -30,5 +27,5 @@ class LanguageHandler(metaclass=abc.ABCMeta):
             if issubclass(c, LanguageHandler))
 
 
-def instantiate(c: Type[LanguageHandler]) -> LanguageHandler:
+def instantiate(c: 'Type[LanguageHandler]') -> LanguageHandler:
     return c()

--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -1,30 +1,34 @@
 import abc
 from .settings import ClientConfig
-from .rpc import Client
+# from .rpc import Client
 try:
-    from typing import Any, List, Dict, Tuple, Callable, Optional, Set
+    from typing import Any, List, Dict, Tuple, Callable, Optional, Set, Type
     assert Any and List and Dict and Tuple and Callable and Optional and Set
 except ImportError:
     pass
 
 
-class LanguageHandler(object):
-    __metaclass__ = abc.ABCMeta
-
+class LanguageHandler(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def name(self) -> str:
-        pass
+        raise NotImplementedError
 
     @abc.abstractproperty
     def config(self) -> ClientConfig:
-        pass
+        raise NotImplementedError
 
-    def on_enable(self) -> None:
-        pass
+    # def on_enable(self) -> None:
+    #     pass
 
-    def on_initialized(self, client: Client) -> None:
-        pass
+    # def on_initialized(self, client: Client) -> None:
+    #     pass
+
+    @classmethod
+    def instantiate_all(cls) -> 'List[LanguageHandler]':
+        return list(
+            instantiate(c) for c in cls.__subclasses__()
+            if issubclass(c, LanguageHandler))
 
 
-def get_language_handlers() -> 'List[LanguageHandler]':
-    return list(cls() for cls in LanguageHandler.__subclasses__())
+def instantiate(c: Type[LanguageHandler]) -> LanguageHandler:
+    return c()

--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -1,0 +1,30 @@
+import abc
+from .settings import ClientConfig
+from .rpc import Client
+try:
+    from typing import Any, List, Dict, Tuple, Callable, Optional, Set
+    assert Any and List and Dict and Tuple and Callable and Optional and Set
+except ImportError:
+    pass
+
+
+class LanguageHandler(object):
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractproperty
+    def name(self) -> str:
+        pass
+
+    @abc.abstractproperty
+    def config(self) -> ClientConfig:
+        pass
+
+    def on_enable(self) -> None:
+        pass
+
+    def on_initialized(self, client: Client) -> None:
+        pass
+
+
+def get_language_handlers() -> 'List[LanguageHandler]':
+    return list(cls() for cls in LanguageHandler.__subclasses__())

--- a/plugin/core/handlers.py
+++ b/plugin/core/handlers.py
@@ -9,7 +9,7 @@ except ImportError:
 
 
 class LanguageHandler(metaclass=abc.ABCMeta):
-    on_enable = None  # type: Optional[Callable]
+    on_start = None  # type: Optional[Callable]
     on_initialized = None  # type: Optional[Callable]
 
     @abc.abstractproperty

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -117,7 +117,7 @@ def load_handlers():
 
 
 def register_language_handler(handler: LanguageHandler) -> None:
-    debug("received handler", handler.name)
+    debug("received config {} from {}".format(handler.name, handler.__class__.__name__))
     register_client_config(handler.config)
     if handler.on_start:
         client_start_listeners[handler.name] = handler.on_start

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -108,7 +108,7 @@ def initialize_on_open(view: sublime.View):
 
 
 client_initialization_listeners = {}  # type: Dict[str, Callable]
-config_enabled_listeners = {}  # type: Dict[str, Callable]
+config_enable_listeners = {}  # type: Dict[str, Callable]
 
 
 def load_handlers():
@@ -121,8 +121,8 @@ def register_language_handler(handler: LanguageHandler) -> None:
     register_client_config(handler.config)
     if handler.on_initialized:
         client_initialization_listeners[handler.name] = handler.on_initialized
-    if handler.on_enabled:
-        config_enabled_listeners[handler.name] = handler.on_enabled
+    if handler.on_enable:
+        config_enable_listeners[handler.name] = handler.on_enable
 
 
 def handle_initialize_result(result, client, window, config):

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -21,7 +21,7 @@ from .logging import debug, exception_log, server_log
 from .rpc import attach_tcp_client, attach_stdio_client
 from .workspace import get_project_path
 from .configurations import (
-    config_for_scope, is_supported_view
+    config_for_scope, is_supported_view, register_client_config
 )
 from .clients import (
     can_start_config, set_config_starting, set_config_ready, clear_config_state,
@@ -106,6 +106,15 @@ def initialize_on_open(view: sublime.View):
 
 
 client_initialization_listeners = {}  # type: Dict[str, Callable]
+
+
+language_handlers = []
+
+
+def register_language_handler(handler):
+    debug("received handler", handler.name)
+    register_client_config(handler.config)
+    language_handlers.append(handler)
 
 
 def register_client_initialization_listener(client_name: str, handler: 'Callable') -> None:

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -17,7 +17,7 @@ from .protocol import (
 from .settings import (
     ClientConfig, settings, load_settings, unload_settings
 )
-from .handlers import LanguageHandler, get_language_handlers
+from .handlers import LanguageHandler
 from .logging import debug, exception_log, server_log
 from .rpc import attach_tcp_client, attach_stdio_client
 from .workspace import get_project_path
@@ -108,10 +108,11 @@ def initialize_on_open(view: sublime.View):
 
 
 client_initialization_listeners = {}  # type: Dict[str, Callable]
+config_enabled_listeners = {}  # type: Dict[str, Callable]
 
 
 def load_handlers():
-    for handler in get_language_handlers():
+    for handler in LanguageHandler.instantiate_all():
         register_language_handler(handler)
 
 
@@ -120,6 +121,8 @@ def register_language_handler(handler: LanguageHandler) -> None:
     register_client_config(handler.config)
     if handler.on_initialized:
         client_initialization_listeners[handler.name] = handler.on_initialized
+    if handler.on_enabled:
+        config_enabled_listeners[handler.name] = handler.on_enabled
 
 
 def handle_initialize_result(result, client, window, config):

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -138,10 +138,10 @@ class ClientConfigs(object):
                 config.apply_settings(self._global_settings[config.name])
         self.all.extend(self._external_configs)
 
-        client_enableds = list("=".join([config.name, str(config.enabled)]) for config in self.all)
-        print(PLUGIN_NAME + ': global clients: ' + ", ".join(client_enableds))
-
     def add_external_config(self, config: ClientConfig):
+        print('adding ', config.name)
+        if config.name in self._global_settings:
+            config.apply_settings(self._global_settings[config.name])
         self._external_configs.append(config)
         self.all.append(config)
 
@@ -207,7 +207,7 @@ def read_client_configs(client_settings, default_client_settings=None) -> 'List[
             client_with_defaults.update(client_config)
 
             config = read_client_config(client_name, client_with_defaults)
-            if config:
+            if config and config.scopes:  # don't return configs only containing "enabled" here.
                 parsed_configs.append(config)
         return parsed_configs
     else:


### PR DESCRIPTION
Aims to provide a richer API allowing packages external to LSP to:

- [x] Register a supported language server configuration
- [x] Verify or even perform language server installation / updates
- [x] Implement server-specific APIs (supplanting `register_client_initialization_listener`)

Motivation is that we are starting to have conflicts in the default configs (so I'd like to remove them entirely). Also, other maintainers can do a much better job ensuring language servers are installed / up to date.

Classes that extend the abstract interface will automatically be instantiated by LSP:
```python
from LSP.plugin.core.handlers import LanguageHandler
from LSP.plugin.core.settings import ClientConfig

class LspYourServerPlugin(LanguageHandler):

    @property
    def name(self) -> str:
        return YOUR_CONFIG_NAME

    @property
    def config(self) -> ClientConfig:
        return YOUR_CLIENT_CONFIG

    def on_start(self, window) -> bool:
        # optional, verify the server is ready to be started here

    def on_initialized(self, client) -> None:
        # optional, register extra 
```

Example plugin implementations at https://github.com/tomv564/LSP-tss and https://github.com/tomv564/LSP-rust