### PR TITLE
fix: local variable referenced before assignment

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -80,8 +80,9 @@ class LspHoverCommand(LspTextCommand):
             "<pre>{}</pre>".format(diagnostic.message)
             for diagnostic in diagnostics
             if diagnostic.severity == DiagnosticSeverity.Error)
+        formatted = []
         if len(formatted_errors) > 0:
-            formatted = ["<div class='errors'>"]
+            formatted.append("<div class='errors'>")
             formatted.extend(formatted_errors)
             formatted.append("<a href='{}'>{}</a>".format('code-actions',
                                                           'Code Actions'))
@@ -93,7 +94,7 @@ class LspHoverCommand(LspTextCommand):
             if diagnostic.severity == DiagnosticSeverity.Warning)
 
         if len(formatted_warnings) > 0:
-            formatted = ["<div class='warnings'>"]
+            formatted.append("<div class='warnings'>")
             formatted.extend(formatted_warnings)
             formatted.append("<a href='{}'>{}</a>".format('code-actions',
                                                           'Code Actions'))


### PR DESCRIPTION
To fix an obvious bug of `local variable referenced before assignment`

```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 1066, in run_
    return self.run(edit, **args)
  File "/Users/Randy/Dropbox/Sublime Text 3/Packages/LSP/plugin/hover.py", line 47, in run
    self.show_hover(point, self.diagnostics_content(point_diagnostics))
  File "/Users/Randy/Dropbox/Sublime Text 3/Packages/LSP/plugin/hover.py", line 102, in diagnostics_content
    return "".join(formatted)
UnboundLocalError: local variable 'formatted' referenced before assignment
```