### PR TITLE
make request and notication classes customizable

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from .core.clients import client_for_view
 from .core.clients import LspTextCommand
-from .core.protocol import Request, Range
+from .core.protocol import Range
 from .core.documents import get_position
 from .core.diagnostics import get_point_diagnostics
 from .core.url import filename_to_uri
@@ -42,7 +42,7 @@ class LspCodeActionsCommand(LspTextCommand):
                 sel.clear()
                 sel.add(sublime.Region(pos))
 
-            client.send_request(Request.codeAction(params), self.handle_codeaction_response)
+            client.send_request(client.request_class.codeAction(params), self.handle_codeaction_response)
 
     def handle_codeaction_response(self, response):
         titles = []
@@ -60,7 +60,7 @@ class LspCodeActionsCommand(LspTextCommand):
             client = client_for_view(self.view)
             if client:
                 client.send_request(
-                    Request.executeCommand(self.commands[index]),
+                    client.request_class.executeCommand(self.commands[index]),
                     self.handle_command_response)
 
     def handle_command_response(self, response):

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -7,7 +7,6 @@ try:
 except ImportError:
     pass
 
-from .core.protocol import Request
 from .core.settings import settings
 from .core.logging import debug, exception_log
 from .core.protocol import CompletionItemKind
@@ -93,7 +92,7 @@ class CompletionSnippetHandler(sublime_plugin.EventListener):
             return
 
         client.send_request(
-            Request.resolveCompletionItem(item),
+            client.request_class.resolveCompletionItem(item),
             lambda response: self.handle_resolve_response(response, view))
 
     def handle_resolve_response(self, response, view):
@@ -219,7 +218,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
             document_position = get_document_position(view, locations[0])
             if document_position:
                 client.send_request(
-                    Request.complete(document_position),
+                    client.request_class.complete(document_position),
                     self.handle_response,
                     self.handle_error)
                 self.state = CompletionState.REQUESTING

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -3,7 +3,6 @@ import sublime_plugin
 
 from .logging import debug, exception_log
 from .configurations import config_for_scope, is_supported_view
-from .protocol import Request
 from .workspace import get_project_path
 
 # typing only
@@ -208,4 +207,6 @@ def on_shutdown(client: Client, window_id: int, config_name: str, response):
 
 
 def unload_client(client: Client, window_id: int, config_name: str):
-    client.send_request(Request.shutdown(), lambda response: on_shutdown(client, window_id, config_name, response))
+    client.send_request(
+        client.request_class.shutdown(),
+        lambda response: on_shutdown(client, window_id, config_name, response))

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -10,7 +10,7 @@ except ImportError:
     pass
 
 from .logging import debug
-from .protocol import Notification, Point
+from .protocol import Point
 from .settings import settings
 from .url import filename_to_uri
 from .configurations import config_for_scope, is_supported_view, is_supported_syntax, is_supportable_syntax
@@ -141,7 +141,7 @@ def notify_did_open(view: sublime.View):
                         "version": ds.version
                     }
                 }
-                client.send_notification(Notification.didOpen(params))
+                client.send_notification(client.notification_class.didOpen(params))
 
 
 def notify_did_close(view: sublime.View):
@@ -153,7 +153,7 @@ def notify_did_close(view: sublime.View):
             client = client_for_closed_view(view)
             if client:
                 params = {"textDocument": {"uri": filename_to_uri(file_name)}}
-                client.send_notification(Notification.didClose(params))
+                client.send_notification(client.notification_class.didClose(params))
 
 
 def notify_did_save(view: sublime.View):
@@ -164,7 +164,7 @@ def notify_did_save(view: sublime.View):
             client = client_for_view(view)
             if client:
                 params = {"textDocument": {"uri": filename_to_uri(file_name)}}
-                client.send_notification(Notification.didSave(params))
+                client.send_notification(client.notification_class.didSave(params))
         else:
             debug('document not tracked', file_name)
 
@@ -190,7 +190,7 @@ def notify_did_change(view: sublime.View):
                     "text": view.substr(sublime.Region(0, view.size()))
                 }]
             }
-            client.send_notification(Notification.didChange(params))
+            client.send_notification(client.notification_class.didChange(params))
 
 
 document_sync_initialized = False

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -12,7 +12,7 @@ import sublime
 
 from .url import filename_to_uri
 from .protocol import (
-    Request, Notification, SymbolKind, CompletionItemKind
+    SymbolKind, CompletionItemKind
 )
 from .settings import (
     ClientConfig, settings, load_settings, unload_settings
@@ -163,12 +163,12 @@ def handle_initialize_result(result, client, window, config):
 
     Events.subscribe('view.on_close', lambda view: remove_diagnostics(view, config.name))
 
-    client.send_notification(Notification.initialized())
+    client.send_notification(client.notification_class.initialized())
     if config.settings:
         configParams = {
             'settings': config.settings
         }
-        client.send_notification(Notification.didChangeConfiguration(configParams))
+        client.send_notification(client.notification_class.didChangeConfiguration(configParams))
 
     # now the client should be available outside the initialization sequence
     set_config_ready(window, config.name, client)
@@ -315,7 +315,7 @@ def start_client(window: sublime.Window, config: ClientConfig):
         initializeParams['initializationOptions'] = config.init_options
 
     client.send_request(
-        Request.initialize(initializeParams),
+        client.request_class.initialize(initializeParams),
         lambda result: handle_initialize_result(result, client, window, config))
     return client
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -72,63 +72,63 @@ class Request:
 
     @classmethod
     def initialize(cls, params: dict):
-        return Request("initialize", params)
+        return cls("initialize", params)
 
     @classmethod
     def hover(cls, params: dict):
-        return Request("textDocument/hover", params)
+        return cls("textDocument/hover", params)
 
     @classmethod
     def complete(cls, params: dict):
-        return Request("textDocument/completion", params)
+        return cls("textDocument/completion", params)
 
     @classmethod
     def signatureHelp(cls, params: dict):
-        return Request("textDocument/signatureHelp", params)
+        return cls("textDocument/signatureHelp", params)
 
     @classmethod
     def references(cls, params: dict):
-        return Request("textDocument/references", params)
+        return cls("textDocument/references", params)
 
     @classmethod
     def definition(cls, params: dict):
-        return Request("textDocument/definition", params)
+        return cls("textDocument/definition", params)
 
     @classmethod
     def rename(cls, params: dict):
-        return Request("textDocument/rename", params)
+        return cls("textDocument/rename", params)
 
     @classmethod
     def codeAction(cls, params: dict):
-        return Request("textDocument/codeAction", params)
+        return cls("textDocument/codeAction", params)
 
     @classmethod
     def executeCommand(cls, params: dict):
-        return Request("workspace/executeCommand", params)
+        return cls("workspace/executeCommand", params)
 
     @classmethod
     def formatting(cls, params: dict):
-        return Request("textDocument/formatting", params)
+        return cls("textDocument/formatting", params)
 
     @classmethod
     def rangeFormatting(cls, params: dict):
-        return Request("textDocument/rangeFormatting", params)
+        return cls("textDocument/rangeFormatting", params)
 
     @classmethod
     def documentSymbols(cls, params: dict):
-        return Request("textDocument/documentSymbol", params)
+        return cls("textDocument/documentSymbol", params)
 
     @classmethod
     def documentHighlight(cls, params: dict):
-        return Request("textDocument/documentHighlight", params)
+        return cls("textDocument/documentHighlight", params)
 
     @classmethod
     def resolveCompletionItem(cls, params: dict):
-        return Request("completionItem/resolve", params)
+        return cls("completionItem/resolve", params)
 
     @classmethod
     def shutdown(cls):
-        return Request("shutdown", None)
+        return cls("shutdown", None)
 
     def __repr__(self):
         return self.method + " " + str(self.params)
@@ -153,31 +153,31 @@ class Notification:
 
     @classmethod
     def initialized(cls):
-        return Notification("initialized", None)
+        return cls("initialized", None)
 
     @classmethod
     def didOpen(cls, params: dict):
-        return Notification("textDocument/didOpen", params)
+        return cls("textDocument/didOpen", params)
 
     @classmethod
     def didChange(cls, params: dict):
-        return Notification("textDocument/didChange", params)
+        return cls("textDocument/didChange", params)
 
     @classmethod
     def didSave(cls, params: dict):
-        return Notification("textDocument/didSave", params)
+        return cls("textDocument/didSave", params)
 
     @classmethod
     def didClose(cls, params: dict):
-        return Notification("textDocument/didClose", params)
+        return cls("textDocument/didClose", params)
 
     @classmethod
     def didChangeConfiguration(cls, params: dict):
-        return Notification("workspace/didChangeConfiguration", params)
+        return cls("workspace/didChangeConfiguration", params)
 
     @classmethod
     def exit(cls):
-        return Notification("exit", None)
+        return cls("exit", None)
 
     def __repr__(self):
         return self.method + " " + str(self.params)

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -246,6 +246,8 @@ class Client(object):
         self.capabilities = {}  # type: Dict[str, Any]
         self.exiting = False
         self._crash_handler = None  # type: Optional[Callable]
+        self.notification_class = Notification
+        self.request_class = Request
 
     def set_capabilities(self, capabilities):
         self.capabilities = capabilities

--- a/plugin/definition.py
+++ b/plugin/definition.py
@@ -2,7 +2,7 @@ import sublime
 
 from .core.clients import LspTextCommand
 from .core.clients import client_for_view
-from .core.protocol import Request, Point
+from .core.protocol import Point
 from .core.documents import get_document_position, get_position, is_at_word
 from .core.url import uri_to_filename
 from .core.logging import debug
@@ -23,7 +23,7 @@ class LspSymbolDefinitionCommand(LspTextCommand):
             pos = get_position(self.view, event)
             document_position = get_document_position(self.view, pos)
             if document_position:
-                request = Request.definition(document_position)
+                request = client.request_class.definition(document_position)
                 client.send_request(
                     request, lambda response: self.handle_response(response, pos))
 

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,5 +1,5 @@
 
-from .core.protocol import Request, Range
+from .core.protocol import Range
 from .core.url import filename_to_uri
 from .core.clients import client_for_view
 from .core.clients import LspTextCommand
@@ -25,7 +25,7 @@ class LspFormatDocumentCommand(LspTextCommand):
                     "insertSpaces": True
                 }
             }
-            request = Request.formatting(params)
+            request = client.request_class.formatting(params)
             client.send_request(
                 request, lambda response: self.handle_response(response, pos))
 
@@ -60,6 +60,6 @@ class LspFormatDocumentRangeCommand(LspTextCommand):
                     "insertSpaces": True
                 }
             }
-            client.send_request(Request.rangeFormatting(params),
+            client.send_request(client.request_class.rangeFormatting(params),
                                 lambda response: self.view.run_command('lsp_apply_document_edit',
                                                                        {'changes': response}))

--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -1,7 +1,7 @@
 import sublime_plugin
 
 from .core.configurations import is_supported_syntax
-from .core.protocol import Request, Range, DocumentHighlightKind
+from .core.protocol import Range, DocumentHighlightKind
 from .core.clients import client_for_view
 from .core.documents import get_document_position
 from .core.settings import settings
@@ -77,7 +77,7 @@ class DocumentHighlightListener(sublime_plugin.ViewEventListener):
             if client:
                 params = get_document_position(self.view, point)
                 if params:
-                    request = Request.documentHighlight(params)
+                    request = client.request_class.documentHighlight(params)
                     client.send_request(request, self._handle_response)
 
     def _handle_response(self, response: list) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -6,7 +6,7 @@ import webbrowser
 from .core.configurations import is_supported_syntax
 from .core.diagnostics import get_point_diagnostics
 from .core.clients import LspTextCommand, client_for_view
-from .core.protocol import Request, DiagnosticSeverity
+from .core.protocol import DiagnosticSeverity
 from .core.documents import get_document_position
 from .core.popups import popup_css, popup_class
 
@@ -52,7 +52,7 @@ class LspHoverCommand(LspTextCommand):
             document_position = get_document_position(self.view, point)
             if document_position:
                 client.send_request(
-                    Request.hover(document_position),
+                    client.request_class.hover(document_position),
                     lambda response: self.handle_response(response, point))
 
     def handle_response(self, response, point):

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -7,7 +7,7 @@ from .core.clients import client_for_view
 from .core.documents import is_at_word, get_position, get_document_position
 from .core.clients import LspTextCommand
 from .core.workspace import get_project_path
-from .core.protocol import Request, Point
+from .core.protocol import Point
 from .core.url import uri_to_filename
 
 
@@ -46,7 +46,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
                 document_position['context'] = {
                     "includeDeclaration": False
                 }
-                request = Request.references(document_position)
+                request = client.request_class.references(document_position)
                 client.send_request(
                     request, lambda response: self.handle_response(response, pos))
 

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -1,7 +1,6 @@
 
 from .core.clients import LspTextCommand
 from .core.clients import client_for_view
-from .core.protocol import Request
 from .core.documents import get_document_position, get_position, is_at_word
 
 
@@ -29,7 +28,7 @@ class LspSymbolRenameCommand(LspTextCommand):
         client = client_for_view(self.view)
         if client:
             params["newName"] = new_name
-            client.send_request(Request.rename(params), self.handle_response)
+            client.send_request(client.request_class.rename(params), self.handle_response)
 
     def handle_response(self, response):
         if 'changes' in response:

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -15,7 +15,6 @@ except ImportError:
 from .core.clients import client_for_view
 from .core.documents import get_document_position, purge_did_change
 from .core.configurations import is_supported_syntax, config_for_scope
-from .core.protocol import Request
 from .core.logging import debug
 from .core.popups import popup_css, popup_class
 from .core.settings import settings
@@ -77,7 +76,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
             document_position = get_document_position(self.view, point)
             if document_position:
                 client.send_request(
-                    Request.signatureHelp(document_position),
+                    client.request_class.signatureHelp(document_position),
                     lambda response: self.handle_response(response, point))
 
     def handle_response(self, response, point):

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -2,7 +2,7 @@
 from .core.protocol import SymbolKind
 from .core.clients import LspTextCommand
 from .core.clients import client_for_view
-from .core.protocol import Request, Range
+from .core.protocol import Range
 from .core.url import filename_to_uri
 
 
@@ -51,7 +51,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
                     "uri": filename_to_uri(self.view.file_name())
                 }
             }
-            request = Request.documentSymbols(params)
+            request = client.request_class.documentSymbols(params)
             client.send_request(request, self.handle_response)
 
     def handle_response(self, response):


### PR DESCRIPTION
This looks like a huge PR, but actually there is only one significant change - the customizable classes at [here](https://github.com/randy3k/LSP/blob/fc829fc9c31abe7f256592ab0bf36155217f9e2e/plugin/core/rpc.py#L249-L250). It allows plugin developers to override the default Request and Notification classes if necessary. A potential usage is to honor the [extended protocol](https://github.com/llvm-mirror/clang-tools-extra/blob/849d20a96082bf06134957850445d2e33dba3bc9/clangd/Protocol.h#L354-L354) used by clangd. See also https://github.com/Microsoft/language-server-protocol/issues/255.