### PR TITLE
Add diagnostics count to statusbar

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -167,10 +167,13 @@
 
   // Open and close the diagnostics panel automatically,
   // depending on available diagnostics.
-  "auto_show_diagnostics_panel": true,
+  "auto_show_diagnostics_panel": false,
 
   // Show in-line diagnostics using phantoms for unchanged files.
   "show_diagnostics_phantoms": false,
+
+  // Show errors and warnings count in the status bar 
+  "show_diagnostics_count_in_view_status": true,
 
   // Show the diagnostics description of the code
   // under the cursor in status bar if available.

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -167,13 +167,13 @@
 
   // Open and close the diagnostics panel automatically,
   // depending on available diagnostics.
-  "auto_show_diagnostics_panel": false,
+  "auto_show_diagnostics_panel": true,
 
   // Show in-line diagnostics using phantoms for unchanged files.
   "show_diagnostics_phantoms": false,
 
   // Show errors and warnings count in the status bar 
-  "show_diagnostics_count_in_view_status": true,
+  "show_diagnostics_count_in_view_status": false,
 
   // Show the diagnostics description of the code
   // under the cursor in status bar if available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,9 @@
 * `resolve_completion_for_snippets` `false` *resolve completions and apply snippet if received*
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
-* `auto_show_diagnostics_panel` `false` *open the diagnostics panel automatically if there are diagnostics*
+* `auto_show_diagnostics_panel` `true` *open the diagnostics panel automatically if there are diagnostics*
 * `show_diagnostics_phantoms` `false` *show diagnostics as phantoms while the file has no changes*
-* `show_diagnostics_count_in_view_status` `true` *show errors and warnings count in the status bar*
+* `show_diagnostics_count_in_view_status` `false` *show errors and warnings count in the status bar*
 * `show_diagnostics_in_view_status` `true` *when on a diagnostic with the cursor, show the text in the status bar*
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics, `"underline"` or `"box"`*
 * `highlight_active_signature_parameter`: *highlight the active parameter of the currently active signature*

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,9 @@
 * `resolve_completion_for_snippets` `false` *resolve completions and apply snippet if received*
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
-* `auto_show_diagnostics_panel` `true` *open and close the diagnostics panel automatically*
+* `auto_show_diagnostics_panel` `false` *open the diagnostics panel automatically if there are diagnostics*
 * `show_diagnostics_phantoms` `false` *show diagnostics as phantoms while the file has no changes*
+* `show_diagnostics_count_in_view_status` `true` *show errors and warnings count in the status bar*
 * `show_diagnostics_in_view_status` `true` *when on a diagnostic with the cursor, show the text in the status bar*
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics, `"underline"` or `"box"`*
 * `highlight_active_signature_parameter`: *highlight the active parameter of the currently active signature*

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -38,8 +38,9 @@ class Settings(object):
     def __init__(self):
         self.show_status_messages = True
         self.show_view_status = True
-        self.auto_show_diagnostics_panel = True
+        self.auto_show_diagnostics_panel = False
         self.show_diagnostics_phantoms = False
+        self.show_diagnostics_count_in_view_status = True
         self.show_diagnostics_in_view_status = True
         self.only_show_lsp_completions = False
         self.diagnostics_highlight_style = "underline"
@@ -63,8 +64,10 @@ class Settings(object):
     def update(self, settings_obj: sublime.Settings):
         self.show_status_messages = read_bool_setting(settings_obj, "show_status_messages", True)
         self.show_view_status = read_bool_setting(settings_obj, "show_view_status", True)
-        self.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", True)
+        self.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", False)
         self.show_diagnostics_phantoms = read_bool_setting(settings_obj, "show_diagnostics_phantoms", False)
+        self.show_diagnostics_count_in_view_status = read_bool_setting(settings_obj,
+                                                                       "show_diagnostics_count_in_view_status", True)
         self.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
         self.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
         self.highlight_active_signature_parameter = read_bool_setting(settings_obj,

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -38,9 +38,9 @@ class Settings(object):
     def __init__(self):
         self.show_status_messages = True
         self.show_view_status = True
-        self.auto_show_diagnostics_panel = False
+        self.auto_show_diagnostics_panel = True
         self.show_diagnostics_phantoms = False
-        self.show_diagnostics_count_in_view_status = True
+        self.show_diagnostics_count_in_view_status = False
         self.show_diagnostics_in_view_status = True
         self.only_show_lsp_completions = False
         self.diagnostics_highlight_style = "underline"
@@ -64,10 +64,10 @@ class Settings(object):
     def update(self, settings_obj: sublime.Settings):
         self.show_status_messages = read_bool_setting(settings_obj, "show_status_messages", True)
         self.show_view_status = read_bool_setting(settings_obj, "show_view_status", True)
-        self.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", False)
+        self.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", True)
         self.show_diagnostics_phantoms = read_bool_setting(settings_obj, "show_diagnostics_phantoms", False)
         self.show_diagnostics_count_in_view_status = read_bool_setting(settings_obj,
-                                                                       "show_diagnostics_count_in_view_status", True)
+                                                                       "show_diagnostics_count_in_view_status", False)
         self.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
         self.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
         self.highlight_active_signature_parameter = read_bool_setting(settings_obj,

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -166,8 +166,37 @@ def update_diagnostics_in_view(view: sublime.View, diagnostics: 'List[Diagnostic
             update_diagnostics_regions(view, diagnostics, severity)
 
 
+def update_diagnostics_in_status_bar(window: sublime.Window):
+    errors = 0
+    warnings = 0
+
+    diagnostics_by_file = get_window_diagnostics(window)
+
+    if diagnostics_by_file:
+        for file_path, source_diagnostics in diagnostics_by_file.items():
+
+            if source_diagnostics:
+                for origin, diagnostics in source_diagnostics.items():
+                    for diagnostic in diagnostics:
+
+                        if diagnostic.severity == DiagnosticSeverity.Error:
+                            errors += 1
+                        if diagnostic.severity == DiagnosticSeverity.Warning:
+                            warnings += 1
+
+    count = 'E: {} W: {}'.format(errors, warnings)
+    view = window.active_view()
+    if view and settings.show_diagnostics_count_in_view_status:
+        view.set_status('lsp_errors_warning_count', count)
+
+
+def update_count_in_status_bar(view):
+    update_diagnostics_in_status_bar(view.window())
+
+
 Events.subscribe("document.diagnostics",
                  lambda update: handle_diagnostics(update))
+Events.subscribe("view.on_activated_async", update_count_in_status_bar)
 
 
 def handle_diagnostics(update: DiagnosticsUpdate):
@@ -176,6 +205,7 @@ def handle_diagnostics(update: DiagnosticsUpdate):
     if view:
         update_diagnostics_in_view(view, update.diagnostics)
     update_diagnostics_panel(window)
+    update_diagnostics_in_status_bar(window)
 
 
 class DiagnosticsCursorListener(sublime_plugin.ViewEventListener):
@@ -261,7 +291,7 @@ def update_diagnostics_panel(window: sublime.Window):
                                    {"panel": "output.diagnostics"})
         else:
             panel.run_command("lsp_clear_panel")
-            if settings.auto_show_diagnostics_panel and is_active_panel:
+            if is_active_panel:
                 window.run_command("hide_panel",
                                    {"panel": "output.diagnostics"})
         panel.set_read_only(True)


### PR DESCRIPTION
closes #186 

### CHANGED
- changed the default value for `auto_show_diagnostics_panel` to false,
- before `auto_show_diagnostics_panel` was responsible for automatically opening and closing the diagnostics panel,
now it is responsible only for opening, as the panel will automatically close when there are no errors(no need to show an empty panel),
- updated the docs for the settings I changed and added.

### ADDED
- new setting for configuring the visibility of the count in the status bar `show_diagnostics_count_in_view_status`, defaults to true,
- added diagnostics count to the status bar.

Waiting for feedback, if you have something you would change, or reject, please say so.. :)   

