### PR TITLE
Improve Vue syntax file reference in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,10 @@ Client configuration:
     "text.html.vue"
   ],
   "syntaxes": [
+    // For ST3 builds < 3153
     "Packages/Vue Syntax Highlight/vue.tmLanguage"
+    // For ST3 builds >= 3153
+    // "Packages/Vue Syntax Highlight/Vue Component.sublime-syntax"
   ]
 }
 ```


### PR DESCRIPTION
[vue-syntax-highlight](https://github.com/vuejs/vue-syntax-highlight) has changed their syntax file to take advantage of the latest ST3 builds. This specifies which file to use against different build versions.