### PR TITLE
Remove invalid type annotation

### DIFF
--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -75,7 +75,7 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
                 message = 'Applied {} change(s) to {}'.format(len(changes), relative_file_path)
                 window.status_message(message)
 
-    def changes_sorted(self, changes: [dict]):
+    def changes_sorted(self, changes):
         # changes looks like this:
         # [
         #   {

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -89,8 +89,8 @@ class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
 
         # Maps a change to the tuple (range.start.line, range.start.character)
         def get_start_position(change):
-            range = change.get('range')
-            start = range.get('start')
+            r = change.get('range')
+            start = r.get('start')
             line = start.get('line')
             character = start.get('character')
             return (line, character)  # Return tuple so comparing/sorting tuples in the form of (1, 2)


### PR DESCRIPTION
The last PR introduced an invalid type annotation. Didn't notice it. This should finally fix the build. Sorry!