### PR TITLE
Fix missing uri

### DIFF
--- a/plugin/definition.py
+++ b/plugin/definition.py
@@ -31,12 +31,14 @@ class LspSymbolDefinitionCommand(LspTextCommand):
         window = sublime.active_window()
         if response:
             location = response if isinstance(response, dict) else response[0]
-            file_path = uri_to_filename(location.get("uri"))
-            start = Point.from_lsp(location['range']['start'])
-            file_location = "{}:{}:{}".format(file_path, start.row + 1, start.col + 1)
-            debug("opening location", location)
-            window.open_file(file_location, sublime.ENCODED_POSITION)
-            # TODO: can add region here.
+            uri = location.get("uri")
+            if uri:
+                file_path = uri_to_filename(uri)
+                start = Point.from_lsp(location['range']['start'])
+                file_location = "{}:{}:{}".format(file_path, start.row + 1, start.col + 1)
+                debug("opening location", location)
+                window.open_file(file_location, sublime.ENCODED_POSITION)
+                # TODO: can add region here.
         else:
             window.run_command("goto_definition")
 


### PR DESCRIPTION
### Bug Fix:

Some servers (Eclipse Java) return responses without `uri` some times:

```json
[{"range": {}}]
```

This causes a traceback:

```python
Traceback (most recent call last):
  File "/Users/kronuz/Library/Application Support/Sublime Text 3/Packages/LSP/plugin/core/rpc.py", line 176, in receive_payload
    self.response_handler(payload)
  File "/Users/kronuz/Library/Application Support/Sublime Text 3/Packages/LSP/plugin/core/rpc.py", line 195, in response_handler
    self._response_handlers[handler_id](result)
  File "/Users/kronuz/Library/Application Support/Sublime Text 3/Packages/LSP/plugin/definition.py", line 28, in <lambda>
    request, lambda response: self.handle_response(response, pos))
  File "/Users/kronuz/Library/Application Support/Sublime Text 3/Packages/LSP/plugin/definition.py", line 34, in handle_response
    file_path = uri_to_filename(location.get("uri"))
  File "/Users/kronuz/Library/Application Support/Sublime Text 3/Packages/LSP/plugin/core/url.py", line 12, in uri_to_filename
    return url2pathname(urlparse(uri).path)
  File "./python3.3/urllib/request.py", line 1552, in url2pathname
  File "./python3.3/urllib/parse.py", line 514, in unquote
TypeError: Type str doesn't support the buffer API
```

This pull request fixes that problem by ignoring such responses.
