### PR TITLE
Bugfix: format completion

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -240,7 +240,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
         elif settings.completion_hint_type == "kind":
             kind = item.get("kind")
             if kind:
-                hint = completion_item_kind_names[kind]
+                hint = completion_item_kind_names.get(kind)
         # label is an alternative for insertText if neither textEdit nor insertText is provided
         insert_text = self.text_edit_text(item) or item.get("insertText") or label
         if len(insert_text) > 0 and insert_text[0] == '$':  # sublime needs leading '$' escaped.

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -54,6 +54,13 @@ class CompletionItemKind(object):
     Color = 16
     File = 17
     Reference = 18
+    Folder = 19
+    EnumMember = 20
+    Constant = 21
+    Struct = 22
+    Event = 23
+    Operator = 24
+    TypeParameter = 25
 
 
 class DocumentHighlightKind(object):


### PR DESCRIPTION
- Update completion item kinds
- More safely fetch the kind (if it doesn't exist, it reverts to None)

I haven't tested this, but this should fix #348. Ping @gobijan and @LaurentTreguier, could you give this a spin with the Ruby server?