### PR TITLE
Show diagnostic source as part of the message

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -77,7 +77,7 @@ class LspHoverCommand(LspTextCommand):
 
     def diagnostics_content(self, diagnostics):
         formatted_errors = list(
-            "<pre>{}</pre>".format(diagnostic.message)
+            "<pre>{}</pre>".format("[{}] {}".format(diagnostic.source, diagnostic.message) if diagnostic.source else "{}".format(diagnostic.message))
             for diagnostic in diagnostics
             if diagnostic.severity == DiagnosticSeverity.Error)
         formatted = []
@@ -89,7 +89,7 @@ class LspHoverCommand(LspTextCommand):
             formatted.append("</div>")
 
         formatted_warnings = list(
-            "<pre>{}</pre>".format(diagnostic.message)
+            "<pre>{}</pre>".format("[{}] {}".format(diagnostic.source, diagnostic.message) if diagnostic.source else "{}".format(diagnostic.message))
             for diagnostic in diagnostics
             if diagnostic.severity == DiagnosticSeverity.Warning)
 


### PR DESCRIPTION
### Suggestion:

When using plugins for language servers, or language servers that natively return the source of a diagnostic, the source should be shown as part of the hover popup.

For example, Python's pycodestyle, flake8 and mypy all return the source for each diagnostic; without adding the source, it's difficult to guess where the errors are coming from, this is a suggestion for. This pull request adds the source, as in: "[mypy] some message" or "[pyflakes] E501: line too long".
