### PR TITLE
Prevent os.path.relpath exception for project and file on 2 drives

### DIFF
--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -287,7 +287,10 @@ def update_diagnostics_panel(window: sublime.Window):
         if diagnostics_by_file:
             to_render = []
             for file_path, source_diagnostics in diagnostics_by_file.items():
-                relative_file_path = os.path.relpath(file_path, base_dir) if base_dir else file_path
+                try:
+                    relative_file_path = os.path.relpath(file_path, base_dir) if base_dir else file_path
+                except ValueError:
+                    relative_file_path = file_path
                 if source_diagnostics:
                     to_render.append(format_diagnostics(relative_file_path, source_diagnostics))
             panel.run_command("lsp_update_panel", {"characters": "\n".join(to_render)})


### PR DESCRIPTION
Otherwise os.path.relpath may emit for example:
`ValueError: path is on mount 'D:', start on mount 'C:'`

This is just a tiny fix for Windows users. Problem occurs when you have your project on one drive, but you add a folder from different drive.