### PR TITLE
Move session lifecycle into window, inject dependencies

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -150,10 +150,6 @@
     }
   },
 
-  // Show activity messages in the status bar for a few seconds.
-  // Example: Starting pyls ...
-  "show_status_messages": true,
-
   // Show permanent language server status in the status bar.
   "show_view_status": true,
 
@@ -164,7 +160,7 @@
   // Show in-line diagnostics using phantoms for unchanged files.
   "show_diagnostics_phantoms": false,
 
-  // Show errors and warnings count in the status bar 
+  // Show errors and warnings count in the status bar
   "show_diagnostics_count_in_view_status": false,
 
   // Show the diagnostics description of the code

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -86,24 +86,22 @@ def get_window_env(window: sublime.Window, config: ClientConfig):
 
 
 def start_window_config(window: sublime.Window, project_path: str, config: ClientConfig,
-                        on_created: 'Callable'):
+                        on_created: 'Callable', on_ended: 'Callable'):
     args, env = get_window_env(window, config)
     config.binary_args = args
     session = create_session(config, project_path, env, settings,
                              on_created=on_created,
-                             on_ended=lambda: on_session_ended(window, config.name))
+                             on_ended=lambda: on_session_ended(window, config.name, on_ended))
     clients_by_window.setdefault(window.id(), {})[config.name] = session
     debug("{} client registered for window {}".format(config.name, window.id()))
     return session
 
 
-def on_session_ended(window: sublime.Window, config_name: str):
+def on_session_ended(window: sublime.Window, config_name: str, on_ended_handler: 'Callable'):
+    on_ended_handler(config_name)
+    # todo: this needs to be cleaned up from window-specific logic
     configs = window_configs(window)
     del configs[config_name]
-    if not configs:
-        debug("all clients unloaded")
-        if clients_unloaded_handler:
-            clients_unloaded_handler(window.id())
 
 
 def set_config_stopping(window: sublime.Window, config_name: str):
@@ -212,11 +210,3 @@ def unload_old_clients(window: sublime.Window):
             debug('unload', config_name, 'project path changed from',
                   session.project_path, 'to', project_path)
             session.end()
-
-
-clients_unloaded_handler = None  # type: Optional[Callable]
-
-
-def register_clients_unloaded_handler(handler: 'Callable'):
-    global clients_unloaded_handler
-    clients_unloaded_handler = handler

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -94,6 +94,7 @@ def start_window_config(window: sublime.Window, project_path: str, config: Clien
                              on_ended=lambda: on_session_ended(window, config.name))
     clients_by_window.setdefault(window.id(), {})[config.name] = session
     debug("{} client registered for window {}".format(config.name, window.id()))
+    return session
 
 
 def on_session_ended(window: sublime.Window, config_name: str):

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -132,3 +132,12 @@ def is_supported_view(view: sublime.View) -> bool:
         return True
     else:
         return False
+
+
+class ConfigManager(object):
+    def is_supported(self, view: sublime.View) -> bool:
+        # todo: calls config_for_scope immediately.
+        return is_supported_view(view)
+
+    def scope_config(self, view: sublime.View) -> 'Optional[ClientConfig]':
+        return config_for_scope(view)

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -4,12 +4,14 @@ import sublime
 from .settings import ClientConfig, client_configs
 from .logging import debug
 from .workspace import get_project_config
+from .windows import ViewLike
 
 assert ClientConfig
 
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional
     assert Any and List and Dict and Tuple and Callable and Optional
+    assert ViewLike
 except ImportError:
     pass
 
@@ -135,9 +137,9 @@ def is_supported_view(view: sublime.View) -> bool:
 
 
 class ConfigManager(object):
-    def is_supported(self, view: sublime.View) -> bool:
+    def is_supported(self, view: 'Any') -> bool:
         # todo: calls config_for_scope immediately.
         return is_supported_view(view)
 
-    def scope_config(self, view: sublime.View) -> 'Optional[ClientConfig]':
+    def scope_config(self, view: 'Any') -> 'Optional[ClientConfig]':
         return config_for_scope(view)

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -5,12 +5,14 @@ from .url import uri_to_filename
 from .protocol import Diagnostic
 from .events import Events
 from .views import range_to_region
+from .windows import WindowLike, ViewLike
 
 assert Diagnostic
 
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional
     assert Any and List and Dict and Tuple and Callable and Optional
+    assert ViewLike and WindowLike
 except ImportError:
     pass
 
@@ -73,10 +75,10 @@ def remove_diagnostics(view: sublime.View, client_name: str):
 
 
 class GlobalDiagnostics(object):
-    def update(self, window: sublime.Window, client_name: str, update: dict):
+    def update(self, window: 'Any', client_name: str, update: dict):
         handle_client_diagnostics(window, client_name, update)
 
-    def remove(self, view: sublime.View, client_name: str):
+    def remove(self, view: 'Any', client_name: str):
         """Removes diagnostics for a file if no views exist for it
         """
         remove_diagnostics(view, client_name)

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -72,6 +72,16 @@ def remove_diagnostics(view: sublime.View, client_name: str):
             debug('file still open?')
 
 
+class GlobalDiagnostics(object):
+    def update(self, window: sublime.Window, client_name: str, update: dict):
+        handle_client_diagnostics(window, client_name, update)
+
+    def remove(self, view: sublime.View, client_name: str):
+        """Removes diagnostics for a file if no views exist for it
+        """
+        remove_diagnostics(view, client_name)
+
+
 def get_line_diagnostics(view, point):
     row, _ = view.rowcol(point)
     diagnostics = get_diagnostics_for_view(view)

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -263,4 +263,3 @@ class GlobalDocumentHandler(object):
 
     def notify_did_open(self, view: sublime.View):
         notify_did_open(view)
-

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -255,3 +255,12 @@ def initialize_document_sync(text_document_sync_kind):
     Events.subscribe('view.on_modified', queue_did_change)
     Events.subscribe('view.on_post_save_async', notify_did_save)
     Events.subscribe('view.on_close', notify_did_close)
+
+
+class GlobalDocumentHandler(object):
+    def initialize(self, text_document_sync_kind):
+        initialize_document_sync(text_document_sync_kind)
+
+    def notify_did_open(self, view: sublime.View):
+        notify_did_open(view)
+

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -265,3 +265,6 @@ class GlobalDocumentHandler(object):
 
     def notify_did_open(self, view: 'Any'):
         notify_did_open(view)
+
+    def reset(self, window: 'Any'):
+        clear_document_states(window)

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -2,13 +2,6 @@ import sublime
 import sublime_plugin
 
 from collections import OrderedDict
-
-try:
-    from typing import Any, List, Dict, Tuple, Callable, Optional
-    assert Any and List and Dict and Tuple and Callable and Optional
-except ImportError:
-    pass
-
 from .logging import debug
 from .protocol import Notification
 from .settings import settings
@@ -17,6 +10,15 @@ from .configurations import config_for_scope, is_supported_view, is_supported_sy
 from .clients import client_for_view, client_for_closed_view, check_window_unloaded
 from .events import Events
 from .views import offset_to_point
+from .windows import ViewLike
+
+try:
+    from typing import Any, List, Dict, Tuple, Callable, Optional
+    assert Any and List and Dict and Tuple and Callable and Optional
+    assert ViewLike
+except ImportError:
+    pass
+
 
 SUBLIME_WORD_MASK = 515
 
@@ -261,5 +263,5 @@ class GlobalDocumentHandler(object):
     def initialize(self, text_document_sync_kind):
         initialize_document_sync(text_document_sync_kind)
 
-    def notify_did_open(self, view: sublime.View):
+    def notify_did_open(self, view: 'Any'):
         notify_did_open(view)

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -9,12 +9,6 @@ from .workspace import get_project_path
 from .views import range_to_region
 
 
-def apply_workspace_edit(window, params):
-    edit = params.get('edit', dict())
-    window.run_command('lsp_apply_workspace_edit', {'changes': edit.get('changes'),
-                                                    'documentChanges': edit.get('documentChanges')})
-
-
 class LspApplyWorkspaceEditCommand(sublime_plugin.WindowCommand):
     def run(self, changes=None, documentChanges=None):
         # debug('workspace edit', changes)

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -1,4 +1,3 @@
-import os
 
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional, Set
@@ -9,30 +8,23 @@ except ImportError:
 import sublime_plugin
 import sublime
 
-from .protocol import Notification
 from .settings import (
     ClientConfig, settings, load_settings, unload_settings
 )
 from .handlers import LanguageHandler
-from .logging import debug, server_log, set_debug_logging
-from .rpc import attach_tcp_client, attach_stdio_client
-from .workspace import get_project_path
+from .logging import debug, set_debug_logging
 from .configurations import (
-    config_for_scope, is_supported_view, register_client_config, ConfigManager
+    is_supported_view, register_client_config, ConfigManager
 )
 from .clients import (
     start_window_config,
-    can_start_config,
-    window_configs, is_ready_window_config,
-    unload_old_clients, unload_window_sessions, unload_all_clients, register_clients_unloaded_handler
+    unload_window_sessions, unload_all_clients, register_clients_unloaded_handler
 )
 from .events import Events
 from .documents import (
-    initialize_document_sync, notify_did_open, clear_document_states, GlobalDocumentHandler
+    clear_document_states, GlobalDocumentHandler
 )
-from .diagnostics import handle_client_diagnostics, remove_diagnostics, GlobalDiagnostics
-from .edit import apply_workspace_edit
-from .process import start_server
+from .diagnostics import GlobalDiagnostics
 from .windows import WindowRegistry
 
 

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -18,7 +18,7 @@ from .logging import debug, server_log, set_debug_logging
 from .rpc import attach_tcp_client, attach_stdio_client
 from .workspace import get_project_path
 from .configurations import (
-    config_for_scope, is_supported_view, register_client_config
+    config_for_scope, is_supported_view, register_client_config, ConfigManager
 )
 from .clients import (
     start_window_config,
@@ -28,23 +28,30 @@ from .clients import (
 )
 from .events import Events
 from .documents import (
-    initialize_document_sync, notify_did_open, clear_document_states
+    initialize_document_sync, notify_did_open, clear_document_states, GlobalDocumentHandler
 )
-from .diagnostics import handle_client_diagnostics, remove_diagnostics
+from .diagnostics import handle_client_diagnostics, remove_diagnostics, GlobalDiagnostics
 from .edit import apply_workspace_edit
 from .process import start_server
+from .windows import WindowRegistry
+
+
+configs = ConfigManager()
+diagnostics = GlobalDiagnostics()
+documents = GlobalDocumentHandler()
+windows = WindowRegistry(configs, documents, diagnostics, start_window_config)
 
 
 def startup():
     load_settings()
     set_debug_logging(settings.log_debug)
     load_handlers()
-    Events.subscribe("view.on_load_async", initialize_on_open)
-    Events.subscribe("view.on_activated_async", initialize_on_open)
+    Events.subscribe("view.on_load_async", on_view_activated)
+    Events.subscribe("view.on_activated_async", on_view_activated)
     register_clients_unloaded_handler(handle_clients_unloaded)
     if settings.show_status_messages:
         sublime.status_message("LSP initialized")
-    start_active_views()
+    start_active_window()
 
 
 def shutdown():
@@ -52,58 +59,25 @@ def shutdown():
     unload_all_clients()
 
 
-def start_active_views():
+def start_active_window():
     window = sublime.active_window()
     if window:
-        views = list()  # type: List[sublime.View]
-        num_groups = window.num_groups()
-        for group in range(0, num_groups):
-            view = window.active_view_in_group(group)
-            if is_supported_view(view):
-                if window.active_group() == group:
-                    views.insert(0, view)
-                else:
-                    views.append(view)
+        windows.lookup(window).start_active_views()
 
-        if len(views) > 0:
-            first_view = views.pop(0)
-            debug('starting active=', first_view.file_name(), 'other=', len(views))
-            initialize_on_open(first_view)
-            if len(views) > 0:
-                for view in views:
-                    open_after_initialize_by_window[window.id()].append(view)
+
+def on_view_activated(view: sublime.View):
+    window = view.window()
+    if window:
+        windows.lookup(window).activate_view(view)
 
 
 TextDocumentSyncKindNone = 0
 TextDocumentSyncKindFull = 1
 TextDocumentSyncKindIncremental = 2
 
-open_after_initialize_by_window = dict()  # type: Dict[int, List[sublime.View]]
+# open_after_initialize_by_window = dict()  # type: Dict[int, List[sublime.View]]
 unsubscribe_initialize_on_load = None
 unsubscribe_initialize_on_activated = None
-
-
-def initialize_on_open(view: sublime.View):
-    window = view.window()
-
-    if not window:
-        return
-
-    debug("initialize on open", window.id(), view.file_name())
-
-    if window_configs(window):
-        unload_old_clients(window)
-
-    global didopen_after_initialize
-    open_after_initialize_by_window[window.id()] = []
-    config = config_for_scope(view)
-    if config:
-        if config.enabled:
-            if not is_ready_window_config(window, config.name):
-                open_after_initialize_by_window[window.id()].append(view)
-                start_window_client(view, window, config)
-        else:
-            debug(config.name, 'is not enabled')
 
 
 client_start_listeners = {}  # type: Dict[str, Callable]
@@ -122,126 +96,6 @@ def register_language_handler(handler: LanguageHandler) -> None:
         client_start_listeners[handler.name] = handler.on_start
     if handler.on_initialized:
         client_initialization_listeners[handler.name] = handler.on_initialized
-
-
-def handle_session_started(session, window, project_path, config):
-    client = session.client
-    client.set_crash_handler(lambda: handle_server_crash(window, config))
-    client.set_error_display_handler(lambda msg: sublime.status_message(msg))
-
-    # handle server requests and notifications
-    client.on_request(
-        "workspace/applyEdit",
-        lambda params: apply_workspace_edit(window, params))
-
-    client.on_request(
-        "window/showMessageRequest",
-        lambda params: handle_message_request(params))
-
-    client.on_notification(
-        "textDocument/publishDiagnostics",
-        lambda params: handle_client_diagnostics(window, config.name, params))
-
-    client.on_notification(
-        "window/showMessage",
-        lambda params: sublime.message_dialog(params.get("message")))
-
-    if settings.log_server:
-        client.on_notification(
-            "window/logMessage",
-            lambda params: server_log(params.get("message")))
-
-    if config.name in client_initialization_listeners:
-        client_initialization_listeners[config.name](client)
-
-    # TODO: These handlers is already filtered by syntax but does not need to
-    # be enabled 2x per client
-    # Move filtering?
-    document_sync = session.capabilities.get("textDocumentSync")
-    if document_sync:
-        initialize_document_sync(document_sync)
-
-    Events.subscribe('view.on_close', lambda view: remove_diagnostics(view, config.name))
-
-    client.send_notification(Notification.initialized())
-    if config.settings:
-        configParams = {
-            'settings': config.settings
-        }
-        client.send_notification(Notification.didChangeConfiguration(configParams))
-
-    for view in open_after_initialize_by_window[window.id()]:
-        notify_did_open(view)
-
-    if settings.show_status_messages:
-        window.status_message("{} initialized".format(config.name))
-    del open_after_initialize_by_window[window.id()]
-
-
-def start_client(window: sublime.Window, project_path: str, config: ClientConfig):
-
-    if config.name in client_start_listeners:
-        handler_startup_hook = client_start_listeners[config.name]
-        if not handler_startup_hook(window):
-            return
-
-    if settings.show_status_messages:
-        window.status_message("Starting " + config.name + "...")
-    debug("starting in", project_path)
-
-    # Create a dictionary of Sublime Text variables
-    variables = window.extract_variables()
-
-    # Expand language server command line environment variables
-    expanded_args = list(
-        sublime.expand_variables(os.path.expanduser(arg), variables)
-        for arg in config.binary_args
-    )
-
-    # Override OS environment variables
-    env = os.environ.copy()
-    for var, value in config.env.items():
-        # Expand both ST and OS environment variables
-        env[var] = os.path.expandvars(sublime.expand_variables(value, variables))
-
-    # TODO: don't start process if tcp already up or command empty?
-    process = start_server(expanded_args, project_path, env)
-    if not process:
-        window.status_message("Could not start " + config.name + ", disabling")
-        debug("Could not start", config.binary_args, ", disabling")
-        return None
-
-    if config.tcp_port is not None:
-        client = attach_tcp_client(config.tcp_port, process, settings)
-    else:
-        client = attach_stdio_client(process, settings)
-
-    if not client:
-        window.status_message("Could not connect to " + config.name + ", disabling")
-        return None
-
-    return client
-
-
-def start_window_client(view: sublime.View, window: sublime.Window, config: ClientConfig):
-    project_path = get_project_path(window)
-    if project_path is None:
-        debug('Cannot start without a project folder')
-        return
-
-    if can_start_config(window, config.name):
-        if config.name in client_start_listeners:
-            handler_startup_hook = client_start_listeners[config.name]
-            if not handler_startup_hook(window):
-                return
-
-        if settings.show_status_messages:
-            window.status_message("Starting " + config.name + "...")
-        debug("starting in", project_path)
-        start_window_config(window, project_path, config,
-                            lambda session: handle_session_started(session, window, project_path, config))
-    else:
-        debug('Already starting on this window:', config.name)
 
 
 def handle_server_crash(window: sublime.Window, config: ClientConfig):
@@ -264,7 +118,7 @@ def handle_clients_unloaded(window_id):
     debug('clients for window {} unloaded'.format(window_id))
     if window_id in restarting_window_ids:
         restarting_window_ids.remove(window_id)
-        start_active_views()
+        start_active_window()
 
 
 def handle_message_request(params: dict):
@@ -289,4 +143,4 @@ class LspStartClientCommand(sublime_plugin.TextCommand):
         return is_supported_view(self.view)
 
     def run(self, edit):
-        start_active_views()
+        start_active_window()

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -28,10 +28,21 @@ from .diagnostics import GlobalDiagnostics
 from .windows import WindowRegistry
 
 
+class SublimeUI(object):
+    def message_dialog(self, msg: str) -> None:
+        sublime.message_dialog(msg)
+
+    def ok_cancel_dialog(self, msg: str, ok_title: str) -> bool:
+        return sublime.ok_cancel_dialog(msg, ok_title)
+
+    def yes_no_cancel_dialog(self, msg, yes_title: str, no_title: str) -> int:
+        return sublime.yes_no_cancel_dialog(msg, yes_title, no_title)
+
+
 configs = ConfigManager()
 diagnostics = GlobalDiagnostics()
 documents = GlobalDocumentHandler()
-windows = WindowRegistry(configs, documents, diagnostics, start_window_config)
+windows = WindowRegistry(configs, documents, diagnostics, start_window_config, SublimeUI())
 
 
 def startup():
@@ -111,14 +122,6 @@ def handle_clients_unloaded(window_id):
     if window_id in restarting_window_ids:
         restarting_window_ids.remove(window_id)
         start_active_window()
-
-
-def handle_message_request(params: dict):
-    message = params.get("message", "(missing message)")
-    actions = params.get("actions", [])
-    addendum = "TODO: showMessageRequest with actions:"
-    titles = list(action.get("title") for action in actions)
-    sublime.message_dialog("\n".join([message, addendum] + titles))
 
 
 class LspRestartClientCommand(sublime_plugin.TextCommand):

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     pass
 
-from .logging import debug, exception_log
+from .logging import debug, exception_log, server_log
 from .protocol import Request, Notification
 from .types import Settings
 
@@ -197,7 +197,10 @@ class Client(object):
     def notification_handler(self, notification):
         method = notification.get("method")
         params = notification.get("params")
-        if method != "window/logMessage":
+        if method == "window/logMessage":
+            debug('<--  ' + method)
+            server_log(params.get("message"))
+        else:
             debug('<--  ' + method)
             if self.settings.log_payloads and params:
                 debug('     ' + str(params))

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -180,4 +180,4 @@ class Session(object):
         self.client = None
         self.capabilities = dict()
         if self._on_ended:
-            self._on_ended()
+            self._on_ended(self.config.name)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -141,7 +141,7 @@ def get_initialize_params(project_path: str, config: ClientConfig):
 
 class Session(object):
     def __init__(self, config: ClientConfig, project_path, client: Client,
-                 on_created, on_ended) -> None:
+                 on_created=None, on_ended=None) -> None:
         self.config = config
         self.project_path = project_path
         self.state = ClientStates.STARTING

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -43,7 +43,6 @@ def read_str_setting(settings_obj: sublime.Settings, key: str, default: str) -> 
 
 
 def update_settings(settings: Settings, settings_obj: sublime.Settings):
-    settings.show_status_messages = read_bool_setting(settings_obj, "show_status_messages", True)
     settings.show_view_status = read_bool_setting(settings_obj, "show_view_status", True)
     settings.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", True)
     settings.show_diagnostics_phantoms = read_bool_setting(settings_obj, "show_diagnostics_phantoms", False)

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -37,6 +37,9 @@ class TestClient():
     def set_error_display_handler(self, handler: 'Callable') -> None:
         pass
 
+    def set_crash_handler(self, handler: 'Callable') -> None:
+        pass
+
 
 test_config = ClientConfig("test", [], None, ["source.test"], ["Test.sublime-syntax"], "test")
 

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -59,7 +59,6 @@ class SessionTest(unittest.TestCase):
         created_callback.assert_called_once()
 
     def test_can_shutdown_session(self):
-        config = ClientConfig("test", [], None, ["source.test"], ["Test.sublime-syntax"], "test")
         project_path = "/"
         created_callback = unittest.mock.Mock()
         ended_callback = unittest.mock.Mock()

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -16,19 +16,22 @@ except ImportError:
 
 
 class TestClient():
-    def __init__(self):
+    def __init__(self) -> None:
         self.responses = {
             'initialize': {"capabilities": dict(testing=True)}
         }  # type: dict
 
-    def send_request(self, request: Request, on_success: 'Callable', on_error: 'Callable'=None):
+    def send_request(self, request: Request, on_success: 'Callable', on_error: 'Callable'=None) -> None:
         response = self.responses.get(request.method)
         on_success(response)
 
-    def send_notification(self, notification: Notification):
+    def send_notification(self, notification: Notification) -> None:
         pass
 
-    def on_notification(self, name, handler: 'Callable'):
+    def on_notification(self, name, handler: 'Callable') -> None:
+        pass
+
+    def set_error_display_handler(self, handler: 'Callable') -> None:
         pass
 
 

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -29,8 +29,7 @@ class TestClient():
         pass
 
 
-def attach_test_client():
-    return TestClient()
+test_config = ClientConfig("test", [], None, ["source.test"], ["Test.sublime-syntax"], "test")
 
 
 class SessionTest(unittest.TestCase):
@@ -46,10 +45,9 @@ class SessionTest(unittest.TestCase):
         # self.assertIsNone(session.capabilities) -- empty dict
 
     def test_can_get_started_session(self):
-        config = ClientConfig("test", [], None, ["source.test"], ["Test.sublime-syntax"], "test")
         project_path = "/"
         created_callback = unittest.mock.Mock()
-        session = create_session(config, project_path, dict(), Settings(),
+        session = create_session(test_config, project_path, dict(), Settings(),
                                  bootstrap_client=TestClient(),
                                  on_created=created_callback)
 
@@ -65,7 +63,7 @@ class SessionTest(unittest.TestCase):
         project_path = "/"
         created_callback = unittest.mock.Mock()
         ended_callback = unittest.mock.Mock()
-        session = create_session(config, project_path, dict(), Settings(),
+        session = create_session(test_config, project_path, dict(), Settings(),
                                  bootstrap_client=TestClient(),
                                  on_created=created_callback,
                                  on_ended=ended_callback)

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -28,6 +28,9 @@ class TestClient():
     def send_notification(self, notification: Notification):
         pass
 
+    def on_notification(self, name, handler: 'Callable'):
+        pass
+
 
 test_config = ClientConfig("test", [], None, ["source.test"], ["Test.sublime-syntax"], "test")
 

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -31,6 +31,9 @@ class TestClient():
     def on_notification(self, name, handler: 'Callable') -> None:
         pass
 
+    def on_request(self, name, handler: 'Callable') -> None:
+        pass
+
     def set_error_display_handler(self, handler: 'Callable') -> None:
         pass
 

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -1,27 +1,27 @@
-from .windows import WindowManager, WindowState, WindowLike
+from .windows import WindowManager, WindowRegistry, WindowLike
 from .sessions import Session
 from .test_session import TestClient, test_config
 
 import unittest
 
 
-class WindowsTests(unittest.TestCase):
+class WindowRegistryTests(unittest.TestCase):
 
     def test_can_get_window_state(self):
-        windows = WindowManager()
+        windows = WindowRegistry(None, None, None, None)
         test_window = WindowLike()
         window_state = windows.lookup(test_window)
         self.assertIsNotNone(window_state)
 
 
-class WindowStateTests(unittest.TestCase):
+class WindowManagerTests(unittest.TestCase):
 
     def test_has_no_sessions(self):
-        state = WindowState()
+        state = WindowManager(None, None, None, None, None)
         self.assertIsNone(state.get_session('asdf'))
 
     def test_can_add_session(self):
-        state = WindowState()
+        state = WindowManager(None, None, None, None, None)
         self.assertIsNone(state.get_session('asdf'))
         state.add_session('asdf', Session(test_config, "", TestClient()))
         self.assertIsNotNone(state.get_session('asdf'))

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -1,8 +1,56 @@
 from .windows import WindowManager, WindowRegistry, WindowLike
-from .sessions import Session
+from .sessions import Session, create_session
 from .test_session import TestClient, test_config
-
+from .test_rpc import TestSettings
+import os
 import unittest
+
+
+class TestView(object):
+    def __init__(self, file_name):
+        self._file_name = file_name
+
+    def file_name(self):
+        return self._file_name
+
+
+class TestWindow(object):
+    def id(self):
+        return 0
+
+    def folders(self):
+        return [os.path.dirname(__file__)]
+
+    def num_groups(self):
+        return 1
+
+    def active_group(self):
+        return 0
+
+    def active_view_in_group(self, group):
+        return TestView(__file__)
+
+
+class TestConfigs(object):
+    def is_supported(self, view):
+        return True
+
+    def scope_config(self, view):
+        return test_config
+
+
+class TestDocuments(object):
+    def __init__(self):
+        self._documents = []
+
+    def notify_did_open(self, view: TestView):
+        self._documents.append(view.file_name())
+
+
+def test_start_session(window, project_path, config, on_created: 'Callable'):
+    return create_session(test_config, project_path, dict(), TestSettings(),
+                          bootstrap_client=TestClient(),
+                          on_created=on_created)
 
 
 class WindowRegistryTests(unittest.TestCase):
@@ -10,21 +58,32 @@ class WindowRegistryTests(unittest.TestCase):
     def test_can_get_window_state(self):
         windows = WindowRegistry(None, None, None, None)
         test_window = WindowLike()
-        window_state = windows.lookup(test_window)
-        self.assertIsNotNone(window_state)
+        wm = windows.lookup(test_window)
+        self.assertIsNotNone(wm)
 
 
 class WindowManagerTests(unittest.TestCase):
 
     def test_has_no_sessions(self):
-        state = WindowManager(None, None, None, None, None)
-        self.assertIsNone(state.get_session('asdf'))
+        wm = WindowManager(None, None, None, None, None)
+        self.assertIsNone(wm.get_session('asdf'))
 
     def test_can_add_session(self):
-        state = WindowManager(None, None, None, None, None)
-        self.assertIsNone(state.get_session('asdf'))
-        state.add_session('asdf', Session(test_config, "", TestClient()))
-        self.assertIsNotNone(state.get_session('asdf'))
+        wm = WindowManager(None, None, None, None, None)
+        self.assertIsNone(wm.get_session('asdf'))
+        wm.add_session('asdf', Session(test_config, "", TestClient()))
+        self.assertIsNotNone(wm.get_session('asdf'))
+
+    def test_can_start_active_views(self):
+        docs = TestDocuments()
+        wm = WindowManager(TestWindow(), TestConfigs(), docs, None, test_start_session)
+        wm.start_active_views()
+
+        # session must be started (todo: verify session is ready)
+        self.assertIsNotNone(wm.get_session(test_config.name))
+
+        #
+        self.assertListEqual(docs._documents, [__file__])
 
     # def test_can_(self):
     #     state = WindowState()

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -11,6 +11,20 @@ except ImportError:
     pass
 
 
+class TestSublimeGlobal(object):
+    def __init__(self):
+        pass
+
+    def message_dialog(self, msg: str) -> None:
+        pass
+
+    def ok_cancel_dialog(self, msg: str, ok_title: str) -> bool:
+        return True
+
+    def yes_no_cancel_dialog(self, msg, yes_title: str, no_title: str) -> int:
+        return 1
+
+
 class TestView(object):
     def __init__(self, file_name):
         self._file_name = file_name
@@ -94,7 +108,8 @@ def test_start_session(window, project_path, config, on_created: 'Callable'):
 class WindowRegistryTests(unittest.TestCase):
 
     def test_can_get_window_state(self):
-        windows = WindowRegistry(TestConfigs(), TestDocuments(), TestDiagnostics(), test_start_session)
+        windows = WindowRegistry(TestConfigs(), TestDocuments(), TestDiagnostics(), test_start_session,
+                                 TestSublimeGlobal())
         test_window = TestWindow()
         wm = windows.lookup(test_window)
         self.assertIsNotNone(wm)
@@ -105,7 +120,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_start_active_views(self):
         docs = TestDocuments()
         wm = WindowManager(TestWindow([[TestView(__file__)]]), TestConfigs(), docs,
-                           TestDiagnostics(), test_start_session)
+                           TestDiagnostics(), test_start_session, TestSublimeGlobal())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -117,7 +132,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_open_supported_view(self):
         docs = TestDocuments()
         window = TestWindow([[]])
-        wm = WindowManager(window, TestConfigs(), docs, TestDiagnostics(), test_start_session)
+        wm = WindowManager(window, TestConfigs(), docs, TestDiagnostics(), test_start_session, TestSublimeGlobal())
 
         wm.start_active_views()
         self.assertIsNone(wm.get_session(test_config.name))

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -12,6 +12,10 @@ except ImportError:
 
 
 class TestSublimeGlobal(object):
+    DIALOG_CANCEL = 0
+    DIALOG_YES = 1
+    DIALOG_NO = 2
+
     def __init__(self):
         pass
 
@@ -22,7 +26,7 @@ class TestSublimeGlobal(object):
         return True
 
     def yes_no_cancel_dialog(self, msg, yes_title: str, no_title: str) -> int:
-        return 1
+        return self.DIALOG_YES
 
 
 class TestView(object):
@@ -99,10 +103,11 @@ class TestDiagnostics(object):
         pass
 
 
-def test_start_session(window, project_path, config, on_created: 'Callable'):
+def test_start_session(window, project_path, config, on_created: 'Callable', on_ended: 'Callable'):
     return create_session(test_config, project_path, dict(), TestSettings(),
                           bootstrap_client=TestClient(),
-                          on_created=on_created)
+                          on_created=on_created,
+                          on_ended=on_ended)
 
 
 class WindowRegistryTests(unittest.TestCase):

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -49,6 +49,9 @@ class TestWindow(object):
             else:
                 return TestView(None)
 
+    def status_message(self, msg: str) -> None:
+        pass
+
 
 class TestConfigs(object):
     def is_supported(self, view):
@@ -98,16 +101,6 @@ class WindowRegistryTests(unittest.TestCase):
 
 
 class WindowManagerTests(unittest.TestCase):
-
-    # def test_has_no_sessions(self):
-    #     wm = WindowManager(TestWindow(), TestConfigs(), docs, None, test_start_session)
-    #     self.assertIsNone(wm.get_session('asdf'))
-
-    # def test_can_add_session(self):
-    #     wm = WindowManager(TestWindow(), TestConfigs(), docs, None, test_start_session)
-    #     self.assertIsNone(wm.get_session('asdf'))
-    #     wm.add_session('asdf', Session(test_config, "", TestClient()))
-    #     self.assertIsNotNone(wm.get_session('asdf'))
 
     def test_can_start_active_views(self):
         docs = TestDocuments()

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -2,6 +2,7 @@ from .windows import WindowManager, WindowRegistry, WindowLike, ViewLike
 from .sessions import create_session
 from .test_session import TestClient, test_config
 from .test_rpc import TestSettings
+# from .logging import set_debug_logging, debug
 import os
 import unittest
 try:
@@ -91,6 +92,9 @@ class TestDocuments(object):
         if file_name:
             self._documents.append(file_name)
 
+    def reset(self, window):
+        self._documents = []
+
 
 class TestDiagnostics(object):
     def __init__(self):
@@ -146,4 +150,44 @@ class WindowManagerTests(unittest.TestCase):
         # session must be started (todo: verify session is ready)
         wm.activate_view(TestView(__file__))
         self.assertIsNotNone(wm.get_session(test_config.name))
+        self.assertListEqual(docs._documents, [__file__])
+
+    def test_can_restart_sessions(self):
+        docs = TestDocuments()
+        wm = WindowManager(TestWindow([[TestView(__file__)]]), TestConfigs(), docs,
+                           TestDiagnostics(), test_start_session, TestSublimeGlobal())
+        wm.start_active_views()
+
+        # session must be started (todo: verify session is ready)
+        self.assertIsNotNone(wm.get_session(test_config.name))
+
+        # our starting document must be loaded
+        self.assertListEqual(docs._documents, [__file__])
+
+        wm.restart_sessions()
+
+        # session must be started (todo: verify session is ready)
+        self.assertIsNotNone(wm.get_session(test_config.name))
+
+        # our starting document must be loaded
+        self.assertListEqual(docs._documents, [__file__])
+
+    def test_offers_restart_on_crash(self):
+        docs = TestDocuments()
+        wm = WindowManager(TestWindow([[TestView(__file__)]]), TestConfigs(), docs,
+                           TestDiagnostics(), test_start_session, TestSublimeGlobal())
+        wm.start_active_views()
+
+        # session must be started (todo: verify session is ready)
+        self.assertIsNotNone(wm.get_session(test_config.name))
+
+        # our starting document must be loaded
+        self.assertListEqual(docs._documents, [__file__])
+
+        wm._handle_server_crash(test_config)
+
+        # session must be started (todo: verify session is ready)
+        self.assertIsNotNone(wm.get_session(test_config.name))
+
+        # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -25,3 +25,7 @@ class WindowStateTests(unittest.TestCase):
         self.assertIsNone(state.get_session('asdf'))
         state.add_session('asdf', Session(test_config, "", TestClient()))
         self.assertIsNotNone(state.get_session('asdf'))
+
+    # def test_can_(self):
+    #     state = WindowState()
+    #     state.request_session

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -1,0 +1,27 @@
+from .windows import WindowManager, WindowState, WindowLike
+from .sessions import Session
+from .test_session import TestClient, test_config
+
+import unittest
+
+
+class WindowsTests(unittest.TestCase):
+
+    def test_can_get_window_state(self):
+        windows = WindowManager()
+        test_window = WindowLike()
+        window_state = windows.lookup(test_window)
+        self.assertIsNotNone(window_state)
+
+
+class WindowStateTests(unittest.TestCase):
+
+    def test_has_no_sessions(self):
+        state = WindowState()
+        self.assertIsNone(state.get_session('asdf'))
+
+    def test_can_add_session(self):
+        state = WindowState()
+        self.assertIsNone(state.get_session('asdf'))
+        state.add_session('asdf', Session(test_config, "", TestClient()))
+        self.assertIsNotNone(state.get_session('asdf'))

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -116,3 +116,6 @@ class WindowLike(Protocol):
 
     def active_view(self) -> 'Optional[ViewLike]':
         ...
+
+    def status_message(self, msg: str) -> None:
+        ...

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -119,3 +119,15 @@ class WindowLike(Protocol):
 
     def status_message(self, msg: str) -> None:
         ...
+
+
+class SublimeGlobal(Protocol):
+
+    def message_dialog(self, msg: str) -> None:
+        ...
+
+    def ok_cancel_dialog(self, msg: str, ok_title: str) -> bool:
+        ...
+
+    def yes_no_cancel_dialog(self, msg, yes_title: str, no_title: str) -> int:
+        ...

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -122,6 +122,9 @@ class WindowLike(Protocol):
 
 
 class SublimeGlobal(Protocol):
+    DIALOG_CANCEL = 0  # type: int
+    DIALOG_YES = 1  # type: int
+    DIALOG_NO = 2  # type: int
 
     def message_dialog(self, msg: str) -> None:
         ...

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -1,3 +1,12 @@
+try:
+    from typing_extensions import Protocol
+    from typing import Optional, List, Callable, Dict
+    assert Optional and List and Callable and Dict
+except ImportError:
+    pass
+    Protocol = object  # type: ignore
+
+
 class Settings(object):
 
     def __init__(self):
@@ -76,3 +85,34 @@ class ClientConfig(object):
             self.settings = settings.get("settings", dict())
         if "env" in settings:
             self.env = settings.get("env", dict())
+
+
+class ViewLike(Protocol):
+    def __init__(self):
+        pass
+
+    def file_name(self) -> 'Optional[str]':
+        ...
+
+
+class WindowLike(Protocol):
+    def id(self) -> int:
+        ...
+
+    def folders(self) -> 'List[str]':
+        ...
+
+    def num_groups(self) -> int:
+        ...
+
+    def active_group(self) -> int:
+        ...
+
+    def active_view_in_group(self, group) -> ViewLike:
+        ...
+
+    def project_data(self) -> 'Optional[dict]':
+        ...
+
+    def active_view(self) -> 'Optional[ViewLike]':
+        ...

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,4 +1,8 @@
 from .sessions import Session
+from .logging import debug
+from .types import ClientStates, ClientConfig
+from .protocol import Notification
+from .workspace import get_project_path
 
 
 class WindowLike(object):
@@ -6,21 +10,63 @@ class WindowLike(object):
         return 0
 
 
+class ViewLike(object):
+    def __init__(self):
+        pass
+
+
+class ConfigRegistry(object):
+    def is_supported(self, view: ViewLike) -> bool:
+        # todo: calls config_for_scope immediately.
+        pass
+
+    def scope_config(self, view: ViewLike) -> 'Optional[ClientConfig]':
+        pass
+
+
+class DiagnosticsHandler(object):
+    def update(window: WindowLike, client_name: str, update: dict):
+        pass
+
+    def remove(view: ViewLike, client_name: str):
+        pass
+
+
+class DocumentHandler(object):
+    def initialize(text_document_sync_kind):
+        pass
+
+    def notify_did_open(view: ViewLike):
+        pass
+
+
+def get_active_views(window: WindowLike):
+    views = list()  # type: List[sublime.View]
+    num_groups = window.num_groups()
+    for group in range(0, num_groups):
+        view = window.active_view_in_group(group)
+        if window.active_group() == group:
+            views.insert(0, view)
+        else:
+            views.append(view)
+
+    return views
+
+
 class WindowManager(object):
-    def __init__(self):
-        self._windows = {}  # type: Dict[int, WindowState]
+    def __init__(self, window: WindowLike, configs: ConfigRegistry, documents: DocumentHandler,
+                 diagnostics: DiagnosticsHandler, session_starter: 'Callable'):
 
-    def lookup(self, window: WindowLike):
-        state = self._windows.get(window.id())
-        if state is None:
-            state = WindowState()
-            self._windows[window.id()] = state
-        return state
-
-
-class WindowState(object):
-    def __init__(self):
+        # to move here:
+        # configurations.py: window_client_configs and all references
+        # clients.py: clients_by_window and all references
+        self._window = window
+        self._configs = configs
+        self._diagnostics = diagnostics
+        self._documents = documents
         self._sessions = dict()  # type: Dict[str, Session]
+        self._start_session = session_starter
+        self._open_after_initialize = []  # type: List[ViewLike]
 
     def get_session(self, config_name: str) -> 'Optional[Session]':
         return self._sessions.get(config_name)
@@ -30,3 +76,141 @@ class WindowState(object):
             self._sessions[config_name] = session
         else:
             raise Exception("session already added")
+
+    def _is_session_ready(self, config_name: str):
+        if config_name not in self._sessions:
+            return False
+
+        if self._sessions[config_name].state == ClientStates.READY:
+            return True
+
+        return False
+
+    def _can_start_config(self, config_name: str):
+        return config_name not in self._sessions
+
+    def start_active_views(self):
+        active_views = get_active_views(self._window)
+        startable_views = list(filter(self._configs.is_supported, active_views))
+
+        if len(startable_views) > 0:
+            first_view = startable_views.pop(0)
+            debug('starting active=', first_view.file_name(), 'other=', len(startable_views))
+            self._initialize_on_open(first_view)
+            if len(startable_views) > 0:
+                for view in startable_views:
+                    self._open_after_initialize.append(view)
+
+    def activate_view(self, view: ViewLike):
+        # TODO: we can shortcut here by checking documentstate.
+        self._initialize_on_open(view)
+
+    def _initialize_on_open(self, view: ViewLike):
+        debug("initialize on open", self._window.id(), view.file_name())
+
+        # TODO: move this back to main.py?
+        # if window_configs(window):
+        #     unload_old_clients(window)
+
+        self._open_after_initialize = []
+        config = self._configs.scope_config(view)
+        if config:
+            if config.enabled:
+                if not self._is_session_ready(config.name):
+                    # TODO: this assumes the 2nd, 3rd, 4th view all have the same config
+                    self._open_after_initialize.append(view)
+                    self._start_client(view, config)
+            else:
+                debug(config.name, 'is not enabled')
+
+    def _start_client(self, view: ViewLike, config: ClientConfig):
+        # TODO: CONTINUE FROM HERE
+        project_path = get_project_path(self._window)
+        if project_path is None:
+            debug('Cannot start without a project folder')
+            return
+
+        if self._can_start_config(config.name):
+            # TODO: re-enable
+            # if config.name in client_start_listeners:
+                # handler_startup_hook = client_start_listeners[config.name]
+                # if not handler_startup_hook(window):
+                #     return
+
+            # if settings.show_status_messages:
+            #     self._window.status_message("Starting " + config.name + "...")
+            debug("starting in", project_path)
+            self._start_session(self._window, project_path, config,
+                                lambda session: self._handle_session_started(session, project_path, config))
+        else:
+            debug('Already starting on this window:', config.name)
+
+    def _handle_session_started(self, session, project_path, config):
+        client = session.client
+        # client.set_crash_handler(lambda: handle_server_crash(self._window, config))
+        # client.set_error_display_handler(lambda msg: sublime.status_message(msg))
+
+        # # handle server requests and notifications
+        # client.on_request(
+        #     "workspace/applyEdit",
+        #     lambda params: apply_workspace_edit(self._window, params))
+
+        # client.on_request(
+        #     "window/showMessageRequest",
+        #     lambda params: handle_message_request(params))
+
+        client.on_notification(
+            "textDocument/publishDiagnostics",
+            lambda params: self._diagnostics.update(self._window, config.name, params))
+
+        # client.on_notification(
+        #     "window/showMessage",
+        #     lambda params: sublime.message_dialog(params.get("message")))
+
+        # if settings.log_server:
+        #     client.on_notification(
+        #         "window/logMessage",
+        #         lambda params: server_log(params.get("message")))
+
+        # if config.name in client_initialization_listeners:
+        #     client_initialization_listeners[config.name](client)
+
+        # TODO: These handlers is already filtered by syntax but does not need to
+        # be enabled 2x per client
+        # Move filtering?
+        document_sync = session.capabilities.get("textDocumentSync")
+        if document_sync:
+            self._documents.initialize(document_sync)
+
+        # Events.subscribe('view.on_close', lambda view: self._diagnostics.remove(view, config.name))
+
+        client.send_notification(Notification.initialized())
+        if config.settings:
+            configParams = {
+                'settings': config.settings
+            }
+            client.send_notification(Notification.didChangeConfiguration(configParams))
+
+        for view in self._open_after_initialize:
+            self._documents.notify_did_open(view)
+
+        # if settings.show_status_messages:
+        #     window.status_message("{} initialized".format(config.name))
+        self._open_after_initialize.clear()
+
+
+class WindowRegistry(object):
+    def __init__(self, configs: ConfigRegistry, documents: DocumentHandler, diagnostics: DiagnosticsHandler,
+                 session_starter: 'Callable'):
+        self._windows = {}  # type: Dict[int, WindowManager]
+        self._configs = configs
+        self._diagnostics = diagnostics
+        self._documents = documents
+        self._session_starter = session_starter
+
+    def lookup(self, window: WindowLike) -> WindowManager:
+        state = self._windows.get(window.id())
+        if state is None:
+            state = WindowManager(window, self._configs, self._documents, self._diagnostics, self._session_starter)
+            self._windows[window.id()] = state
+        return state

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,0 +1,32 @@
+from .sessions import Session
+
+
+class WindowLike(object):
+    def id(self):
+        return 0
+
+
+class WindowManager(object):
+    def __init__(self):
+        self._windows = {}  # type: Dict[int, WindowState]
+
+    def lookup(self, window: WindowLike):
+        state = self._windows.get(window.id())
+        if state is None:
+            state = WindowState()
+            self._windows[window.id()] = state
+        return state
+
+
+class WindowState(object):
+    def __init__(self):
+        self._sessions = dict()  # type: Dict[str, Session]
+
+    def get_session(self, config_name: str) -> 'Optional[Session]':
+        return self._sessions.get(config_name)
+
+    def add_session(self, config_name: str, session: Session) -> None:
+        if config_name not in self._sessions:
+            self._sessions[config_name] = session
+        else:
+            raise Exception("session already added")

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -152,15 +152,20 @@ class WindowManager(object):
             debug("unloading session", config_name)
             session.end()
 
+    def _apply_workspace_edit(self, params):
+        edit = params.get('edit', dict())
+        self._window.run_command('lsp_apply_workspace_edit', {'changes': edit.get('changes'),
+                                                              'documentChanges': edit.get('documentChanges')})
+
     def _handle_session_started(self, session, project_path, config):
         client = session.client
         client.set_crash_handler(lambda: self._handle_server_crash(config))
         client.set_error_display_handler(lambda msg: self._window.status_message(msg))
 
-        # # handle server requests and notifications
-        # client.on_request(
-        #     "workspace/applyEdit",
-        #     lambda params: apply_workspace_edit(self._window, params))
+        # handle server requests and notifications
+        client.on_request(
+            "workspace/applyEdit",
+            lambda params: self._apply_workspace_edit(params))
 
         client.on_request(
             "window/showMessageRequest",

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -124,7 +124,6 @@ class WindowManager(object):
                 debug(config.name, 'is not enabled')
 
     def _start_client(self, view: ViewLike, config: ClientConfig):
-        # TODO: CONTINUE FROM HERE
         project_path = get_project_path(self._window)
         if project_path is None:
             debug('Cannot start without a project folder')
@@ -140,8 +139,9 @@ class WindowManager(object):
             # if settings.show_status_messages:
             #     self._window.status_message("Starting " + config.name + "...")
             debug("starting in", project_path)
-            self._start_session(self._window, project_path, config,
-                                lambda session: self._handle_session_started(session, project_path, config))
+            session = self._start_session(self._window, project_path, config,
+                                          lambda session: self._handle_session_started(session, project_path, config))
+            self._sessions[config.name] = session
         else:
             debug('Already starting on this window:', config.name)
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,3 +1,4 @@
+from .events import Events
 from .logging import debug
 from .types import ClientStates, ClientConfig, WindowLike, ViewLike
 from .protocol import Notification
@@ -157,11 +158,6 @@ class WindowManager(object):
         #     "window/showMessage",
         #     lambda params: sublime.message_dialog(params.get("message")))
 
-        # if settings.log_server:
-        #     client.on_notification(
-        #         "window/logMessage",
-        #         lambda params: server_log(params.get("message")))
-
         # if config.name in client_initialization_listeners:
         #     client_initialization_listeners[config.name](client)
 
@@ -172,7 +168,7 @@ class WindowManager(object):
         if document_sync:
             self._documents.initialize(document_sync)
 
-        # Events.subscribe('view.on_close', lambda view: self._diagnostics.remove(view, config.name))
+        Events.subscribe('view.on_close', lambda view: self._diagnostics.remove(view, config.name))
 
         client.send_notification(Notification.initialized())
         if config.settings:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,5 +1,4 @@
 import os
-import sublime
 try:
     from typing import List, Optional
     assert List and Optional
@@ -9,7 +8,17 @@ except ImportError:
 from .logging import debug
 
 
-def get_project_path(window: sublime.Window) -> 'Optional[str]':
+class WindowLike(object):
+    def id(self):
+        return 0
+
+
+class ViewLike(object):
+    def __init__(self):
+        pass
+
+
+def get_project_path(window: WindowLike) -> 'Optional[str]':
     """
     Returns the common root of all open folders in the window
     """
@@ -44,7 +53,7 @@ def get_common_parent(paths: 'List[str]') -> str:
     return os.path.commonprefix([path + '/' for path in paths]).rstrip('/')
 
 
-def is_in_workspace(window: sublime.Window, file_path: str) -> bool:
+def is_in_workspace(window: WindowLike, file_path: str) -> bool:
     workspace_path = get_project_path(window)
     if workspace_path is None:
         return False
@@ -71,7 +80,7 @@ def disable_in_project(window, config_name: str) -> None:
     window.set_project_data(project_data)
 
 
-def get_project_config(window: sublime.Window) -> dict:
+def get_project_config(window: WindowLike) -> dict:
     project_data = window.project_data() or dict()
     project_settings = project_data.setdefault('settings', dict())
     project_lsp_settings = project_settings.setdefault('LSP', dict())

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -6,16 +6,7 @@ except ImportError:
     pass
 
 from .logging import debug
-
-
-class WindowLike(object):
-    def id(self):
-        return 0
-
-
-class ViewLike(object):
-    def __init__(self):
-        pass
+from .types import WindowLike
 
 
 def get_project_path(window: WindowLike) -> 'Optional[str]':


### PR DESCRIPTION
This makes some of the core behaviour around startup, failure, restarting and language handler hooks tested.

Some ugly stuff introduced:
* Some hastily done typing (at times poorly named) resolves to using `Any` where eg. `ViewLike` meets `sublime.View`
  * This is hopefully temporary
* modules like clients and configuration expose a shim over their global state
  * The hope is to remove remaining global-dict-by-window-id state gradually.