### PR TITLE
Dedicated server writing thread

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -119,14 +119,8 @@ class Client(object):
             self._crash_handler()
 
     def send_payload(self, payload: 'Dict[str, Any]') -> None:
-        if self.transport:
-            try:
-                message = format_request(payload)
-                self.transport.send(message)
-            except Exception as err:
-                self._error_display_handler("Failure sending LSP server message, exiting")
-                exception_log("Failure writing payload", err)
-                self.handle_transport_failure()
+        message = format_request(payload)
+        self.transport.send(message)
 
     def receive_payload(self, message: str) -> None:
         payload = None

--- a/plugin/core/test_rpc.py
+++ b/plugin/core/test_rpc.py
@@ -138,20 +138,6 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(len(responses), 0)
         self.assertGreater(len(errors), 0)
 
-    def test_forwards_transport_error(self):
-        set_exception_logging(False)
-        transport = TestTransport(raise_error)
-        settings = TestSettings()
-        client = Client(transport, settings)
-        errors = []
-        client.set_transport_failure_handler(lambda: errors.append(""))
-        self.assertTrue(transport.has_started)
-        responses = []
-        req = Request.initialize(dict())
-        client.send_request(req, lambda resp: responses.append(resp))
-        self.assertEqual(len(responses), 0)
-        self.assertGreater(len(errors), 0)
-
     def test_handles_transport_closed_unexpectedly(self):
         set_exception_logging(False)
         transport = TestTransport(raise_error)

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -60,14 +60,18 @@ def start_tcp_transport(port: int):
 class TCPTransport(Transport):
     def __init__(self, socket: 'Any') -> None:
         self.socket = socket  # type: 'Optional[Any]'
+        self.send_queue = Queue()  # type: Queue[Optional[str]]
 
     def start(self, on_receive: 'Callable[[str], None]', on_closed: 'Callable[[], None]') -> None:
         self.on_receive = on_receive
         self.on_closed = on_closed
         self.read_thread = threading.Thread(target=self.read_socket)
         self.read_thread.start()
+        self.write_thread = threading.Thread(target=self.write_socket)
+        self.write_thread.start()
 
     def close(self) -> None:
+        self.send_queue.put(None)  # kill the write thread as it's blocked on send_queue
         self.socket = None
         self.on_closed()
 
@@ -119,14 +123,19 @@ class TCPTransport(Transport):
                         remaining_data = data
 
     def send(self, message: str) -> None:
-        try:
-            if self.socket:
-                # debug('socket send')
-                self.socket.sendall(bytes(message, 'UTF-8'))
-        except Exception as err:
-            exception_log("Failure writing to socket", err)
-            self.socket = None
-            self.on_closed()
+        self.send_queue.put(message)
+
+    def write_socket(self) -> None:
+        while self.socket:
+            message = self.send_queue.get()
+            if message is None:
+                break
+            else:
+                try:
+                    self.socket.sendall(bytes(message, 'UTF-8'))
+                except Exception as err:
+                    exception_log("Failure writing to socket", err)
+                    self.close()
 
 
 class StdioTransport(Transport):


### PR DESCRIPTION
As suggested by @Kronuz in his fork, instead of any sublime thread blocking on writing stdio/socket, now a dedicated thread takes messages from a queue.

No longer seeing sublime hangs while triggering various messages during lsp-tsserver startup.

This should fix #287.