### PR TITLE
Update default PHP settings to match docs

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -73,7 +73,7 @@
     },
     "phpls":
     {
-        "command": ["php", "~/vendor/felixfbecker/language-server/bin/php-language-server.php"],
+        "command": ["php", "/PATH-TO-HOME-DIR/.composer/vendor/felixfbecker/language-server/bin/php-language-server.php"],
         "scopes": ["source.php", "embedding.php"],
         "syntaxes": ["Packages/PHP/PHP.sublime-syntax"],
         "languageId": "php"


### PR DESCRIPTION
I was a little confused by the default settings which made it seem like tilde expansion in the `command` should work.  This PR changes the example to match the docs, which should hopefully make it clearer that you need to use the absolute path.