### PR TITLE
Add missing CRLF after JSON RPC message

### DIFF
--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -25,7 +25,7 @@ def format_request(payload: 'Dict[str, Any]') -> str:
     """Converts the request into json and adds the Content-Length header"""
     content = json.dumps(payload, sort_keys=False)
     content_length = len(content)
-    result = "Content-Length: {}\r\n\r\n{}".format(content_length, content)
+    result = "Content-Length: {}\r\n\r\n{}\r\n".format(content_length, content)
     return result
 
 


### PR DESCRIPTION
This is not explicitly mentioned in the specification, but shouldn't it be this way?