### PR TITLE
Exclude some folders in project for LSP #435

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -77,6 +77,7 @@ def apply_window_settings(client_config: 'ClientConfig', window: 'sublime.Window
             client_settings,
             client_env,
             overrides.get("tcp_host", client_config.tcp_host),
+            overrides.get("sub_folder", client_config.sub_folder),
         )
 
     return client_config

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -164,7 +164,8 @@ def read_client_config(name: str, client_config: 'Dict') -> ClientConfig:
         client_config.get("initializationOptions", dict()),
         client_config.get("settings", dict()),
         client_config.get("env", dict()),
-        client_config.get("tcp_host", None)
+        client_config.get("tcp_host", None),
+        client_config.get("sub_folder", "")
     )
 
 
@@ -182,5 +183,6 @@ def update_client_config(config: 'ClientConfig', settings: dict) -> 'ClientConfi
         settings.get("init_options", config.init_options),
         settings.get("settings", config.settings),
         settings.get("env", config.env),
-        settings.get("tcp_host", config.tcp_host)
+        settings.get("tcp_host", config.tcp_host),
+        settings.get("sub_folder", config.sub_folder)
     )

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -56,7 +56,7 @@ class ClientConfig(object):
     def __init__(self, name: str, binary_args: 'List[str]', tcp_port: 'Optional[int]', scopes=[],
                  syntaxes=[], languageId: 'Optional[str]'=None,
                  languages: 'List[LanguageConfig]'=[], enabled: bool=True, init_options=dict(),
-                 settings=dict(), env=dict(), tcp_host: 'Optional[str]'=None) -> None:
+                 settings=dict(), env=dict(), tcp_host: 'Optional[str]'=None, sub_folder: str="") -> None:
         self.name = name
         self.binary_args = binary_args
         self.tcp_port = tcp_port
@@ -68,6 +68,7 @@ class ClientConfig(object):
         self.init_options = init_options
         self.settings = settings
         self.env = env
+        self.sub_folder = sub_folder
 
 
 class ViewLike(Protocol):

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,4 +1,5 @@
 import re
+import os
 from .events import global_events
 from .logging import debug
 from .types import ClientStates, ClientConfig, WindowLike, ViewLike, LanguageConfig
@@ -371,6 +372,9 @@ class WindowManager(object):
             return
 
         self._window.status_message("Starting " + config.name + "...")
+
+        project_path = os.path.join(project_path, config.sub_folder)
+
         debug("starting in", project_path)
         try:
             session = self._start_session(self._window, project_path, config,


### PR DESCRIPTION
Some language servers (like php-language-server (https://github.com/felixfbecker/php-language-server)) process all file in rootPath. If in project added protected folders, server throw fatal error.

I add sub_folder param for client config.

Config <project>.sublime-project example:
```
{
  ...
  "settings":
  {
    "LSP":
    {
      "phpls":
      {
        "enabled": true,
        "sub_folder": "repo/spygasm",
      }
    },
    ...
  }
}
```

