### PR TITLE
Add enabled flag to the go client configuration example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -291,10 +291,11 @@ NOTE: This language server is missing completions and diagnostics support. You m
 See: [github:palantir/sourcegraphgo-langserver](https://github.com/sourcegraph/go-langserver)
 
 Client configuration:
-```
+```json
 "golsp":
 {
   "command": ["go-langserver"],
+  "enabled": true,
   "scopes": ["source.go"],
   "syntaxes": ["Packages/Go/Go.sublime-syntax"],
   "languageId": "go"


### PR DESCRIPTION
It took me a minute to realize I needed to add `"enabled": true` for the go language server to startup.