### PR TITLE
Dont scroll to end when the diagnostics panel is open  

### DIFF
--- a/plugin/core/panels.py
+++ b/plugin/core/panels.py
@@ -50,7 +50,6 @@ class LspUpdatePanelCommand(sublime_plugin.TextCommand):
     def run(self, edit, characters):
         self.view.replace(edit, sublime.Region(0, self.view.size()), characters)
 
-        # Move cursor to the end
+        # Clear the selection
         selection = self.view.sel()
         selection.clear()
-        selection.add(sublime.Region(self.view.size(), self.view.size()))


### PR DESCRIPTION
Dont scroll to end when the diagnostics panel is open, but keep the clear selection, so that panel text is not selected when opened.

Closes  #446