### PR TITLE
Fix RPC memory leak, update tests, and dust off tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 LSP.sublime-workspace
 LSP.sublime-project
 .mypy_cache
+.pytest_cache
+.tox
 .ropeproject
 *.pyc
+.coverage

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -151,6 +151,8 @@ class Client(object):
         request_id = int(response["id"])
         result = response.get("result", None)
         error = response.get("error", None)
+        if self.settings.log_payloads:
+            debug('     ' + str(result))
         handler, error_handler = self._response_handlers.pop(request_id, (None, None))
         if result is not None and error is None:
             if handler:

--- a/plugin/core/test_rpc.py
+++ b/plugin/core/test_rpc.py
@@ -23,11 +23,6 @@ class TestSettings(Settings):
 def return_result(message):
     return '{"id": 1, "result": {}}'
 
-    # parsed = json.loads(message)
-    # request_id = parsed.get("id")
-    # if request_id is not None:
-    #     return '{"id": ' + str(request_id) + ', "result": {}}'
-
 
 def return_error(message):
     return '{"id": 1, "error": {"message": "oops"}}'
@@ -90,6 +85,8 @@ class ClientTest(unittest.TestCase):
         responses = []
         client.send_request(req, lambda resp: responses.append(resp))
         self.assertGreater(len(responses), 0)
+        # Make sure the response handler dict does not grow.
+        self.assertEqual(len(client._response_handlers), 0)
 
     def test_client_notification(self):
         transport = TestTransport(notify_pong)
@@ -137,6 +134,7 @@ class ClientTest(unittest.TestCase):
         client.send_request(req, lambda resp: responses.append(resp))
         self.assertEqual(len(responses), 0)
         self.assertGreater(len(errors), 0)
+        self.assertEqual(len(client._response_handlers), 0)
 
     def test_handles_transport_closed_unexpectedly(self):
         set_exception_logging(False)
@@ -159,3 +157,4 @@ class ClientTest(unittest.TestCase):
         req = Request.initialize(dict())
         client.send_request(req, lambda resp: raise_error('handler failed'))
         # exception would fail test if not handled in client
+        self.assertEqual(len(client._response_handlers), 0)

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -216,7 +216,7 @@ class TestDiagnostics(object):
         pass
 
 
-def test_start_session(window, project_path, config, on_created: 'Callable', on_ended: 'Callable'):
+def mock_start_session(window, project_path, config, on_created: 'Callable', on_ended: 'Callable'):
     return create_session(test_config, project_path, dict(), TestSettings(),
                           bootstrap_client=TestClient(),
                           on_created=on_created,
@@ -227,7 +227,7 @@ class WindowRegistryTests(unittest.TestCase):
 
     def test_can_get_window_state(self):
         windows = WindowRegistry(TestGlobalConfigs(), TestDocumentHandlerFactory(),
-                                 TestDiagnostics(), test_start_session,
+                                 TestDiagnostics(), mock_start_session,
                                  test_sublime, TestHandlerDispatcher())
         test_window = TestWindow()
         wm = windows.lookup(test_window)
@@ -237,7 +237,7 @@ class WindowRegistryTests(unittest.TestCase):
         global_events.reset()
         test_window = TestWindow([[TestView(__file__)]])
         windows = WindowRegistry(TestGlobalConfigs(), TestDocumentHandlerFactory(),
-                                 TestDiagnostics(), test_start_session,
+                                 TestDiagnostics(), mock_start_session,
                                  test_sublime, TestHandlerDispatcher())
         wm = windows.lookup(test_window)
         wm.start_active_views()
@@ -257,7 +257,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_start_active_views(self):
         docs = TestDocuments()
         wm = WindowManager(TestWindow([[TestView(__file__)]]), TestConfigs(), docs,
-                           TestDiagnostics(), test_start_session, test_sublime, TestHandlerDispatcher())
+                           TestDiagnostics(), mock_start_session, test_sublime, TestHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -269,7 +269,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_open_supported_view(self):
         docs = TestDocuments()
         window = TestWindow([[]])
-        wm = WindowManager(window, TestConfigs(), docs, TestDiagnostics(), test_start_session, test_sublime,
+        wm = WindowManager(window, TestConfigs(), docs, TestDiagnostics(), mock_start_session, test_sublime,
                            TestHandlerDispatcher())
 
         wm.start_active_views()
@@ -286,7 +286,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_restart_sessions(self):
         docs = TestDocuments()
         wm = WindowManager(TestWindow([[TestView(__file__)]]), TestConfigs(), docs,
-                           TestDiagnostics(), test_start_session, test_sublime, TestHandlerDispatcher())
+                           TestDiagnostics(), mock_start_session, test_sublime, TestHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -308,7 +308,7 @@ class WindowManagerTests(unittest.TestCase):
         docs = TestDocuments()
         test_window = TestWindow([[TestView(__file__)]])
         wm = WindowManager(test_window, TestConfigs(), docs,
-                           TestDiagnostics(), test_start_session, test_sublime, TestHandlerDispatcher())
+                           TestDiagnostics(), mock_start_session, test_sublime, TestHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -329,7 +329,7 @@ class WindowManagerTests(unittest.TestCase):
         docs = TestDocuments()
         test_window = TestWindow([[TestView(__file__)]])
         wm = WindowManager(test_window, TestConfigs(), docs,
-                           TestDiagnostics(), test_start_session, test_sublime, TestHandlerDispatcher())
+                           TestDiagnostics(), mock_start_session, test_sublime, TestHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -351,7 +351,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_offers_restart_on_crash(self):
         docs = TestDocuments()
         wm = WindowManager(TestWindow([[TestView(__file__)]]), TestConfigs(), docs,
-                           TestDiagnostics(), test_start_session, test_sublime,
+                           TestDiagnostics(), mock_start_session, test_sublime,
                            TestHandlerDispatcher())
         wm.start_active_views()
 
@@ -373,7 +373,7 @@ class WindowManagerTests(unittest.TestCase):
         docs = TestDocuments()
         dispatcher = TestHandlerDispatcher()
         wm = WindowManager(TestWindow([[TestView(__file__)]]), TestConfigs(), docs,
-                           TestDiagnostics(), test_start_session, test_sublime,
+                           TestDiagnostics(), mock_start_session, test_sublime,
                            dispatcher)
         wm.start_active_views()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -5,25 +5,27 @@
 
 [tox]
 envlist = py3
+skipsdist = True
 
 [pycodestyle]
 max-line-length = 120
 
-# [pytest]
-# testpaths = test
-# addopts =
-#     --cov-report html --cov-report term --junitxml=pytest.xml
-#     --cov pyls --cov test
+[flake8]
+ignore =
+    F841  # local variable is assigned to but never used
+    E252  # missing whitespace around parameter equals
+    W504  # line break after binary operator
+    F821  # undefined name
+max-line-length = 120
 
-# [testenv]
-# commands =
-#     py.test {posargs}
-# deps =
-#     pytest
-#     coverage
-#     pytest-cov
-
-# [testenv:lint]
-# commands =
-#     pycodestyle pyls
-#     pyflakes pyls
+[testenv]
+deps =
+    pytest
+    coverage
+    pytest-cov
+    flake8
+    mypy
+commands =
+    mypy plugin
+    flake8 plugin tests
+    pytest --quiet plugin


### PR DESCRIPTION
- The _response_handlers dictionary was never cleared.
- Add tests checking that it is cleared now after handling a response
  from the server.
- Re-organize tox.ini so that contributors can just run "tox" on the
  command-line and do the basic checks.