### PR TITLE
Fix all pytest warnings

### DIFF
--- a/plugin/core/test_documents.py
+++ b/plugin/core/test_documents.py
@@ -2,11 +2,11 @@ import unittest
 from .events import Events
 from .windows import WindowDocumentHandler
 from .sessions import create_session, Session
-from .test_windows import TestWindow, TestView, TestConfigs
-from .test_session import test_config, TestClient, test_language
+from .test_windows import MockWindow, MockView, MockConfigs
+from .test_session import test_config, MockClient, test_language
 import unittest.mock
 from . import test_sublime as test_sublime
-from .test_rpc import TestSettings
+from .test_rpc import MockSettings
 # from .logging import debug, set_debug_logging
 from .types import ClientConfig
 from os.path import basename
@@ -26,13 +26,13 @@ class WindowDocumentHandlerTests(unittest.TestCase):
 
     def test_sends_did_open_to_session(self):
         events = Events()
-        view = TestView(__file__)
-        window = TestWindow([[view]])
+        view = MockView(__file__)
+        window = MockWindow([[view]])
         view.set_window(window)
-        handler = WindowDocumentHandler(test_sublime, TestSettings(), window, events, TestConfigs())
-        client = TestClient()
+        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, events, MockConfigs())
+        client = MockClient()
         session = self.assert_if_none(
-            create_session(test_config, "", dict(), TestSettings(),
+            create_session(test_config, "", dict(), MockSettings(),
                            bootstrap_client=client))
         handler.add_session(session)
 
@@ -87,12 +87,12 @@ class WindowDocumentHandlerTests(unittest.TestCase):
 
     def test_ignores_views_from_other_window(self):
         events = Events()
-        window = TestWindow()
-        view = TestView(__file__)
-        handler = WindowDocumentHandler(test_sublime, TestSettings(), window, events, TestConfigs())
-        client = TestClient()
+        window = MockWindow()
+        view = MockView(__file__)
+        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, events, MockConfigs())
+        client = MockClient()
         session = self.assert_if_none(
-            create_session(test_config, "", dict(), TestSettings(),
+            create_session(test_config, "", dict(), MockSettings(),
                            bootstrap_client=client))
         handler.add_session(session)
         events.publish("view.on_activated_async", view)
@@ -101,18 +101,18 @@ class WindowDocumentHandlerTests(unittest.TestCase):
 
     def test_sends_did_open_to_multiple_sessions(self):
         events = Events()
-        view = TestView(__file__)
-        window = TestWindow([[view]])
+        view = MockView(__file__)
+        window = MockWindow([[view]])
         view.set_window(window)
-        handler = WindowDocumentHandler(test_sublime, TestSettings(), window, events, TestConfigs())
-        client = TestClient()
+        handler = WindowDocumentHandler(test_sublime, MockSettings(), window, events, MockConfigs())
+        client = MockClient()
         session = self.assert_if_none(
-            create_session(test_config, "", dict(), TestSettings(),
+            create_session(test_config, "", dict(), MockSettings(),
                            bootstrap_client=client))
-        client2 = TestClient()
+        client2 = MockClient()
         test_config2 = ClientConfig("test2", [], None, languages=[test_language])
         session2 = self.assert_if_none(
-            create_session(test_config2, "", dict(), TestSettings(),
+            create_session(test_config2, "", dict(), MockSettings(),
                            bootstrap_client=client2))
 
         handler.add_session(session)

--- a/plugin/core/test_rpc.py
+++ b/plugin/core/test_rpc.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 
-class TestSettings(Settings):
+class MockSettings(Settings):
 
     def __init__(self):
         Settings.__init__(self)
@@ -39,7 +39,7 @@ def notify_pong(message):
     return json.dumps(notification)
 
 
-class TestTransport(Transport):
+class MockTransport(Transport):
     def __init__(self, responder=None):
         self.messages = []  # type: List[str]
         self.responder = responder
@@ -70,14 +70,14 @@ class FormatTests(unittest.TestCase):
 class ClientTest(unittest.TestCase):
 
     def test_can_create_client(self):
-        transport = TestTransport()
+        transport = MockTransport()
         client = Client(transport, dict())
         self.assertIsNotNone(client)
         self.assertTrue(transport.has_started)
 
     def test_client_request_response(self):
-        transport = TestTransport(return_result)
-        settings = TestSettings()
+        transport = MockTransport(return_result)
+        settings = MockSettings()
         client = Client(transport, settings)
         self.assertIsNotNone(client)
         self.assertTrue(transport.has_started)
@@ -89,8 +89,8 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(len(client._response_handlers), 0)
 
     def test_client_notification(self):
-        transport = TestTransport(notify_pong)
-        settings = TestSettings()
+        transport = MockTransport(notify_pong)
+        settings = MockSettings()
         client = Client(transport, settings)
         self.assertIsNotNone(client)
         self.assertTrue(transport.has_started)
@@ -107,8 +107,8 @@ class ClientTest(unittest.TestCase):
     def test_server_request(self):
         # TODO: LSP never responds to eg workspace/applyEdit.
 
-        transport = TestTransport()
-        settings = TestSettings()
+        transport = MockTransport()
+        settings = MockSettings()
         client = Client(transport, settings)
         self.assertIsNotNone(client)
         self.assertTrue(transport.has_started)
@@ -122,8 +122,8 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(len(pings), 1)
 
     def test_response_error(self):
-        transport = TestTransport(return_error)
-        settings = TestSettings()
+        transport = MockTransport(return_error)
+        settings = MockSettings()
         client = Client(transport, settings)
         self.assertIsNotNone(client)
         self.assertTrue(transport.has_started)
@@ -138,8 +138,8 @@ class ClientTest(unittest.TestCase):
 
     def test_handles_transport_closed_unexpectedly(self):
         set_exception_logging(False)
-        transport = TestTransport(raise_error)
-        settings = TestSettings()
+        transport = MockTransport(raise_error)
+        settings = MockSettings()
         client = Client(transport, settings)
         errors = []
         client.set_transport_failure_handler(lambda: errors.append(""))
@@ -149,8 +149,8 @@ class ClientTest(unittest.TestCase):
 
     def test_survives_handler_error(self):
         set_exception_logging(False)
-        transport = TestTransport(return_result)
-        settings = TestSettings()
+        transport = MockTransport(return_result)
+        settings = MockSettings()
         client = Client(transport, settings)
         self.assertIsNotNone(client)
         self.assertTrue(transport.has_started)

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -11,7 +11,7 @@ except ImportError:
     pass
 
 
-class TestClient():
+class MockClient():
     def __init__(self) -> None:
         self.responses = {
             'initialize': {"capabilities": dict(testing=True, hoverProvider=True, textDocumentSync=True)},
@@ -69,7 +69,7 @@ class SessionTest(unittest.TestCase):
         created_callback = unittest.mock.Mock()
         session = self.assert_if_none(
             create_session(test_config, project_path, dict(), Settings(),
-                           bootstrap_client=TestClient(),
+                           bootstrap_client=MockClient(),
                            on_created=created_callback))
 
         self.assertEqual(session.state, ClientStates.READY)
@@ -85,7 +85,7 @@ class SessionTest(unittest.TestCase):
         ended_callback = unittest.mock.Mock()
         session = self.assert_if_none(
             create_session(test_config, project_path, dict(), Settings(),
-                           bootstrap_client=TestClient(),
+                           bootstrap_client=MockClient(),
                            on_created=created_callback,
                            on_ended=ended_callback))
 

--- a/tests/test_hover.py
+++ b/tests/test_hover.py
@@ -3,7 +3,7 @@ import sublime
 from os.path import dirname
 from LSP.plugin.hover import _test_contents
 from LSP.plugin.core.types import ClientConfig, ClientStates, LanguageConfig
-from LSP.plugin.core.test_session import TestClient
+from LSP.plugin.core.test_session import MockClient
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.registry import windows  # , session_for_view
 from LSP.plugin.core.settings import client_configs
@@ -36,7 +36,7 @@ class LspHoverCommandTests(DeferrableTestCase):
         client_configs.update_configs()
         wm._configs.all.append(text_config)
 
-        session = Session(text_config, dirname(__file__), TestClient())
+        session = Session(text_config, dirname(__file__), MockClient())
         session.state = ClientStates.READY
         wm._sessions[text_config.name] = session
 


### PR DESCRIPTION
There were a bunch of warnings all of the form

> PytestWarning: cannot collect test class 'TestFoo' because it has a `__init__` constructor

Simple fix is to rename them to MockFoo etc.