### PR TITLE
No need to send the languageId in a didChange notification

### DIFF
--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -263,8 +263,6 @@ class WindowManagerTests(unittest.TestCase):
 
         # session must be started (todo: verify session is ready)
         self.assertIsNotNone(wm.get_session(test_config.name))
-
-        #
         self.assertListEqual(docs._documents, [__file__])
 
     def test_can_open_supported_view(self):

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -278,7 +278,6 @@ class WindowDocumentHandler(object):
                         params = {
                             "textDocument": {
                                 "uri": uri,
-                                "languageId": self._view_language(view, session.config.name),
                                 "version": document_state.inc_version(),
                             },
                             "contentChanges": [{


### PR DESCRIPTION
See: https://microsoft.github.io/language-server-protocol/specification#textDocument_didChange

Compare: VersionedTextDocumentIdentifier (from didChange) versus TextDocumentItem (from didOpen)