### PR TITLE
Fix #471

### DIFF
--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -13,7 +13,7 @@ def get_project_path(window: 'Any') -> 'Optional[str]':
     """
     Returns the first project folder or the parent folder of the active view
     """
-    if len(window.folders()):
+    if len(window.folders()) == 1:
         folder_paths = window.folders()
         return folder_paths[0]
     else:


### PR DESCRIPTION
Fixes a logic error that causes `get_project_path` to always return the first directory in the current workspace.