### PR TITLE
send null for result fiend when no-op for "window/showMessageRequest"

### DIFF
--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -154,7 +154,7 @@ class Request:
 
 
 class Response:
-    def __init__(self, request_id: int, result: 'Dict[str, Any]') -> None:
+    def __init__(self, request_id: int, result: 'Optional[Dict[str, Any]]') -> None:
         self.request_id = request_id
         self.result = result
         self.jsonrpc = "2.0"

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -388,10 +388,12 @@ class WindowManager(object):
         titles = list(action.get("title") for action in actions)
 
         def send_user_choice(index):
-            # otherwise noop; nothing was selected e.g. the user pressed escape
+            # when noop; nothing was selected e.g. the user pressed escape
+            result = None
             if index != -1:
-                response = Response(request_id, {"title": titles[index]})
-                client.send_response(response)
+                result = {"title": titles[index]}
+            response = Response(request_id, result)
+            client.send_response(response)
 
         if actions:
             self._sublime.active_window().show_quick_panel(titles, send_user_choice)


### PR DESCRIPTION
complement to https://github.com/tomv564/LSP/pull/470
See https://github.com/tomv564/LSP/pull/470#issuecomment-445992403