### PR TITLE
Add support for Djaneiro Python syntax

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -47,7 +47,7 @@
     {
       "command": ["pyls"],
       "scopes": ["source.python"],
-      "syntaxes": ["Packages/Python/Python.sublime-syntax"],
+      "syntaxes": ["Packages/Python/Python.sublime-syntax", "Packages/Djaneiro/Syntaxes/Python Django.tmLanguage"],
       "languageId": "python"
     },
     "rls":


### PR DESCRIPTION
If you install [Djaneiro](https://github.com/squ1b3r/Djaneiro), Python language server does not activate automatically because Djaneiro defines its own scope (`source.python.django`) and syntax (`Python (Django)`).