### PR TITLE
Implement quick panel for symbol references

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -326,7 +326,7 @@
   "diagnostics_gutter_marker": "dot",
 
   // Show a bulb in the gutter when code actions are available
-  "show_code_actions_bulb": false, 
+  "show_code_actions_bulb": false,
 
   // Request completions for all characters if set to true,
   // or just after trigger characters only otherwise.
@@ -344,6 +344,9 @@
 
   // Resolve completions and apply snippet if received.
   "resolve_completion_for_snippets": false,
+
+  // Show symbol references in Sublime's quick panel instead of the bottom panel.
+  "show_references_in_quick_panel": false,
 
   // Show verbose debug messages in the sublime console.
   "log_debug": false,

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Global plugin settings and settings defined at project level are merged together
 * `only_show_lsp_completions` `false` *disable sublime word completion and snippets from autocomplete lists*
 * `completion_hint_type` `"auto"` *override automatic completion hints with "detail", "kind" or "none"*
 * `resolve_completion_for_snippets` `false` *resolve completions and apply snippet if received*
+* `show_references_in_quick_panel` `false` *show symbol references in Sublime's quick panel instead of the bottom panel*
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
 * `auto_show_diagnostics_panel` `true` *open the diagnostics panel automatically if there are diagnostics*

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -65,6 +65,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings):
     settings.completion_hint_type = read_str_setting(settings_obj, "completion_hint_type", "auto")
     settings.complete_using_text_edit = read_bool_setting(settings_obj, "complete_using_text_edit", False)
     settings.resolve_completion_for_snippets = read_bool_setting(settings_obj, "resolve_completion_for_snippets", False)
+    settings.show_references_in_quick_panel = read_bool_setting(settings_obj, "show_references_in_quick_panel", False)
     settings.log_debug = read_bool_setting(settings_obj, "log_debug", False)
     settings.log_server = read_bool_setting(settings_obj, "log_server", True)
     settings.log_stderr = read_bool_setting(settings_obj, "log_stderr", False)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -35,6 +35,7 @@ class Settings(object):
         self.completion_hint_type = "auto"
         self.complete_using_text_edit = False
         self.resolve_completion_for_snippets = False
+        self.show_references_in_quick_panel = False
         self.log_debug = True
         self.log_server = True
         self.log_stderr = False


### PR DESCRIPTION
Usually the quick panel is better suited for showing symbol references
because you can cycle through the references using the keyboard.

It is also closer to the original Sublime Text behavior.

I chose to make this opt-in to avoid confusing existing users.