### PR TITLE
Always reset completion state to IDLE when in CANCELLING

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -323,10 +323,10 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
             self.view.run_command("hide_auto_complete")
             self.run_auto_complete()
         elif self.state == CompletionState.CANCELLING:
+            self.state = CompletionState.IDLE
             if self.next_request:
                 prefix, locations = self.next_request
                 self.do_request(prefix, locations)
-            self.state = CompletionState.IDLE
         else:
             debug('Got unexpected response while in state {}'.format(self.state))
 

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -326,7 +326,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
             if self.next_request:
                 prefix, locations = self.next_request
                 self.do_request(prefix, locations)
-                self.state = CompletionState.IDLE
+            self.state = CompletionState.IDLE
         else:
             debug('Got unexpected response while in state {}'.format(self.state))
 


### PR DESCRIPTION
Previously adding a space while requesting completion would
cause completion to stay in CANCELLING indefinitely.

Fixes https://github.com/tomv564/LSP/issues/510