### PR TITLE
Fix exception when kind is None

### DIFF
--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -103,7 +103,8 @@ class DocumentHighlightListener(sublime_plugin.ViewEventListener):
         for highlight in response:
             r = range_to_region(Range.from_lsp(highlight["range"]), self.view)
             kind = highlight.get("kind", DocumentHighlightKind.Unknown)
-            kind2regions[_kind2name[kind]].append(r)
+            if kind is not None:
+                kind2regions[_kind2name[kind]].append(r)
         if settings.document_highlight_style == "fill":
             flags = 0
         elif settings.document_highlight_style == "box":


### PR DESCRIPTION
At least when using this package in conjunction with https://github.com/guillermooo/dart-sublime-bundle, there are cases where kind is None, resulting in an exception. This resolves that issue.