### PR TITLE
Add a settings entry in pyls configurations

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -48,7 +48,17 @@
       "command": ["pyls"],
       "scopes": ["source.python"],
       "syntaxes": ["Packages/Python/Python.sublime-syntax", "Packages/Djaneiro/Syntaxes/Python Django.tmLanguage"],
-      "languageId": "python"
+      "languageId": "python",
+      // "settings": {
+      //   "pyls": {
+      //       "configurationSources": ["flake8"],
+      //       "plugins": {
+      //           "pyflakes": {
+      //               "enabled": false
+      //           }
+      //       },
+      //   }
+      // },
     },
     "rls":
     {


### PR DESCRIPTION
This PR adds a settings entry for pyls
I was trying to disable pyflakes warnings as they were annoying, I searched in the web, changed the settings such as:
```json
{
  ...
  "settings": {
    "pyflakes": {
      "enabled": false
    }
  }
}
```
and
```json
{
  ...
  "settings": {
    "plugins": {
      "pyflakes": {
        "enabled": false
      }
    }
  }
}
```
in various ways and gave up many times before stumbling upon the solution in a thread (I forget where)
and the trick was adding `"pyls"` entry like this:
```json
{
  ...
  "settings": {
    "pyls": {
      "plugins": {
        "pyflakes": {
          "enabled": false
        }
      }
    }
  }
}
```
I think adding this entry commented will save many people a lot of time.