### PR TITLE
Remove trailing commas in pyls configuration

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -48,7 +48,7 @@
       "command": ["pyls"],
       "scopes": ["source.python"],
       "syntaxes": ["Packages/Python/Python.sublime-syntax", "Packages/Djaneiro/Syntaxes/Python Django.tmLanguage"],
-      "languageId": "python",
+      "languageId": "python"
       // "settings": {
       //   "pyls": {
       //       "configurationSources": ["flake8"],
@@ -56,9 +56,9 @@
       //           "pyflakes": {
       //               "enabled": false
       //           }
-      //       },
+      //       }
       //   }
-      // },
+      // }
     },
     "rls":
     {


### PR DESCRIPTION
https://github.com/tomv564/LSP/pull/522 introduced a trailing comma that shouldn't be there.