### PR TITLE
Completions that start with a "$" are not extracted correctly

### DIFF
--- a/tests/powershell_completion_sample.json
+++ b/tests/powershell_completion_sample.json
@@ -1,0 +1,407 @@
+[
+  {
+    "sortText": "0001Error",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$Error"
+    },
+    "insertText": "$Error",
+    "command": null,
+    "label": "Error",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[ArrayList]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$Error",
+    "data": null
+  },
+  {
+    "sortText": "0002ErrorActionPreference",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$ErrorActionPreference"
+    },
+    "insertText": "$ErrorActionPreference",
+    "command": null,
+    "label": "ErrorActionPreference",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[ActionPreference]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$ErrorActionPreference",
+    "data": null
+  },
+  {
+    "sortText": "0003ErrorView",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$ErrorView"
+    },
+    "insertText": "$ErrorView",
+    "command": null,
+    "label": "ErrorView",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$ErrorView",
+    "data": null
+  },
+  {
+    "sortText": "0004ExecutionContext",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$ExecutionContext"
+    },
+    "insertText": "$ExecutionContext",
+    "command": null,
+    "label": "ExecutionContext",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[EngineIntrinsics]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$ExecutionContext",
+    "data": null
+  },
+  {
+    "sortText": "0005env:__CF_USER_TEXT_ENCODING",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:__CF_USER_TEXT_ENCODING"
+    },
+    "insertText": "$env:__CF_USER_TEXT_ENCODING",
+    "command": null,
+    "label": "env:__CF_USER_TEXT_ENCODING",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:__CF_USER_TEXT_ENCODING",
+    "data": null
+  },
+  {
+    "sortText": "0006env:Apple_PubSub_Socket_Render",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:Apple_PubSub_Socket_Render"
+    },
+    "insertText": "$env:Apple_PubSub_Socket_Render",
+    "command": null,
+    "label": "env:Apple_PubSub_Socket_Render",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:Apple_PubSub_Socket_Render",
+    "data": null
+  },
+  {
+    "sortText": "0007env:BROWSER",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:BROWSER"
+    },
+    "insertText": "$env:BROWSER",
+    "command": null,
+    "label": "env:BROWSER",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:BROWSER",
+    "data": null
+  },
+  {
+    "sortText": "0011env:DISPLAY",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:DISPLAY"
+    },
+    "insertText": "$env:DISPLAY",
+    "command": null,
+    "label": "env:DISPLAY",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:DISPLAY",
+    "data": null
+  },
+  {
+    "sortText": "0012env:EDITOR",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:EDITOR"
+    },
+    "insertText": "$env:EDITOR",
+    "command": null,
+    "label": "env:EDITOR",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:EDITOR",
+    "data": null
+  },
+  {
+    "sortText": "0013env:HOME",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:HOME"
+    },
+    "insertText": "$env:HOME",
+    "command": null,
+    "label": "env:HOME",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:HOME",
+    "data": null
+  },
+  {
+    "sortText": "0025env:VISUAL",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:VISUAL"
+    },
+    "insertText": "$env:VISUAL",
+    "command": null,
+    "label": "env:VISUAL",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:VISUAL",
+    "data": null
+  },
+  {
+    "sortText": "0026env:XPC_FLAGS",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:XPC_FLAGS"
+    },
+    "insertText": "$env:XPC_FLAGS",
+    "command": null,
+    "label": "env:XPC_FLAGS",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:XPC_FLAGS",
+    "data": null
+  },
+  {
+    "sortText": "0027env:XPC_SERVICE_NAME",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:XPC_SERVICE_NAME"
+    },
+    "insertText": "$env:XPC_SERVICE_NAME",
+    "command": null,
+    "label": "env:XPC_SERVICE_NAME",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": "[string]",
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:XPC_SERVICE_NAME",
+    "data": null
+  },
+  {
+    "sortText": "0028env:PATHEXT",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$env:PATHEXT"
+    },
+    "insertText": "$env:PATHEXT",
+    "command": null,
+    "label": "env:PATHEXT",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": null,
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$env:PATHEXT",
+    "data": null
+  },
+  {
+    "sortText": "0029Env",
+    "range": null,
+    "textEdit": {
+      "range": {
+        "end": {
+          "character": 2,
+          "line": 2
+        },
+        "start": {
+          "character": 0,
+          "line": 2
+        }
+      },
+      "newText": "$Env:"
+    },
+    "insertText": "$Env:",
+    "command": null,
+    "label": "Env",
+    "commitCharacters": null,
+    "documentation": null,
+    "detail": null,
+    "additionalTextEdits": null,
+    "kind": 6,
+    "filterText": "$Env:",
+    "data": null
+  }
+]

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -3,7 +3,7 @@ from unittesting import DeferrableTestCase
 from unittest.mock import MagicMock
 import sublime
 import json
-from LSP.plugin.completion import CompletionHandler, CompletionState
+from LSP.plugin.completion import CompletionHandler, CompletionState, format_completion
 from LSP.plugin.core.settings import client_configs, ClientConfig
 from os.path import dirname, join
 
@@ -140,22 +140,18 @@ class CompletionFormattingTests(DeferrableTestCase):
         self.view = sublime.active_window().open_file(test_file_path)
 
     def test_only_label_item(self):
-        handler = CompletionHandler(self.view)
-        result = handler.format_completion(create_completion_item("asdf"))
+        result = format_completion(create_completion_item("asdf"))
         self.assertEqual(len(result), 2)
         self.assertEqual("asdf", result[0])
         self.assertEqual("asdf", result[1])
 
     def test_prefers_insert_text(self):
-        handler = CompletionHandler(self.view)
-        result = handler.format_completion(create_completion_item("asdf", "Asdf"))
+        result = format_completion(create_completion_item("asdf", "Asdf"))
         self.assertEqual(len(result), 2)
         self.assertEqual("asdf", result[0])
         self.assertEqual("Asdf", result[1])
 
     def test_ignores_text_edit(self):
-        handler = CompletionHandler(self.view)
-
         # partial completion from cursor (instead of full word) causes issues.
         item = {
             'insertText': '$true',
@@ -169,10 +165,10 @@ class CompletionFormattingTests(DeferrableTestCase):
             }
         }
 
-        result = handler.format_completion(item)
+        result = format_completion(item)
         self.assertEqual(len(result), 2)
         self.assertEqual("true", result[0])
-        self.assertEqual("\\$true", result[1])
+        self.assertEqual("rue", result[1])
 
     def test_ignore_label(self):
         # issue #368
@@ -198,7 +194,7 @@ class CompletionFormattingTests(DeferrableTestCase):
         handler = CompletionHandler(self.view)
         handler.last_location = 1
         handler.last_prefix = ""
-        result = handler.format_completion(item)
+        result = format_completion(item)
         self.assertEqual(result, ('const\t  Keyword', 'const'))
 
     def test_text_edit_intelephense(self):
@@ -206,7 +202,7 @@ class CompletionFormattingTests(DeferrableTestCase):
         handler = CompletionHandler(self.view)
         handler.last_location = 1
         handler.last_prefix = ""
-        result = [handler.format_completion(item) for item in intelephense_completion_sample]
+        result = [format_completion(item) for item in intelephense_completion_sample]
         self.assertEqual(
             result,
             [
@@ -234,7 +230,7 @@ class CompletionFormattingTests(DeferrableTestCase):
         handler = CompletionHandler(self.view)
         handler.last_location = 1
         handler.last_prefix = ""
-        result = [handler.format_completion(item) for item in clangd_completion_sample]
+        result = [format_completion(item) for item in clangd_completion_sample]
         # We should prefer textEdit over insertText. This test covers that.
         self.assertEqual(
             result,
@@ -267,7 +263,7 @@ class CompletionFormattingTests(DeferrableTestCase):
         handler = CompletionHandler(self.view)
         handler.last_location = 1
         handler.last_prefix = ""
-        result = [handler.format_completion(item) for item in pyls_completion_sample]
+        result = [format_completion(item) for item in pyls_completion_sample]
         self.assertEqual(
             result,
             [


### PR DESCRIPTION
The last_row, last_col logic causes $_POST to become _POST et cetera.
I have removed this logic in favor of getting intelephense to work correctly.
We should rethink the edit range of the TextEdit.

@nanoant, I would like to test these changes with https://github.com/PowerShell/PowerShellEditorServices. I fired up my windows machine, installed Powershell 6, cloned the repository, and ran the instruction in the repository. But I don't understand how to actually run the server with SublimeText. What do I put in my `"clients"` dict to run the server?