### PR TITLE
Correctly handle code action of CodeAction type (fixes #566)

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -7,9 +7,10 @@ try:
 except ImportError:
     pass
 
-from .core.registry import LspTextCommand
+from .core.registry import client_for_view, LspTextCommand
 from .core.protocol import Request
 from .diagnostics import get_point_diagnostics
+from .core.edit import parse_workspace_edit
 from .core.url import filename_to_uri
 from .core.views import region_to_range
 from .core.registry import session_for_view
@@ -80,6 +81,11 @@ class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
         self.view.erase_regions('lsp_bulb')
 
 
+def is_command(command_or_code_action: dict) -> bool:
+    command_field = command_or_code_action.get('command')
+    return isinstance(command_field, str)
+
+
 class LspCodeActionsCommand(LspTextCommand):
     def is_enabled(self):
         return self.has_client_with_capability('codeActionProvider')
@@ -108,18 +114,26 @@ class LspCodeActionsCommand(LspTextCommand):
 
     def handle_select(self, index: int) -> None:
         if index > -1:
-            # TODO for CodeAction, handle potential WorkspaceEdit before Command.
-            result = self.commands[index]
-            command_attr = result.get('command', None)
-            # Result can be either a Command or CodeAction type.
-            command = result if isinstance(command_attr, str) else command_attr
-            if command:
-                command_name = command.get('command')
-                command_args = command.get('arguments', None)
 
-                args = {
-                    "command_name": command_name,
-                    "command_args": command_args,
-                    "modal_result": False,
-                }
-                self.view.run_command('lsp_execute', args)
+            selected = self.commands[index]
+            if is_command(selected):
+                self.run_command(selected)
+            else:
+                # CodeAction can have an edit and/or command.
+                maybe_edit = selected.get('edit')
+                if maybe_edit:
+                    changes = parse_workspace_edit(maybe_edit)
+                    self.view.window().run_command("lsp_apply_workspace_edit", {'changes': changes})
+                maybe_command = selected.get('command')
+                if maybe_command:
+                    self.run_command(maybe_command)
+
+    def run_command(self, command) -> None:
+        client = client_for_view(self.view)
+        if client:
+            client.send_request(
+                Request.executeCommand(command),
+                self.handle_command_response)
+
+    def handle_command_response(self, response):
+        pass

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -135,7 +135,9 @@ def get_initialize_params(project_path: str, config: ClientConfig):
                 "formatting": {},
                 "rangeFormatting": {},
                 "definition": {},
-                "codeAction": {},
+                "codeAction": {
+                    "codeActionLiteralSupport": {}
+                },
                 "rename": {}
             },
             "workspace": {

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -140,7 +140,8 @@ def get_initialize_params(project_path: str, config: ClientConfig):
             },
             "workspace": {
                 "applyEdit": True,
-                "didChangeConfiguration": {}
+                "didChangeConfiguration": {},
+                "executeCommand": {},
             }
         }
     }

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -14,32 +14,28 @@ class LspExecuteCommand(LspTextCommand):
     def __init__(self, view):
         super().__init__(view)
 
-    def run(self, edit, command_name=None, command_args=None, modal_result=True) -> None:
+    def run(self, edit, command_name=None, command_args=None) -> None:
         client = client_for_view(self.view)
         if client and command_name:
             self.view.window().status_message("Running command {}".format(command_name))
-            self._send_command(client, command_name, command_args, modal_result)
+            self._send_command(client, command_name, command_args)
 
-    def _handle_response(self, command: str, response: 'Optional[Any]', modal_result: bool) -> None:
+    def _handle_response(self, command: str, response: 'Optional[Any]') -> None:
         msg = "command {} completed".format(command)
         if response:
             msg += "with response: {}".format(response)
 
-        if modal_result:
-            sublime.message_dialog(msg)
-        else:
-            self.view.window().status_message(msg)
+        sublime.message_dialog(msg)
 
     def _handle_error(self, command: str, error: 'Dict[str, Any]') -> None:
         msg = "command {} failed. Reason: {}".format(command, error.get("message", "none provided by server :("))
         sublime.message_dialog(msg)
 
-    def _send_command(self, client: Client, command_name: str, command_args: 'Optional[List[Any]]',
-                      modal_result) -> None:
+    def _send_command(self, client: Client, command_name: str, command_args: 'Optional[List[Any]]') -> None:
         request = {
             "command": command_name,
             "arguments": command_args
         }
         client.send_request(Request.executeCommand(request),
-                            lambda reponse: self._handle_response(command_name, reponse, modal_result),
+                            lambda reponse: self._handle_response(command_name, reponse),
                             lambda error: self._handle_error(command_name, error))


### PR DESCRIPTION
Fixes two issues:
  - The Command's arguments passed to workspace/executeCommand should be
    passed through 'arguments' property rather than 'args'.
  - Fix handling of code action in case textDocument/codeAction [1] returns
    list of CodeAction's rather than Command's [2].

    Instead of having LspCodeActionsCommand duplicate logic of
    LspExecuteCommand, pass data from former to the latter to
    execute code action. Had to modify latter to not trigger a
    dialog box on success as it's not the best user experience in case
    when executing action from a popup menu.
  - Advertise support for workspace/executeCommand as we clearly support
    that. That wasn't necessary to fix anything but it felt right to do.

[1] https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction
[2] https://microsoft.github.io/language-server-protocol/specification#command