### PR TITLE
Change flake8 rules formatting to make compatible with pyls

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,11 @@ skipsdist = True
 max-line-length = 120
 
 [flake8]
-ignore =
-    F841  # local variable is assigned to but never used
-    E252  # missing whitespace around parameter equals
-    W504  # line break after binary operator
-    F821  # undefined name
+# F841 local variable is assigned to but never used
+# E252 missing whitespace around parameter equals
+# W504 line break after binary operator
+# F821 undefined name
+ignore = F841, E252, W504, F821
 max-line-length = 120
 
 [testenv]


### PR DESCRIPTION
Pyls language server is not capable of parsing previous formatting of
flake8 configuration. It does its own parsing that expects rule codes
to be separated by comma.