### PR TITLE
Text editing cleanup/testability

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -4,7 +4,7 @@ from .plugin.core.main import startup, shutdown
 from .plugin.core.panels import *
 from .plugin.core.registry import LspRestartClientCommand
 from .plugin.core.documents import *
-from .plugin.core.edit import *
+from .plugin.edit import *
 from .plugin.completion import *
 from .plugin.diagnostics import *
 from .plugin.configuration import *

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -3,7 +3,7 @@ import sublime_plugin
 
 try:
     from typing import List, Dict, Optional, Any, Iterable
-    assert List and Dict and Optional and Any
+    assert List and Dict and Optional and Any and Iterable
 except ImportError:
     pass
 

--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -1,34 +1,25 @@
-import os
 import sublime
 import sublime_plugin
-from timeit import default_timer as timer
 
 try:
-    from typing import List, Dict, Optional, Any
+    from typing import List, Dict, Optional, Any, Iterable
     assert List and Dict and Optional and Any
 except ImportError:
     pass
 
 from .url import uri_to_filename
-from .protocol import Range
+from .protocol import Edit
 from .logging import debug
-from .workspace import get_project_path
 from .views import range_to_region
 
 
 class LspApplyWorkspaceEditCommand(sublime_plugin.WindowCommand):
-    def run(self, changes=None, document_changes=None):
+    def run(self, changes: 'Optional[Dict[str, List[Edit]]]'=None):
         documents_changed = 0
         if changes:
-            for uri, file_changes in changes.items():
-                path = uri_to_filename(uri)
-                self.open_and_apply_edits(path, file_changes)
-                documents_changed += 1
-        elif document_changes:
-            for document_change in document_changes:
-                uri = document_change.get('textDocument').get('uri')
-                path = uri_to_filename(uri)
-                self.open_and_apply_edits(path, document_change.get('edits'))
+            for (document_uri, document_changes) in changes.items():
+                path = uri_to_filename(document_uri)
+                self.open_and_apply_edits(path, document_changes)
                 documents_changed += 1
 
         if documents_changed > 0:
@@ -54,61 +45,34 @@ class LspApplyWorkspaceEditCommand(sublime_plugin.WindowCommand):
             debug('view not found to apply', path, file_changes)
 
 
+def sort_by_application_order(changes: 'Iterable[Edit]') -> 'List[Edit]':
+
+    def get_start_position(change: Edit):
+        start = change.range.start
+        return (start.row, start.col)
+
+    # The spec reads:
+    # > However, it is possible that multiple edits have the same start position: multiple
+    # > inserts, or any number of inserts followed by a single remove or replace edit. If
+    # > multiple inserts have the same position, the order in the array defines the order in
+    # > which the inserted strings appear in the resulting text.
+    # So we sort by start position. But if multiple text edits start at the same position,
+    # we use the index in the array as the key.
+
+    # todo: removed array logic because sorted is stable, but does it work correctly with reverse?
+    return sorted(changes, key=get_start_position, reverse=True)
+
+
 class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
-    def run(self, edit, changes: 'Optional[List[dict]]' = None, show_status=True):
+    def run(self, edit, changes: 'Optional[List[Edit]]'=None):
         # Apply the changes in reverse, so that we don't invalidate the range
         # of any change that we haven't applied yet.
-        start = timer()
-        changes2 = changes or []  # New variable of type List[dict]
-        indices = self.changes_order(changes2)
-        for index in indices:
-            change = changes2[index]
-            self.apply_change(self.create_region(change), change.get('newText'), edit)
-        elapsed = timer() - start
+        if changes:
+            sorted_changes = sort_by_application_order(changes)
+            for change in sorted_changes:
+                self.apply_change(range_to_region(change.range, self.view), change.newText, edit)
 
-        if show_status:
-            window = self.view.window()
-            if window:
-                base_dir = get_project_path(window)
-                file_path = self.view.file_name()
-                relative_file_path = os.path.relpath(file_path, base_dir) if base_dir else file_path
-                message = 'Applied {} change(s) to {} in {:.1f} ms'.format(
-                    len(indices), relative_file_path, elapsed * 1000)
-                window.status_message(message)
-                debug(message)
-
-    def changes_order(self, changes: 'List[dict]') -> 'List[int]':
-        # Changes look like this:
-        # [
-        #   {
-        #       'newText': str,
-        #       'range': {
-        #            'start': {'line': int, 'character': int},
-        #            'end': {'line': int, 'character': int}
-        #       }
-        #   }
-        # ]
-
-        def get_start_position(index: int):
-            change = changes[index]  # type: Any
-            start = change.get('range').get('start')
-            line = start.get('line')
-            character = start.get('character')
-            return (line, character, index)
-
-        # The spec reads:
-        # > However, it is possible that multiple edits have the same start position: multiple
-        # > inserts, or any number of inserts followed by a single remove or replace edit. If
-        # > multiple inserts have the same position, the order in the array defines the order in
-        # > which the inserted strings appear in the resulting text.
-        # So we sort by start position. But if multiple text edits start at the same position,
-        # we use the index in the array as the key.
-        return sorted(range(len(changes)), key=get_start_position, reverse=True)
-
-    def create_region(self, change):
-        return range_to_region(Range.from_lsp(change['range']), self.view)
-
-    def apply_change(self, region, newText, edit):
+    def apply_change(self, region: 'sublime.Region', newText: str, edit):
         if region.empty():
             self.view.insert(edit, region.a, newText)
         else:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -268,7 +268,7 @@ class Range(object):
         }
 
 
-def parse_workspace_edit(workspace_edit: Dict[str, Any]) -> 'Dict[str, List[Edit]]':
+def parse_workspace_edit(workspace_edit: 'Dict[str, Any]') -> 'Dict[str, List[Edit]]':
     changes = {}  # type: Dict[str, List[Edit]]
     if 'changes' in workspace_edit:
         for uri, file_changes in workspace_edit.get('changes', {}).items():

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -1,4 +1,3 @@
-from .url import uri_to_filename
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional
     assert Any and List and Dict and Tuple and Callable and Optional
@@ -266,29 +265,6 @@ class Range(object):
             'start': self.start.to_lsp(),
             'end': self.end.to_lsp()
         }
-
-
-def parse_workspace_edit(workspace_edit: 'Dict[str, Any]') -> 'Dict[str, List[Edit]]':
-    changes = {}  # type: Dict[str, List[Edit]]
-    if 'changes' in workspace_edit:
-        for uri, file_changes in workspace_edit.get('changes', {}).items():
-            changes[uri_to_filename(uri)] = list(Edit.from_lsp(change) for change in file_changes)
-    if 'documentChanges' in workspace_edit:
-        for document_change in workspace_edit.get('documentChanges', []):
-            uri = document_change.get('textDocument').get('uri')
-            changes[uri_to_filename(uri)] = list(Edit.from_lsp(change) for change in document_change.get('edits'))
-    return changes
-
-
-class Edit(object):
-
-    def __init__(self, range: Range, newText: str) -> None:
-        self.newText = newText
-        self.range = range
-
-    @classmethod
-    def from_lsp(cls, edit: dict) -> 'Edit':
-        return Edit(Range.from_lsp(edit.get('range', {})), edit.get('newText', ''))
 
 
 class Diagnostic(object):

--- a/plugin/core/test_edit.py
+++ b/plugin/core/test_edit.py
@@ -19,7 +19,7 @@ LSP_EDIT_CHANGES = {
 
 LSP_EDIT_DOCUMENT_CHANGES = {
     'documentChanges': [{
-        'document': {'uri': 'file:///file.py'},
+        'textDocument': {'uri': 'file:///file.py'},
         'edits': [LSP_TEXT_EDIT]
     }]
 }
@@ -27,7 +27,7 @@ LSP_EDIT_DOCUMENT_CHANGES = {
 
 class TextEditTests(unittest.TestCase):
 
-    def parse_from_lsp(self):
+    def test_parse_from_lsp(self):
         (start, end, newText) = parse_text_edit(LSP_TEXT_EDIT)
         self.assertEqual(newText, 'newText')
         self.assertEqual(start[0], 10)
@@ -38,16 +38,16 @@ class TextEditTests(unittest.TestCase):
 
 class WorkspaceEditTests(unittest.TestCase):
 
-    def parse_no_changes_from_lsp(self):
+    def test_parse_no_changes_from_lsp(self):
         edit = parse_workspace_edit(dict())
         self.assertEqual(len(edit), 0)
 
-    def parse_changes_from_lsp(self):
+    def test_parse_changes_from_lsp(self):
         edit = parse_workspace_edit(LSP_EDIT_CHANGES)
         self.assertEqual(len(edit), 1)
         self.assertEqual(len(edit['/file.py']), 1)
 
-    def parse_document_changes_from_lsp(self):
+    def test_parse_document_changes_from_lsp(self):
         edit = parse_workspace_edit(LSP_EDIT_DOCUMENT_CHANGES)
         self.assertEqual(len(edit), 1)
         self.assertEqual(len(edit['/file.py']), 1)

--- a/plugin/core/test_edit.py
+++ b/plugin/core/test_edit.py
@@ -1,0 +1,71 @@
+import unittest
+from .edit import sort_by_application_order, parse_workspace_edit, parse_text_edit
+from .test_protocol import LSP_RANGE
+
+try:
+    from typing import List, Dict, Optional, Any, Iterable, Tuple
+    from .edit import TextEdit
+    assert List and Dict and Optional and Any and Iterable and Tuple and TextEdit
+except ImportError:
+    pass
+
+LSP_TEXT_EDIT = dict(newText='newText', range=LSP_RANGE)
+
+LSP_EDIT_CHANGES = {
+    'changes': {
+        'file:///file.py': [LSP_TEXT_EDIT]
+    }
+}
+
+LSP_EDIT_DOCUMENT_CHANGES = {
+    'documentChanges': [{
+        'document': {'uri': 'file:///file.py'},
+        'edits': [LSP_TEXT_EDIT]
+    }]
+}
+
+
+class TextEditTests(unittest.TestCase):
+
+    def parse_from_lsp(self):
+        (start, end, newText) = parse_text_edit(LSP_TEXT_EDIT)
+        self.assertEqual(newText, 'newText')
+        self.assertEqual(start[0], 10)
+        self.assertEqual(start[1], 4)
+        self.assertEqual(end[0], 11)
+        self.assertEqual(end[1], 3)
+
+
+class WorkspaceEditTests(unittest.TestCase):
+
+    def parse_no_changes_from_lsp(self):
+        edit = parse_workspace_edit(dict())
+        self.assertEqual(len(edit), 0)
+
+    def parse_changes_from_lsp(self):
+        edit = parse_workspace_edit(LSP_EDIT_CHANGES)
+        self.assertEqual(len(edit), 1)
+        self.assertEqual(len(edit['/file.py']), 1)
+
+    def parse_document_changes_from_lsp(self):
+        edit = parse_workspace_edit(LSP_EDIT_DOCUMENT_CHANGES)
+        self.assertEqual(len(edit), 1)
+        self.assertEqual(len(edit['/file.py']), 1)
+
+
+class SortByApplicationOrderTests(unittest.TestCase):
+
+    def test_empty_sort(self):
+        self.assertEqual(sort_by_application_order([]), [])
+
+    def test_sorts_backwards(self):
+        edits = [
+            ((0, 0), (0, 0), 'b'),
+            ((0, 0), (0, 0), 'a'),
+            ((0, 2), (0, 2), 'c')
+        ]
+        # expect 'c' (higher start), 'a' now reverse order before 'b'
+        sorted = sort_by_application_order(edits)
+        self.assertEqual(sorted[0][2], 'c')
+        self.assertEqual(sorted[1][2], 'a')
+        self.assertEqual(sorted[2][2], 'b')

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -2,7 +2,7 @@ from .diagnostics import WindowDiagnostics, DiagnosticsUpdate
 from .events import global_events
 from .logging import debug, server_log
 from .types import ClientStates, ClientConfig, WindowLike, ViewLike, LanguageConfig, config_supports_syntax
-from .protocol import Notification, Response
+from .protocol import Notification, Response, parse_workspace_edit
 from .sessions import Session
 from .url import filename_to_uri
 from .workspace import get_project_path
@@ -419,8 +419,8 @@ class WindowManager(object):
 
     def _apply_workspace_edit(self, params: 'Dict[str, Any]', client: Client, request_id: int) -> None:
         edit = params.get('edit', dict())
-        self._window.run_command('lsp_apply_workspace_edit', {'changes': edit.get('changes'),
-                                                              'document_changes': edit.get('documentChanges')})
+        changes = parse_workspace_edit(edit)
+        self._window.run_command('lsp_apply_workspace_edit', {'changes': changes})
         # TODO: We should ideally wait for all changes to have been applied.
         # This however seems overly complicated, because we have to bring along a string representation of the
         # client through the sublime-command invocations (as well as the request ID, but that is easy), and then

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -2,7 +2,8 @@ from .diagnostics import WindowDiagnostics, DiagnosticsUpdate
 from .events import global_events
 from .logging import debug, server_log
 from .types import ClientStates, ClientConfig, WindowLike, ViewLike, LanguageConfig, config_supports_syntax
-from .protocol import Notification, Response, parse_workspace_edit
+from .protocol import Notification, Response
+from .edit import parse_workspace_edit
 from .sessions import Session
 from .url import filename_to_uri
 from .workspace import get_project_path

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -1,0 +1,61 @@
+import sublime
+import sublime_plugin
+from .core.edit import sort_by_application_order
+try:
+    from typing import List, Dict, Optional, Any, Iterable, Tuple
+    from .core.edit import TextEdit
+    assert List and Dict and Optional and Any and Iterable and Tuple
+except ImportError:
+    pass
+from .core.logging import debug
+
+
+class LspApplyWorkspaceEditCommand(sublime_plugin.WindowCommand):
+    def run(self, changes: 'Optional[Dict[str, List[TextEdit]]]'=None):
+        documents_changed = 0
+        if changes:
+            for path, document_changes in changes.items():
+                self.open_and_apply_edits(path, document_changes)
+                documents_changed += 1
+
+        if documents_changed > 0:
+            message = 'Applied changes to {} documents'.format(documents_changed)
+            self.window.status_message(message)
+        else:
+            self.window.status_message('No changes to apply to workspace')
+
+    def open_and_apply_edits(self, path, file_changes):
+        view = self.window.open_file(path)
+        if view:
+            if view.is_loading():
+                # TODO: wait for event instead.
+                sublime.set_timeout_async(
+                    lambda: view.run_command('lsp_apply_document_edit', {'changes': file_changes}),
+                    500
+                )
+            else:
+                view.run_command('lsp_apply_document_edit',
+                                 {'changes': file_changes,
+                                  'show_status': False})
+        else:
+            debug('view not found to apply', path, file_changes)
+
+
+class LspApplyDocumentEditCommand(sublime_plugin.TextCommand):
+    def run(self, edit, changes: 'Optional[List[TextEdit]]'=None):
+        # Apply the changes in reverse, so that we don't invalidate the range
+        # of any change that we haven't applied yet.
+        if changes:
+            for change in sort_by_application_order(changes):
+                start, end, newText = change
+                region = sublime.Region(self.view.text_point(*start), self.view.text_point(*end))
+                self.apply_change(region, newText, edit)
+
+    def apply_change(self, region: 'sublime.Region', newText: str, edit):
+        if region.empty():
+            self.view.insert(edit, region.a, newText)
+        else:
+            if len(newText) > 0:
+                self.view.replace(edit, region, newText)
+            else:
+                self.view.erase(edit, region)

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -4,7 +4,7 @@ from .core.edit import sort_by_application_order
 try:
     from typing import List, Dict, Optional, Any, Iterable, Tuple
     from .core.edit import TextEdit
-    assert List and Dict and Optional and Any and Iterable and Tuple
+    assert List and Dict and Optional and Any and Iterable and Tuple and TextEdit
 except ImportError:
     pass
 from .core.logging import debug

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,4 +1,5 @@
-from .core.protocol import Request, Edit
+from .core.protocol import Request
+from .core.edit import parse_text_edit
 from .core.registry import client_for_view, LspTextCommand
 from .core.types import ViewLike
 from .core.url import filename_to_uri
@@ -18,8 +19,8 @@ def options_for_view(view: ViewLike) -> 'Dict[str, Any]':
     }
 
 
-def apply_reponse_to_view(response, view):
-    edits = list(Edit.from_lsp(change) for change in response) if response else []
+def apply_response_to_view(response, view):
+    edits = list(parse_text_edit(change) for change in response) if response else []
     view.run_command('lsp_apply_document_edit', {'changes': edits})
 
 
@@ -41,7 +42,7 @@ class LspFormatDocumentCommand(LspTextCommand):
             }
             request = Request.formatting(params)
             client.send_request(
-                request, lambda response: apply_reponse_to_view(response, self.view))
+                request, lambda response: apply_response_to_view(response, self.view))
 
 
 class LspFormatDocumentRangeCommand(LspTextCommand):
@@ -68,4 +69,4 @@ class LspFormatDocumentRangeCommand(LspTextCommand):
                 "options": options_for_view(self.view)
             }
             client.send_request(Request.rangeFormatting(params),
-                                lambda response: apply_reponse_to_view(response, self.view))
+                                lambda response: apply_response_to_view(response, self.view))

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -1,6 +1,6 @@
 import sublime_plugin
 from .core.registry import client_for_view, LspTextCommand
-from .core.protocol import Request
+from .core.protocol import Request, parse_workspace_edit
 from .core.documents import get_document_position, get_position, is_at_word
 try:
     from typing import List, Dict, Optional
@@ -64,9 +64,9 @@ class LspSymbolRenameCommand(LspTextCommand):
 
     def handle_response(self, response: 'Optional[Dict]') -> None:
         if response:
+            changes = parse_workspace_edit(response)
             self.view.window().run_command('lsp_apply_workspace_edit',
-                                           {'changes': response.get('changes'),
-                                            'document_changes': response.get('documentChanges')})
+                                           {'changes': changes})
         else:
             self.view.window().status_message('No rename edits returned')
 

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -1,6 +1,7 @@
 import sublime_plugin
 from .core.registry import client_for_view, LspTextCommand
-from .core.protocol import Request, parse_workspace_edit
+from .core.protocol import Request
+from .core.edit import parse_workspace_edit
 from .core.documents import get_document_position, get_position, is_at_word
 try:
     from typing import List, Dict, Optional

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,15 +1,12 @@
 from unittesting import DeferrableTestCase
+
 import sublime
 
-
-def text_edit(Start: 'Tuple[int, int]', End: 'Tuple[int, int]', NewText: str):
-    return {
-        'range': {
-            'start': {'line': Start[0], 'character': Start[1]},
-            'end': {'line': End[0], 'character': End[1]},
-        },
-        'newText': NewText,
-    }
+try:
+    from typing import Tuple
+    assert Tuple
+except ImportError:
+    pass
 
 
 class ApplyDocumentEditTests(DeferrableTestCase):
@@ -25,9 +22,9 @@ class ApplyDocumentEditTests(DeferrableTestCase):
             '</dom-module>\n'
         )
         file_changes = [
-            text_edit((0, 28), (1, 0), ''),  # delete first \n
-            text_edit((1, 0), (1, 15), ''),  # delete second line (but not the \n)
-            text_edit((2, 10), (2, 10), '\n    <style></style>'),  # insert after <template>
+            ((0, 28), (1, 0), ''),  # delete first \n
+            ((1, 0), (1, 15), ''),  # delete second line (but not the \n)
+            ((2, 10), (2, 10), '\n    <style></style>'),  # insert after <template>
         ]
         expected = (
             '<dom-module id="some-thing">\n'
@@ -45,12 +42,12 @@ class ApplyDocumentEditTests(DeferrableTestCase):
         )
         # Note that (1, 2) comes before (0, 1) in the text.
         file_changes = [
-            text_edit((1, 2), (1, 2), '4'),  # insert after the g
-            text_edit((1, 2), (1, 2), '5'),
-            text_edit((1, 2), (1, 3), '6'),  # replace the h
-            text_edit((0, 1), (0, 1), '1'),  # insert after a
-            text_edit((0, 1), (0, 1), '2'),
-            text_edit((0, 1), (0, 1), '3'),
+            ((1, 2), (1, 2), '4'),  # insert after the g
+            ((1, 2), (1, 2), '5'),
+            ((1, 2), (1, 3), '6'),  # replace the h
+            ((0, 1), (0, 1), '1'),  # insert after a
+            ((0, 1), (0, 1), '2'),
+            ((0, 1), (0, 1), '3'),
         ]
         expected = (
             'a123bcde\n'
@@ -61,7 +58,7 @@ class ApplyDocumentEditTests(DeferrableTestCase):
     def run_test(self, original: str, expected: str, file_changes):
         self.view.run_command('insert', {"characters": original})
         self.view.run_command(
-            'lsp_apply_document_edit', {'changes': file_changes, 'show_status': False})
+            'lsp_apply_document_edit', {'changes': file_changes})
         edited_content = self.view.substr(sublime.Region(0, self.view.size()))
         self.assertEquals(edited_content, expected)
 


### PR DESCRIPTION
Separate sublime-tied logic to plugin/edit.py.
Add tests for remaining logic (response parsing, sorting)
Remove debugging status/logging when applying doc edits.

Part of an effort to improve unit test coverage.