### PR TITLE
Move parsing and formatting of signature help to core with tests

### DIFF
--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -91,7 +91,7 @@ class SignatureHelp(object):
                 if param_docs:
                     formatted.append("**{}**\n".format(parameter.get('label')))
                     formatted.append("* *{}*\n".format(param_docs))
-        sigDocs = signature.get('documentation', None)
+        sigDocs = get_documentation(signature)
         if sigDocs:
             formatted.append(sigDocs)
         return "\n".join(formatted)

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -66,6 +66,15 @@ class SignatureHelp(object):
         else:
             return self._build_popup_content_style_sublime()
 
+    def has_overloads(self) -> bool:
+        return len(self._signatures) > 1
+
+    def select_signature(self, direction: int) -> None:
+        new_index = self._active_signature + direction
+
+        # clamp signature index
+        self._active_signature = max(0, min(new_index, len(self._signatures) - 1))
+
     def _build_overload_selector(self) -> str:
         return "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
             str(self._active_signature + 1), str(len(self._signatures)))

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -1,0 +1,151 @@
+import re
+import html
+from .logging import debug
+from .types import Settings
+try:
+    from typing import Tuple, Optional, Dict, List, Union, Any
+    assert Tuple and Optional and Dict and List and Union and Any
+except ImportError:
+    pass
+
+
+def get_documentation(d: 'Dict[str, Any]') -> 'Optional[str]':
+    docs = d.get('documentation', None)
+    if docs is None:
+        return None
+    elif isinstance(docs, str):
+        # In older version of the protocol, documentation was just a string.
+        return docs
+    elif isinstance(docs, dict):
+        # This can be either "plaintext" or "markdown" format. For now, we can dump it into the popup box. It would
+        # be nice to handle the markdown in a special way.
+        return docs.get('value', None)
+    else:
+        debug('unknown documentation type:', str(d))
+        return None
+
+
+def create_signature_help(response: 'Optional[Dict]', language_id, settings: Settings) -> 'Optional[SignatureHelp]':
+    signatures = []  # type: List[Dict]
+    active_signature = -1
+    active_parameter = -1
+    if response is not None:
+        signatures = response.get("signatures", [])
+        active_signature = response.get("activeSignature", -1)
+        active_parameter = response.get("activeParameter", -1)
+
+        if len(signatures) > 0:
+            if not 0 <= active_signature < len(signatures):
+                debug("activeSignature {} not a valid index for signatures length {}".format(
+                    active_signature, len(signatures)))
+                active_signature = 0
+        else:
+            if active_signature != -1:
+                debug("activeSignature should be -1 or null when no signatures are returned")
+                active_signature = -1
+
+    if signatures:
+        return SignatureHelp(signatures, language_id, active_signature, active_parameter,
+                             settings.highlight_active_signature_parameter)
+    else:
+        return None
+
+
+class SignatureHelp(object):
+
+    def __init__(self, signatures, language_id, active_signature=0, active_parameter=0, highlight_parameter=False):
+        self._signatures = signatures
+        self._language_id = language_id
+        self._active_signature = active_signature
+        self._active_parameter = active_parameter
+        self._highlight_parameter = highlight_parameter
+
+    def build_popup_content(self) -> str:
+        if self._highlight_parameter:
+            return self._build_popup_content_style_vscode()
+        else:
+            return self._build_popup_content_style_sublime()
+
+    def _build_overload_selector(self) -> str:
+        return "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
+            str(self._active_signature + 1), str(len(self._signatures)))
+
+    def _build_popup_content_style_sublime(self) -> str:
+        signature = self._signatures[self._active_signature]
+        formatted = []
+
+        if len(self._signatures) > 1:
+            formatted.append(self._build_overload_selector())
+
+        signature_label = signature.get('label')
+        if len(signature_label) > 400:
+            label = "```{} ...```".format(signature_label[0:400])  # long code blocks = hangs
+        else:
+            label = "```{}\n{}\n```\n".format(self._language_id, signature_label)
+        formatted.append(label)
+
+        params = signature.get('parameters')
+        if params:
+            for parameter in params:
+                param_docs = get_documentation(parameter)
+                if param_docs:
+                    formatted.append("**{}**\n".format(parameter.get('label')))
+                    formatted.append("* *{}*\n".format(param_docs))
+        sigDocs = signature.get('documentation', None)
+        if sigDocs:
+            formatted.append(sigDocs)
+        return "\n".join(formatted)
+
+    def _build_popup_content_style_vscode(self) -> str:
+        # Fetch all the relevant data.
+        signature_label = ""
+        signature_documentation = ""  # type: Optional[str]
+        parameter_label = ""
+        parameter_documentation = ""  # type: Optional[str]
+        if self._active_signature in range(0, len(self._signatures)):
+            signature = self._signatures[self._active_signature]
+            signature_label = html.escape(signature["label"], quote=False)
+            signature_documentation = get_documentation(signature)
+            parameters = signature.get("parameters", None)
+            if parameters and self._active_parameter in range(0, len(parameters)):
+                parameter = parameters[self._active_parameter]
+                parameter_label = html.escape(parameter["label"], quote=False)
+                parameter_documentation = get_documentation(parameter)
+
+        formatted = []
+
+        if len(self._signatures) > 1:
+            formatted.append(self._build_overload_selector())
+
+        # Write the active signature and give special treatment to the active parameter (if found).
+        # Note that this <div> class and the extra <pre> are copied from mdpopups' HTML output. When mdpopups changes
+        # its output style, we must update this literal string accordingly.
+        formatted.append('<div class="highlight"><pre>')
+        if parameter_label:
+            signature_label = self._replace_active_parameter(signature_label, parameter_label)
+        formatted.append(signature_label)
+        formatted.append("</pre></div>")
+
+        if parameter_documentation:
+            formatted.append(parameter_documentation)
+
+        if signature_documentation:
+            formatted.append(signature_documentation)
+
+        return "\n".join(formatted)
+
+    def _replace_active_parameter(self, signature: str, parameter: str) -> str:
+        if parameter[0].isalnum() and parameter[-1].isalnum():
+            pattern = r'\b{}\b'.format(re.escape(parameter))
+        else:
+            # If the left or right boundary of the parameter string is not an alphanumeric character, the \b check will
+            # never match. In this case, it's probably safe to assume the parameter string itself will be a good pattern
+            # to search for.
+            pattern = re.escape(parameter)
+        replacement = '<span style="font-weight: bold; text-decoration: underline">{}</span>'.format(parameter)
+        # FIXME: This is somewhat language-specific to look for an opening parenthesis. Most languages use parentheses
+        # for their parameter lists though.
+        start_of_param_list_pos = signature.find('(')
+        # Note that this works even when we don't find an opening parenthesis, because .find returns -1 in that case.
+        start_of_param_list = signature[start_of_param_list_pos + 1:]
+        return signature[:start_of_param_list_pos + 1] + re.sub(pattern, replacement, start_of_param_list, 1)

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -58,10 +58,6 @@ def create_signature_help(response: 'Optional[Dict]', language_id, settings: Set
                 debug("activeSignature {} not a valid index for signatures length {}".format(
                     active_signature, len(signatures)))
                 active_signature = 0
-        else:
-            if active_signature != -1:
-                debug("activeSignature should be -1 or null when no signatures are returned")
-                active_signature = -1
 
     if signatures:
         return SignatureHelp(signatures, language_id, active_signature, active_parameter,

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -6,6 +6,14 @@ language_id = "asdf"
 settings = Settings()
 signature = {
     'label': 'foo_bar(value: int) -> None',
+    'documentation': {'value': 'The default function for foobaring'},
+    'parameters': [{
+        'label': 'value'
+    }]
+}  # type: dict
+signature_overload = {
+    'label': 'foo_bar(value: int, multiplier: int) -> None',
+    'documentation': {'value': 'Foobaring with a multipler'},
     'parameters': [{
         'label': 'value'
     }]
@@ -15,11 +23,13 @@ signature = {
 SUBLIME_SINGLE_SIGNATURE = """```asdf
 foo_bar(value: int) -> None
 ```
-"""
+
+The default function for foobaring"""
 
 VSCODE_SINGLE_SIGNATURE = """<div class="highlight"><pre>
 foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int) -&gt; None
-</pre></div>"""
+</pre></div>
+The default function for foobaring"""
 
 
 class GetDocumentationTests(unittest.TestCase):

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -8,14 +8,23 @@ signature = {
     'label': 'foo_bar(value: int) -> None',
     'documentation': {'value': 'The default function for foobaring'},
     'parameters': [{
-        'label': 'value'
+        'label': 'value',
+        'documentation': {
+            'value': 'A number to foobar on'
+        }
     }]
 }  # type: dict
 signature_overload = {
     'label': 'foo_bar(value: int, multiplier: int) -> None',
     'documentation': {'value': 'Foobaring with a multipler'},
     'parameters': [{
-        'label': 'value'
+        'label': 'value',
+        'documentation': {
+            'value': 'A number to foobar on'
+        }
+    }, {
+        'label': 'multiplier',
+        'documentation': 'Change foobar to work on larger increments'
     }]
 }  # type: dict
 
@@ -24,11 +33,16 @@ SUBLIME_SINGLE_SIGNATURE = """```asdf
 foo_bar(value: int) -> None
 ```
 
+**value**
+
+* *A number to foobar on*
+
 The default function for foobaring"""
 
 VSCODE_SINGLE_SIGNATURE = """<div class="highlight"><pre>
 foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int) -&gt; None
 </pre></div>
+A number to foobar on
 The default function for foobaring"""
 
 

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -2,7 +2,7 @@ from .signature_help import create_signature_help, SignatureHelp, get_documentat
 from .types import Settings
 import unittest
 
-language_id = "asdf"
+language_id = "python"
 settings = Settings()
 signature = {
     'label': 'foo_bar(value: int) -> None',
@@ -16,7 +16,7 @@ signature = {
 }  # type: dict
 signature_overload = {
     'label': 'foo_bar(value: int, multiplier: int) -> None',
-    'documentation': {'value': 'Foobaring with a multipler'},
+    'documentation': {'value': 'Foobaring with a multiplier'},
     'parameters': [{
         'label': 'value',
         'documentation': {
@@ -29,7 +29,7 @@ signature_overload = {
 }  # type: dict
 
 
-SUBLIME_SINGLE_SIGNATURE = """```asdf
+SUBLIME_SINGLE_SIGNATURE = """```python
 foo_bar(value: int) -> None
 ```
 
@@ -39,11 +39,55 @@ foo_bar(value: int) -> None
 
 The default function for foobaring"""
 
+SUBLIME_OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate):
+
+```python
+foo_bar(value: int) -> None
+```
+
+**value**
+
+* *A number to foobar on*
+
+The default function for foobaring"""
+
+SUBLIME_OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
+
+```python
+foo_bar(value: int, multiplier: int) -> None
+```
+
+**value**
+
+* *A number to foobar on*
+
+**multiplier**
+
+* *Change foobar to work on larger increments*
+
+Foobaring with a multiplier"""
+
 VSCODE_SINGLE_SIGNATURE = """<div class="highlight"><pre>
 foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int) -&gt; None
 </pre></div>
 A number to foobar on
 The default function for foobaring"""
+
+VSCODE_OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate):
+
+<div class="highlight"><pre>
+foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int) -&gt; None
+</pre></div>
+A number to foobar on
+The default function for foobaring"""
+
+VSCODE_OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
+
+<div class="highlight"><pre>
+foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int, multiplier: int) -&gt; None
+</pre></div>
+A number to foobar on
+Foobaring with a multiplier"""
 
 
 class GetDocumentationTests(unittest.TestCase):
@@ -83,7 +127,21 @@ class SublimeSignatureHelpTests(unittest.TestCase):
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
+            self.assertFalse(help.has_overloads())
             self.assertEqual(content, SUBLIME_SINGLE_SIGNATURE)
+
+    def test_overload(self):
+        help = SignatureHelp([signature, signature_overload], language_id)
+        self.assertIsNotNone(help)
+        if help:
+            content = help.build_popup_content()
+            self.assertTrue(help.has_overloads())
+            self.assertEqual(content, SUBLIME_OVERLOADS_FIRST)
+
+            help.select_signature(1)
+            help.select_signature(1)  # verify we don't go out of bounds,
+            content = help.build_popup_content()
+            self.assertEqual(content, SUBLIME_OVERLOADS_SECOND)
 
 
 class VsCodeSignatureHelpTests(unittest.TestCase):
@@ -93,4 +151,18 @@ class VsCodeSignatureHelpTests(unittest.TestCase):
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
+            self.assertFalse(help.has_overloads())
             self.assertEqual(content, VSCODE_SINGLE_SIGNATURE)
+
+    def test_overload(self):
+        help = SignatureHelp([signature, signature_overload], language_id, highlight_parameter=True)
+        self.assertIsNotNone(help)
+        if help:
+            content = help.build_popup_content()
+            self.assertTrue(help.has_overloads())
+            self.assertEqual(content, VSCODE_OVERLOADS_FIRST)
+
+            help.select_signature(1)
+            help.select_signature(1)  # verify we don't go out of bounds,
+            content = help.build_popup_content()
+            self.assertEqual(content, VSCODE_OVERLOADS_SECOND)

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -1,0 +1,72 @@
+from .signature_help import create_signature_help, SignatureHelp, get_documentation
+from .types import Settings
+import unittest
+
+language_id = "asdf"
+settings = Settings()
+signature = {
+    'label': 'foo_bar(value: int) -> None',
+    'parameters': [{
+        'label': 'value'
+    }]
+}  # type: dict
+
+
+SUBLIME_SINGLE_SIGNATURE = """```asdf
+foo_bar(value: int) -> None
+```
+"""
+
+VSCODE_SINGLE_SIGNATURE = """<div class="highlight"><pre>
+foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int) -&gt; None
+</pre></div>"""
+
+
+class GetDocumentationTests(unittest.TestCase):
+
+    def test_absent(self):
+        self.assertIsNone(get_documentation({}))
+
+    def test_is_str(self):
+        self.assertEqual(get_documentation({'documentation': 'str'}), 'str')
+
+    def test_is_dict(self):
+        self.assertEqual(get_documentation({'documentation': {'value': 'value'}}), 'value')
+
+
+class CreateSignatureHelpTests(unittest.TestCase):
+
+    def test_none(self):
+        self.assertIsNone(create_signature_help(None, language_id, settings))
+
+    def test_empty(self):
+        self.assertIsNone(create_signature_help({}, language_id, settings))
+
+    def test_default_indices(self):
+
+        help = create_signature_help({"signatures": [signature]}, language_id, settings)
+
+        self.assertIsNotNone(help)
+        if help:
+            self.assertEqual(help._active_signature, 0)
+            self.assertEqual(help._active_parameter, -1)
+
+
+class SublimeSignatureHelpTests(unittest.TestCase):
+
+    def test_single_signature(self):
+        help = SignatureHelp([signature], language_id)
+        self.assertIsNotNone(help)
+        if help:
+            content = help.build_popup_content()
+            self.assertEqual(content, SUBLIME_SINGLE_SIGNATURE)
+
+
+class VsCodeSignatureHelpTests(unittest.TestCase):
+
+    def test_single_signature(self):
+        help = SignatureHelp([signature], language_id, highlight_parameter=True)
+        self.assertIsNotNone(help)
+        if help:
+            content = help.build_popup_content()
+            self.assertEqual(content, VSCODE_SINGLE_SIGNATURE)

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -97,7 +97,6 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
     def handle_response(self, response: 'Optional[Dict]', point) -> None:
         self._help = create_signature_help(response, self._language_id, settings)
 
-        # if len(self._signatures) > 0:
         if self._help:
             if self._visible:
                 self._update_popup()
@@ -113,21 +112,15 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                 return True
             else:
                 return False  # Let someone else handle this keybinding.
-        elif len(self._signatures) < 2:
-            return False  # Let someone else handle this keybinding.
-        else:
+        elif self._help and self._help.has_overloads():
+
             # We use the "operand" for the number -1 or +1. See the keybindings.
-            new_index = self._active_signature + operand
-
-            # clamp signature index
-            new_index = max(0, min(new_index, len(self._signatures) - 1))
-
-            # only update when changed
-            if new_index != self._active_signature:
-                self._active_signature = new_index
-                self._update_popup()
+            self._help.select_signature(operand)
+            self._update_popup()
 
             return True  # We handled this keybinding.
+
+        return False
 
     def _build_popup_content(self) -> str:
         if self._help:

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -2,8 +2,6 @@ import mdpopups
 import sublime
 import sublime_plugin
 import webbrowser
-import re
-import html
 
 try:
     from typing import Any, List, Dict, Optional
@@ -18,7 +16,9 @@ from .core.events import global_events
 from .core.protocol import Request
 from .core.logging import debug
 from .core.popups import popup_css, popup_class
-from .core.settings import settings, client_configs
+from .core.settings import client_configs, settings
+from .core.signature_help import create_signature_help, SignatureHelp
+assert SignatureHelp
 
 
 def get_documentation(d: 'Dict[str, Any]') -> 'Optional[str]':
@@ -45,9 +45,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         self._signature_help_triggers = []  # type: List[str]
         self._visible = False
         self._language_id = ""
-        self._signatures = []  # type: List[Any]
-        self._active_signature = -1
-        self._active_parameter = -1
+        self._help = None  # type: Optional[SignatureHelp]
 
     @classmethod
     def is_applicable(cls, settings):
@@ -97,26 +95,14 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                     lambda response: self.handle_response(response, point))
 
     def handle_response(self, response: 'Optional[Dict]', point) -> None:
-        if response is not None:
-            self._signatures = response.get("signatures", [])
-            self._active_signature = response.get("activeSignature", -1)
-            self._active_parameter = response.get("activeParameter", -1)
+        self._help = create_signature_help(response, self._language_id, settings)
 
-            if self._signatures:
-                if not 0 <= self._active_signature < len(self._signatures):
-                    debug("activeSignature {} not a valid index for signatures length {}".format(
-                        self._active_signature, len(self._signatures)))
-                    self._active_signature = 0
+        # if len(self._signatures) > 0:
+        if self._help:
+            if self._visible:
+                self._update_popup()
             else:
-                if self._active_signature != -1:
-                    debug("activeSignature should be -1 or null when no signatures are returned")
-                    self._active_signature = -1
-
-            if len(self._signatures) > 0:
-                if self._visible:
-                    self._update_popup()
-                else:
-                    self._show_popup(point)
+                self._show_popup(point)
 
     def on_query_context(self, key, _, operand, __):
         if key != "lsp.signature_help":
@@ -143,6 +129,11 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
 
             return True  # We handled this keybinding.
 
+    def _build_popup_content(self) -> str:
+        if self._help:
+            return self._help.build_popup_content()
+        return ""
+
     def _show_popup(self, point: int) -> None:
         mdpopups.show_popup(self.view,
                             self._build_popup_content(),
@@ -163,13 +154,6 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                               md=True,
                               wrapper_class=popup_class)
 
-    def _build_popup_content(self) -> str:
-        if settings.highlight_active_signature_parameter:
-            return self._build_popup_content_style_vscode()
-        else:
-            # Default to "sublime".
-            return self._build_popup_content_style_sublime()
-
     def _view_language(self, view: sublime.View, config_name: str) -> 'Optional[str]':
         languages = view.settings().get('lsp_language')
         return languages.get(config_name) if languages else None
@@ -179,87 +163,3 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
 
     def _on_hover_navigate(self, href):
         webbrowser.open_new_tab(href)
-
-    def _build_overload_selector(self) -> str:
-        return "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
-            str(self._active_signature + 1), str(len(self._signatures)))
-
-    def _build_popup_content_style_sublime(self) -> str:
-        signature = self._signatures[self._active_signature]
-        formatted = []
-
-        if len(self._signatures) > 1:
-            formatted.append(self._build_overload_selector())
-
-        signature_label = signature.get('label')
-        if len(signature_label) > 400:
-            label = "```{} ...```".format(signature_label[0:400])  # long code blocks = hangs
-        else:
-            label = "```{}\n{}\n```\n".format(self._language_id, signature_label)
-        formatted.append(label)
-
-        params = signature.get('parameters')
-        if params:
-            for parameter in params:
-                param_docs = get_documentation(parameter)
-                if param_docs:
-                    formatted.append("**{}**\n".format(parameter.get('label')))
-                    formatted.append("* *{}*\n".format(param_docs))
-        sigDocs = signature.get('documentation', None)
-        if sigDocs:
-            formatted.append(sigDocs)
-        return "\n".join(formatted)
-
-    def _build_popup_content_style_vscode(self) -> str:
-        # Fetch all the relevant data.
-        signature_label = ""
-        signature_documentation = ""  # type: Optional[str]
-        parameter_label = ""
-        parameter_documentation = ""  # type: Optional[str]
-        if self._active_signature in range(0, len(self._signatures)):
-            signature = self._signatures[self._active_signature]
-            signature_label = html.escape(signature["label"], quote=False)
-            signature_documentation = get_documentation(signature)
-            parameters = signature.get("parameters", None)
-            if parameters and self._active_parameter in range(0, len(parameters)):
-                parameter = parameters[self._active_parameter]
-                parameter_label = html.escape(parameter["label"], quote=False)
-                parameter_documentation = get_documentation(parameter)
-
-        formatted = []
-
-        if len(self._signatures) > 1:
-            formatted.append(self._build_overload_selector())
-
-        # Write the active signature and give special treatment to the active parameter (if found).
-        # Note that this <div> class and the extra <pre> are copied from mdpopups' HTML output. When mdpopups changes
-        # its output style, we must update this literal string accordingly.
-        formatted.append('<div class="highlight"><pre>')
-        if parameter_label:
-            signature_label = self._replace_active_parameter(signature_label, parameter_label)
-        formatted.append(signature_label)
-        formatted.append("</pre></div>")
-
-        if parameter_documentation:
-            formatted.append(parameter_documentation)
-
-        if signature_documentation:
-            formatted.append(signature_documentation)
-
-        return "\n".join(formatted)
-
-    def _replace_active_parameter(self, signature: str, parameter: str) -> str:
-        if parameter[0].isalnum() and parameter[-1].isalnum():
-            pattern = r'\b{}\b'.format(re.escape(parameter))
-        else:
-            # If the left or right boundary of the parameter string is not an alphanumeric character, the \b check will
-            # never match. In this case, it's probably safe to assume the parameter string itself will be a good pattern
-            # to search for.
-            pattern = re.escape(parameter)
-        replacement = '<span style="font-weight: bold; text-decoration: underline">{}</span>'.format(parameter)
-        # FIXME: This is somewhat language-specific to look for an opening parenthesis. Most languages use parentheses
-        # for their parameter lists though.
-        start_of_param_list_pos = signature.find('(')
-        # Note that this works even when we don't find an opening parenthesis, because .find returns -1 in that case.
-        start_of_param_list = signature[start_of_param_list_pos + 1:]
-        return signature[:start_of_param_list_pos + 1] + re.sub(pattern, replacement, start_of_param_list, 1)


### PR DESCRIPTION
To do:
- [x] clean up
- [x] add parameter/signature documentation fields to test data
- [x] test case around overloads
- [x] test case around parameter highlighting