### PR TITLE
Improve in-sublime testing

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -4,6 +4,7 @@ from .transports import start_tcp_transport
 from .rpc import Client, attach_stdio_client
 from .process import start_server
 from .url import filename_to_uri
+from .logging import debug
 import os
 from .protocol import CompletionItemKind, SymbolKind
 try:
@@ -44,7 +45,7 @@ def create_session(config: ClientConfig, project_path: str, env: dict, settings:
             session = Session(config, project_path, bootstrap_client,
                               on_created, on_ended)
         else:
-            raise Exception("No way to start session")
+            debug("No way to start session")
 
     return session
 

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -23,7 +23,6 @@ class MockClient():
         self.responses = {
             'initialize': {"capabilities": dict(testing=True, hoverProvider=True,
                                                 completionProvider=completion_provider, textDocumentSync=True)},
-            'textDocument/hover': {"contents": "greeting"}
         }  # type: dict
         self._notifications = []  # type: List[Notification]
         self._async_response_callback = async_response

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -1,6 +1,7 @@
 from .types import ClientConfig, LanguageConfig, ClientStates, Settings
 from .sessions import create_session, Session
 from .protocol import Request, Notification
+from .logging import debug
 
 import unittest
 import unittest.mock
@@ -11,17 +12,29 @@ except ImportError:
     pass
 
 
+completion_provider = {
+    'triggerCharacters': ['.'],
+    'resolveProvider': False
+}
+
+
 class MockClient():
-    def __init__(self) -> None:
+    def __init__(self, async_response=None) -> None:
         self.responses = {
-            'initialize': {"capabilities": dict(testing=True, hoverProvider=True, textDocumentSync=True)},
+            'initialize': {"capabilities": dict(testing=True, hoverProvider=True,
+                                                completionProvider=completion_provider, textDocumentSync=True)},
             'textDocument/hover': {"contents": "greeting"}
         }  # type: dict
         self._notifications = []  # type: List[Notification]
+        self._async_response_callback = async_response
 
     def send_request(self, request: Request, on_success: 'Callable', on_error: 'Callable' = None) -> None:
         response = self.responses.get(request.method)
-        on_success(response)
+        debug("TEST: responding to", request.method, "with", response)
+        if self._async_response_callback:
+            self._async_response_callback(lambda: on_success(response))
+        else:
+            on_success(response)
 
     def send_notification(self, notification: Notification) -> None:
         self._notifications.append(notification)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,0 +1,69 @@
+import sublime
+from sublime_plugin import view_event_listeners
+from LSP.plugin.core.types import ClientConfig, LanguageConfig
+from LSP.plugin.core.sessions import Session
+from LSP.plugin.core.test_session import MockClient
+from LSP.plugin.core.settings import client_configs
+from os.path import dirname
+from LSP.plugin.core.registry import windows  # , session_for_view
+from unittesting import DeferrableTestCase
+
+test_file_path = dirname(__file__) + "/testfile.txt"
+
+SUPPORTED_SCOPE = "text.plain"
+SUPPORTED_SYNTAX = "Packages/Text/Plain text.tmLanguage"
+text_language = LanguageConfig("text", [SUPPORTED_SCOPE], [SUPPORTED_SYNTAX])
+text_config = ClientConfig("textls", [], None, languages=[text_language])
+
+
+def sublime_delayer(delay):
+    def timeout_function(callable):
+        sublime.set_timeout(callable, delay)
+
+    return timeout_function
+
+
+def add_config(config):
+    client_configs.all.append(config)
+
+
+def remove_config(config):
+    client_configs.all.remove(config)
+
+
+def inject_session(wm, config, client):
+
+    session = Session(config, "", client)
+    # session.state = ClientStates.READY
+    wm.update_configs(client_configs.all)
+    wm._sessions[config.name] = session
+    wm._handle_session_started(session, "", config)
+
+
+def remove_session(wm, config_name):
+    wm._handle_session_ended(config_name)
+
+
+class TextDocumentTestCase(DeferrableTestCase):
+
+    def setUp(self):
+        self.view = sublime.active_window().open_file(test_file_path)
+        self.wm = windows.lookup(self.view.window())
+        self.client = MockClient(async_response=sublime_delayer(100))
+        add_config(text_config)
+        inject_session(self.wm, text_config, self.client)
+        # from LSP import rpdb; rpdb.set_trace()
+
+    def get_view_event_listener(self, unique_attribute: str):
+        for listener in view_event_listeners[self.view.id()]:
+            if unique_attribute in dir(listener):
+                return listener
+
+    def tearDown(self):
+        remove_session(self.wm, text_config.name)
+        remove_config(text_config)
+
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
+            self.view.window().run_command("close_file")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,10 +1,11 @@
-import unittest
 from unittesting import DeferrableTestCase
-from unittest.mock import MagicMock
 import sublime
 from LSP.plugin.completion import CompletionHandler, CompletionState
 from LSP.plugin.core.settings import client_configs, ClientConfig
+from LSP.plugin.core.registry import windows
 from os.path import dirname
+from LSP.plugin.core.sessions import Session
+from LSP.plugin.core.test_session import MockClient
 
 try:
     from typing import Dict, Optional
@@ -13,38 +14,32 @@ except ImportError:
     pass
 
 
-class FakeClient(object):
-
-    def __init__(self):
-        self.response = None
-        pass
-
-    def get_capability(self, capability_name: str):
-        return {
-            'triggerCharacters': ['.'],
-            'resolveProvider': False
-        }
-
-
 SUPPORTED_SCOPE = "text.plain"
-SUPPORTED_SYNTAX = "Lang.sublime-syntax"
-test_client_config = ClientConfig('langls', [], None, [SUPPORTED_SCOPE], [SUPPORTED_SYNTAX], 'lang')
+SUPPORTED_SYNTAX = "Packages/Text/Plain text.tmLanguage"
+test_client_config = ClientConfig('textls', [], None, [SUPPORTED_SCOPE], [SUPPORTED_SYNTAX], 'lang')
 test_file_path = dirname(__file__) + "/testfile.txt"
 
+completions = [dict(label='asdf'), dict(label='efgh')]
 
-@unittest.skip('asd')
+
+def sublime_delayer(delay):
+    def timeout_function(callable):
+        sublime.set_timeout(callable, delay)
+
+    return timeout_function
+
+
 class InitializationTests(DeferrableTestCase):
 
     def setUp(self):
         self.view = sublime.active_window().new_file()
-        self.old_configs = client_configs.all
-        client_configs.all = [test_client_config]
+        client_configs.all.append(test_client_config)
 
     def test_is_not_applicable(self):
         self.assertFalse(CompletionHandler.is_applicable(dict()))
 
     def test_is_applicable(self):
-        self.assertEquals(len(client_configs.all), 1)
+        # self.assertEquals(len(client_configs.all), 1)
         self.assertTrue(CompletionHandler.is_applicable(dict(syntax=SUPPORTED_SYNTAX)))
 
     def test_not_enabled(self):
@@ -52,60 +47,74 @@ class InitializationTests(DeferrableTestCase):
         self.assertFalse(handler.initialized)
         self.assertFalse(handler.enabled)
         result = handler.on_query_completions("", [0])
+        yield 100
         self.assertTrue(handler.initialized)
         self.assertFalse(handler.enabled)
         self.assertIsNone(result)
 
     def tearDown(self):
-        client_configs.all = self.old_configs
+        client_configs.all.remove(test_client_config)
         if self.view:
             self.view.set_scratch(True)
             self.view.window().focus_view(self.view)
             self.view.window().run_command("close_file")
 
 
-@unittest.skip('asf')
-class QueryCompletionsTests(unittest.TestCase):
+class QueryCompletionsTests(DeferrableTestCase):
 
     def setUp(self):
-        self.view = sublime.active_window().open_file(test_file_path)
-        self.old_configs = client_configs.all
-        client_configs.all = [test_client_config]
-        self.client = FakeClient()
-        # add_window_client(sublime.active_window(), test_client_config.name, self.client)
+        window = sublime.active_window()
+        self.view = window.open_file(test_file_path)
+        client_configs.all.append(test_client_config)
+        self.client = MockClient(async_response=sublime_delayer(100))
+        self.client.responses['textDocument/completion'] = completions
+        self.wm = windows.lookup(window)
+        session = Session(test_client_config, "", self.client)
+        self.wm.update_configs(client_configs.all)
+        self.wm._sessions[test_client_config.name] = session
+        self.wm._handle_session_started(session, "", test_client_config)
 
     def test_enabled(self):
-        self.view.run_command('insert', {"characters": '.'})
+        yield 100
 
-        self.client.send_request = MagicMock()
+        from sublime_plugin import view_event_listeners
+        handler = None
+        for listener in view_event_listeners[self.view.id()]:
+            if "on_query_completions" in dir(listener):
+                handler = listener
 
-        handler = CompletionHandler(self.view)
-        self.assertEquals(handler.state, CompletionState.IDLE)
+        # self.assertTrue(CompletionHandler.is_applicable(self.view.settings()))
+        # handler = CompletionHandler(self.view)
+        self.assertIsNotNone(handler)
+        if handler:
 
-        result = handler.on_query_completions("", [1])
-        self.assertIsNotNone(result)
-        items, mask = result
-        self.assertEquals(len(items), 0)
-        self.assertEquals(mask, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+            self.assertEquals(handler.state, CompletionState.IDLE)
 
-        self.assertTrue(handler.initialized)
-        self.assertTrue(handler.enabled)
-        self.assertEquals(handler.state, CompletionState.REQUESTING)
+            # todo: want to test trigger chars?
+            # self.view.run_command('insert', {"characters": '.'})
+            result = handler.on_query_completions("", [1])
 
-        self.client.send_request.assert_called_once()
-        # time.sleep(1000)
-        # self.assertEquals(len(handler.completions), 2)
-        # self.assertEquals(handler.state, CompletionState.APPLYING)
+            # from LSP import rpdb
+            # rpdb.set_trace()
 
-        # running auto_complete command does not work
-        # sublime does not know about the instance we registered here.
-        # we do it directly here
-        # items, mask = handler.on_query_completions("", [1])
+            self.assertTrue(handler.initialized)
+            self.assertTrue(handler.enabled)
+            self.assertIsNotNone(result)
+            items, mask = result
+            self.assertEquals(len(items), 0)
+            self.assertEquals(mask, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
 
-        # self.assertEquals(len(items), 2)
-        # self.assertEquals(mask, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+            yield 100
+            self.assertEquals(handler.state, CompletionState.IDLE)
+            self.assertEquals(len(handler.completions), 2)
+
+            self.view.run_command("insert_best_completion")
+            self.assertEquals(self.view.substr(sublime.Region(0, self.view.size())), completions[0]["label"])
 
     def tearDown(self):
-        client_configs.all = self.old_configs
+        client_configs.all.remove(test_client_config)
+        self.wm._handle_session_ended(test_client_config.name)
         if self.view:
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
             self.view.window().run_command("close_file")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,11 +1,9 @@
 from unittesting import DeferrableTestCase
 import sublime
 from LSP.plugin.completion import CompletionHandler, CompletionState
-from LSP.plugin.core.settings import client_configs, ClientConfig
-from LSP.plugin.core.registry import windows
-from os.path import dirname
-from LSP.plugin.core.sessions import Session
-from LSP.plugin.core.test_session import MockClient
+from setup import (
+    SUPPORTED_SYNTAX, text_config, add_config, remove_config, TextDocumentTestCase
+)
 
 try:
     from typing import Dict, Optional
@@ -14,32 +12,19 @@ except ImportError:
     pass
 
 
-SUPPORTED_SCOPE = "text.plain"
-SUPPORTED_SYNTAX = "Packages/Text/Plain text.tmLanguage"
-test_client_config = ClientConfig('textls', [], None, [SUPPORTED_SCOPE], [SUPPORTED_SYNTAX], 'lang')
-test_file_path = dirname(__file__) + "/testfile.txt"
-
 completions = [dict(label='asdf'), dict(label='efgh')]
-
-
-def sublime_delayer(delay):
-    def timeout_function(callable):
-        sublime.set_timeout(callable, delay)
-
-    return timeout_function
 
 
 class InitializationTests(DeferrableTestCase):
 
     def setUp(self):
         self.view = sublime.active_window().new_file()
-        client_configs.all.append(test_client_config)
+        add_config(text_config)
 
     def test_is_not_applicable(self):
         self.assertFalse(CompletionHandler.is_applicable(dict()))
 
     def test_is_applicable(self):
-        # self.assertEquals(len(client_configs.all), 1)
         self.assertTrue(CompletionHandler.is_applicable(dict(syntax=SUPPORTED_SYNTAX)))
 
     def test_not_enabled(self):
@@ -53,50 +38,28 @@ class InitializationTests(DeferrableTestCase):
         self.assertIsNone(result)
 
     def tearDown(self):
-        client_configs.all.remove(test_client_config)
+        remove_config(text_config)
         if self.view:
             self.view.set_scratch(True)
             self.view.window().focus_view(self.view)
             self.view.window().run_command("close_file")
 
 
-class QueryCompletionsTests(DeferrableTestCase):
-
-    def setUp(self):
-        window = sublime.active_window()
-        self.view = window.open_file(test_file_path)
-        client_configs.all.append(test_client_config)
-        self.client = MockClient(async_response=sublime_delayer(100))
-        self.client.responses['textDocument/completion'] = completions
-        self.wm = windows.lookup(window)
-        session = Session(test_client_config, "", self.client)
-        self.wm.update_configs(client_configs.all)
-        self.wm._sessions[test_client_config.name] = session
-        self.wm._handle_session_started(session, "", test_client_config)
+class QueryCompletionsTests(TextDocumentTestCase):
 
     def test_enabled(self):
         yield 100
 
-        from sublime_plugin import view_event_listeners
-        handler = None
-        for listener in view_event_listeners[self.view.id()]:
-            if "on_query_completions" in dir(listener):
-                handler = listener
+        self.client.responses['textDocument/completion'] = completions
 
-        # self.assertTrue(CompletionHandler.is_applicable(self.view.settings()))
-        # handler = CompletionHandler(self.view)
+        handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)
         if handler:
-
-            self.assertEquals(handler.state, CompletionState.IDLE)
-
-            # todo: want to test trigger chars?
+            # todo: want to test trigger chars instead?
             # self.view.run_command('insert', {"characters": '.'})
             result = handler.on_query_completions("", [1])
 
-            # from LSP import rpdb
-            # rpdb.set_trace()
-
+            # synchronous response
             self.assertTrue(handler.initialized)
             self.assertTrue(handler.enabled)
             self.assertIsNotNone(result)
@@ -104,17 +67,11 @@ class QueryCompletionsTests(DeferrableTestCase):
             self.assertEquals(len(items), 0)
             self.assertEquals(mask, 0)
 
+            # now wait for server response
             yield 100
             self.assertEquals(handler.state, CompletionState.IDLE)
             self.assertEquals(len(handler.completions), 2)
 
+            # verify insertion works
             self.view.run_command("insert_best_completion")
             self.assertEquals(self.view.substr(sublime.Region(0, self.view.size())), completions[0]["label"])
-
-    def tearDown(self):
-        client_configs.all.remove(test_client_config)
-        self.wm._handle_session_ended(test_client_config.name)
-        if self.view:
-            self.view.set_scratch(True)
-            self.view.window().focus_view(self.view)
-            self.view.window().run_command("close_file")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -102,7 +102,7 @@ class QueryCompletionsTests(DeferrableTestCase):
             self.assertIsNotNone(result)
             items, mask = result
             self.assertEquals(len(items), 0)
-            self.assertEquals(mask, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+            self.assertEquals(mask, 0)
 
             yield 100
             self.assertEquals(handler.state, CompletionState.IDLE)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -62,6 +62,7 @@ class WindowConfigTests(DeferrableTestCase):
         self.view = sublime.active_window().open_file(test_file_path)
 
     def test_window_without_configs(self):
+        yield 100
         wm = windows.lookup(sublime.active_window())
         self.assertFalse(wm._configs.syntax_supported(self.view))
 

--- a/tests/test_hover.py
+++ b/tests/test_hover.py
@@ -1,14 +1,5 @@
-from unittesting import DeferrableTestCase
-import sublime
-from os.path import dirname
 from LSP.plugin.hover import _test_contents
-from LSP.plugin.core.types import ClientConfig, ClientStates, LanguageConfig
-from LSP.plugin.core.test_session import MockClient
-from LSP.plugin.core.sessions import Session
-from LSP.plugin.core.registry import windows  # , session_for_view
-from LSP.plugin.core.settings import client_configs
-
-test_file_path = dirname(__file__) + "/testfile.txt"
+from setup import TextDocumentTestCase
 
 ORIGINAL_CONTENT = """Hello Wrld"""
 
@@ -19,46 +10,17 @@ EXPECTED_CONTENT = """<dom-module id="some-thing">
 </dom-module>"""
 
 
-test_language = LanguageConfig("test", ["text.plain"], ["Plain text"])
-text_config = ClientConfig("test", [], None, languages=[test_language],)
-
-
-class LspHoverCommandTests(DeferrableTestCase):
-
-    def setUp(self):
-        self.view = sublime.active_window().open_file(test_file_path)
-        wm = windows.lookup(self.view.window())
-        client_configs.all.append(text_config)
-        wm._configs.all.append(text_config)
-
-        session = Session(text_config, dirname(__file__), MockClient())
-        session.state = ClientStates.READY
-        wm._sessions[text_config.name] = session
-        self.wm = wm
+class LspHoverCommandTests(TextDocumentTestCase):
 
     def test_hover_info(self):
+        self.client.responses['textDocument/hover'] = {"contents": "greeting"}
 
         yield 100  # wait for file to be open
         self.view.run_command('insert', {"characters": ORIGINAL_CONTENT})
-
-        # session = session_for_view(self.view)
-        # self.assertIsNotNone(session)
-        # self.assertTrue(session.has_capability('hoverProvider'))
-
         self.view.run_command('lsp_hover', {'point': 3})
 
-        # popup should be visible eventually
-        yield self.view.is_popup_visible()
+        yield 100  # popup should be visible eventually
+        self.assertTrue(self.view.is_popup_visible())
 
         last_content = _test_contents[-1]
         self.assertTrue("greeting" in last_content)
-
-    def tearDown(self):
-        self.wm._handle_session_ended(text_config.name)
-        self.wm._configs.all.remove(text_config)
-        client_configs.all.remove(text_config)
-
-        if self.view:
-            self.view.set_scratch(True)
-            self.view.window().focus_view(self.view)
-            self.view.window().run_command("close_file")

--- a/tests/test_hover.py
+++ b/tests/test_hover.py
@@ -19,26 +19,27 @@ EXPECTED_CONTENT = """<dom-module id="some-thing">
 </dom-module>"""
 
 
+test_language = LanguageConfig("test", ["text.plain"], ["Plain text"])
+text_config = ClientConfig("test", [], None, languages=[test_language],)
+
+
 class LspHoverCommandTests(DeferrableTestCase):
 
     def setUp(self):
         self.view = sublime.active_window().open_file(test_file_path)
-
-    def test_hover_info(self):
-
-        yield 100  # wait for file to be open
-        self.view.run_command('insert', {"characters": ORIGINAL_CONTENT})
-
         wm = windows.lookup(self.view.window())
-        test_language = LanguageConfig("test", ["text.plain"], ["Plain text"])
-        text_config = ClientConfig("test", [], None, languages=[test_language],)
-        client_configs.add_external_config(text_config)
-        client_configs.update_configs()
+        client_configs.all.append(text_config)
         wm._configs.all.append(text_config)
 
         session = Session(text_config, dirname(__file__), MockClient())
         session.state = ClientStates.READY
         wm._sessions[text_config.name] = session
+        self.wm = wm
+
+    def test_hover_info(self):
+
+        yield 100  # wait for file to be open
+        self.view.run_command('insert', {"characters": ORIGINAL_CONTENT})
 
         # session = session_for_view(self.view)
         # self.assertIsNotNone(session)
@@ -53,6 +54,10 @@ class LspHoverCommandTests(DeferrableTestCase):
         self.assertTrue("greeting" in last_content)
 
     def tearDown(self):
+        self.wm._handle_session_ended(text_config.name)
+        self.wm._configs.all.remove(text_config)
+        client_configs.all.remove(text_config)
+
         if self.view:
             self.view.set_scratch(True)
             self.view.window().focus_view(self.view)


### PR DESCRIPTION
For the code that cannot be unit tested, we want it to be quick and reliable to add an in-sublime test.
This PR restored some disabled tests, extracted some shared setup / teardown logic so tests are less likely to affect each other.
MockClient (rename?) was also changed to support async responses