### PR TITLE
stdio transport fix

### DIFF
--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -39,7 +39,14 @@ class Transport(object, metaclass=ABCMeta):
 
 STATE_HEADERS = 0
 STATE_CONTENT = 1
+STATE_EOF = 2
 
+StateStrings = { STATE_HEADERS: 'STATE_HEADERS'
+               , STATE_CONTENT: 'STATE_CONTENT'
+               , STATE_EOF:     'STATE_EOF'}
+
+def state_to_string(state: int) -> None:
+    return StateStrings.get(state, '<unknown state: %d'.format(state))
 
 def start_tcp_transport(port: int, host: 'Optional[str]' = None) -> 'Transport':
     start_time = time.time()
@@ -159,26 +166,36 @@ class StdioTransport(Transport):
         """
         Reads JSON responses from process and dispatch them to response_handler
         """
-        ContentLengthHeader = b"Content-Length: "
-
         running = True
         while running and self.process:
             running = self.process.poll() is None
 
             try:
+                state = STATE_HEADERS
                 content_length = 0
-                while self.process:
-                    header = self.process.stdout.readline()
-                    if header:
-                        header = header.strip()
-                    if not header:
-                        break
-                    if header.startswith(ContentLengthHeader):
-                        content_length = int(header[len(ContentLengthHeader):])
+                while self.process and state != STATE_EOF:
+                    debug("read_stdout: state = {}".format(state_to_string(state)))
+                    if state == STATE_HEADERS:
+                        header = self.process.stdout.readline()
+                        debug('read_stdout reads: {}'.format(header))
+                        if not header:
+                            ## Truly, this is the EOF on the stream
+                            state = STATE_EOF
+                            break
 
-                if (content_length > 0):
-                    content = self.process.stdout.read(content_length)
-                    self.on_receive(content.decode("UTF-8"))
+                        header = header.strip()
+                        if not header:
+                            ## Not EOF, blank line -> content follows
+                            state = STATE_CONTENT
+                        elif header.startswith(ContentLengthHeader):
+                            content_length = int(header[len(ContentLengthHeader):])
+                    elif state == STATE_CONTENT:
+                        if content_length > 0:
+                            content = self.process.stdout.read(content_length)
+                            self.on_receive(content.decode("UTF-8"))
+                            debug("read_stdout: read and received {} byte message".format(content_length))
+                            content_length = 0
+                        state = STATE_HEADERS
 
             except IOError as err:
                 self.close()
@@ -197,7 +214,8 @@ class StdioTransport(Transport):
                 break
             else:
                 try:
-                    self.process.stdin.write(bytes(message, 'UTF-8'))
+                    msgbytes = bytes(message, 'UTF-8')
+                    self.process.stdin.write(msgbytes)
                     self.process.stdin.flush()
                 except (BrokenPipeError, OSError) as err:
                     exception_log("Failure writing to stdout", err)

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -43,7 +43,7 @@ STATE_EOF = 2
 
 StateStrings = {STATE_HEADERS: 'STATE_HEADERS',
                 STATE_CONTENT: 'STATE_CONTENT',
-               STATE_EOF:     'STATE_EOF'}
+                STATE_EOF:     'STATE_EOF'}
 
 
 def state_to_string(state: int) -> str:

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -41,12 +41,14 @@ STATE_HEADERS = 0
 STATE_CONTENT = 1
 STATE_EOF = 2
 
-StateStrings = { STATE_HEADERS: 'STATE_HEADERS'
-               , STATE_CONTENT: 'STATE_CONTENT'
-               , STATE_EOF:     'STATE_EOF'}
+StateStrings = {STATE_HEADERS: 'STATE_HEADERS',
+                STATE_CONTENT: 'STATE_CONTENT',
+               STATE_EOF:     'STATE_EOF'}
 
-def state_to_string(state: int) -> None:
-    return StateStrings.get(state, '<unknown state: %d'.format(state))
+
+def state_to_string(state: int) -> str:
+    return StateStrings.get(state, '<unknown state: %d>'.format(state))
+
 
 def start_tcp_transport(port: int, host: 'Optional[str]' = None) -> 'Transport':
     start_time = time.time()
@@ -179,13 +181,13 @@ class StdioTransport(Transport):
                         header = self.process.stdout.readline()
                         debug('read_stdout reads: {}'.format(header))
                         if not header:
-                            ## Truly, this is the EOF on the stream
+                            # Truly, this is the EOF on the stream
                             state = STATE_EOF
                             break
 
                         header = header.strip()
                         if not header:
-                            ## Not EOF, blank line -> content follows
+                            # Not EOF, blank line -> content follows
                             state = STATE_CONTENT
                         elif header.startswith(ContentLengthHeader):
                             content_length = int(header[len(ContentLengthHeader):])


### PR DESCRIPTION
Give the stdio transport a bit of love, fix a fairly subtle bug that might have mistaken an empty string as EOF, make the processing loop state-driven like the TCP transport.

The LSP protocol does insert a blank line between the headers to signal where the content starts. There was a subtle bug in the stdio processing loop that could have mistaken a blank line as EOF, which is what `readline()` returns when it reads EOF.

I came across this while debugging an issue in `haskell-ide-engine`.