### PR TITLE
WIP: Unify signature helps

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -328,10 +328,6 @@
   // Valid values are "underline" or "box"
   "diagnostics_highlight_style": "underline",
 
-  // If true, highlight the active parameter of the currently active signature.
-  // Note that this disables mdpopups highlighting.
-  "highlight_active_signature_parameter": true,
-
   // Highlighting style of "highlights": accentuating nearby text entities that
   // are related to the one under your cursor.
   // Valid values are "fill", "box", "underline", "stippled", "squiggly" or "".

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -92,7 +92,10 @@ def get_initialize_params(project_path: str, config: ClientConfig):
                 },
                 "signatureHelp": {
                     "signatureInformation": {
-                        "documentationFormat": ["markdown", "plaintext"]
+                        "documentationFormat": ["markdown", "plaintext"],
+                        "parameterInformation": {
+                            "labelOffsetSupport": True
+                        }
                     }
                 },
                 "references": {},

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -53,8 +53,6 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings):
     settings.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
     settings.show_diagnostics_severity_level = read_int_setting(settings_obj, "show_diagnostics_severity_level", 3)
     settings.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
-    settings.highlight_active_signature_parameter = read_bool_setting(settings_obj,
-                                                                      "highlight_active_signature_parameter", True)
     settings.document_highlight_style = read_str_setting(settings_obj, "document_highlight_style", "stippled")
     settings.document_highlight_scopes = read_dict_setting(settings_obj, "document_highlight_scopes",
                                                            settings.document_highlight_scopes)

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -1,14 +1,23 @@
-import re
 import html
 from .logging import debug
-from .types import Settings
 try:
+    from typing_extensions import Protocol
     from typing import Tuple, Optional, Dict, List, Union, Any
     assert Tuple and Optional and Dict and List and Union and Any
 except ImportError:
     pass
 
-BOLD_UNDERLINED = '<span style="font-weight: bold; text-decoration: underline">{}</span>'
+
+class ScopeRenderer(Protocol):
+
+    def render_function(self, content: str) -> str:
+        ...
+
+    def render_punctuation(self, content: str) -> str:
+        ...
+
+    def render_parameter(self, content: str, emphasize: bool = False) -> str:
+        ...
 
 
 def get_documentation(d: 'Dict[str, Any]') -> 'Optional[str]':
@@ -31,6 +40,7 @@ def parse_signature_information(signature: 'Dict') -> 'SignatureInformation':
     param_infos = []  # type: 'List[ParameterInformation]'
     parameters = signature.get('parameters')
     if parameters:
+        # todo: if we advertise labelOffsetSupport, we can get [int,int] ranges in "label"
         param_infos = list(ParameterInformation(param['label'], get_documentation(param)) for param in parameters)
     return SignatureInformation(signature['label'], get_documentation(signature), param_infos)
 
@@ -51,24 +61,7 @@ class SignatureInformation(object):
         self.parameters = parameters
 
 
-def replace_active_parameter(signature: str, parameter: str, highlight_format: str = BOLD_UNDERLINED) -> str:
-    if parameter[0].isalnum() and parameter[-1].isalnum():
-        pattern = r'\b{}\b'.format(re.escape(parameter))
-    else:
-        # If the left or right boundary of the parameter string is not an alphanumeric character, the \b check will
-        # never match. In this case, it's probably safe to assume the parameter string itself will be a good pattern
-        # to search for.
-        pattern = re.escape(parameter)
-    replacement = highlight_format.format(parameter)
-    # FIXME: This is somewhat language-specific to look for an opening parenthesis. Most languages use parentheses
-    # for their parameter lists though.
-    start_of_param_list_pos = signature.find('(')
-    # Note that this works even when we don't find an opening parenthesis, because .find returns -1 in that case.
-    start_of_param_list = signature[start_of_param_list_pos + 1:]
-    return signature[:start_of_param_list_pos + 1] + re.sub(pattern, replacement, start_of_param_list, 1)
-
-
-def create_signature_help(response: 'Optional[Dict]', language_id, settings: Settings) -> 'Optional[SignatureHelp]':
+def create_signature_help(response: 'Optional[Dict]', renderer: ScopeRenderer) -> 'Optional[SignatureHelp]':
     if response is None:
         return None
 
@@ -82,70 +75,28 @@ def create_signature_help(response: 'Optional[Dict]', language_id, settings: Set
                 active_signature, len(signatures)))
             active_signature = 0
 
-        return SignatureHelp(signatures, language_id, active_signature, active_parameter,
-                             settings.highlight_active_signature_parameter)
+        return SignatureHelp(signatures, renderer, active_signature, active_parameter)
     else:
         return None
 
 
 class SignatureHelp(object):
 
-    def __init__(self, signatures: 'List[SignatureInformation]', language_id: str, active_signature=0,
-                 active_parameter=0, highlight_parameter=False) -> None:
+    def __init__(self, signatures: 'List[SignatureInformation]', renderer: ScopeRenderer,
+                 active_signature=0, active_parameter=0) -> None:
         self._signatures = signatures
-        self._language_id = language_id
-        self._active_signature = active_signature
+        self._active_signature_index = active_signature
         self._active_parameter = active_parameter
-        self._highlight_parameter = highlight_parameter
+        self._renderer = renderer
 
     def build_popup_content(self) -> str:
-        if self._highlight_parameter:
-            return self._build_popup_content_style_vscode()
-        else:
-            return self._build_popup_content_style_sublime()
+        parameter_documentation = None  # type: Optional[str]
 
-    def has_overloads(self) -> bool:
-        return len(self._signatures) > 1
+        signature = self._signatures[self._active_signature_index]  # type: SignatureInformation
+        signature_label = self._highlight_signature(signature.label)
+        debug('LABEL:', signature_label)
 
-    def select_signature(self, direction: int) -> None:
-        new_index = self._active_signature + direction
-
-        # clamp signature index
-        self._active_signature = max(0, min(new_index, len(self._signatures) - 1))
-
-    def _build_overload_selector(self) -> str:
-        return "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
-            str(self._active_signature + 1), str(len(self._signatures)))
-
-    def _build_popup_content_style_sublime(self) -> str:
-        signature = self._signatures[self._active_signature]  # type: SignatureInformation
-        formatted = []
-
-        if len(self._signatures) > 1:
-            formatted.append(self._build_overload_selector())
-
-        if len(signature.label) > 400:
-            label = "```{} ...```".format(signature.label[0:400])  # long code blocks = hangs
-        else:
-            label = "```{}\n{}\n```\n".format(self._language_id, signature.label)
-        formatted.append(label)
-
-        for parameter in signature.parameters:
-            formatted.append("**{}**\n".format(parameter.label))
-            formatted.append("* *{}*\n".format(parameter.documentation))
-
-        if signature.documentation:
-            formatted.append(signature.documentation)
-
-        return "\n".join(formatted)
-
-    def _build_popup_content_style_vscode(self) -> str:
-        # Fetch all the relevant data.
-        parameter_label = ""
-        parameter_documentation = ""  # type: Optional[str]
-
-        signature = self._signatures[self._active_signature]  # type: SignatureInformation
-        signature_label = html.escape(signature.label, quote=False)
+        # signature_label = html.escape(signature.label, quote=False)
         if signature.parameters and self._active_parameter in range(0, len(signature.parameters)):
             parameter = signature.parameters[self._active_parameter]
             parameter_label = html.escape(parameter.label, quote=False)
@@ -160,15 +111,81 @@ class SignatureHelp(object):
         # Note that this <div> class and the extra <pre> are copied from mdpopups' HTML output. When mdpopups changes
         # its output style, we must update this literal string accordingly.
         formatted.append('<div class="highlight"><pre>')
-        if parameter_label:
-            signature_label = replace_active_parameter(signature_label, parameter_label)
         formatted.append(signature_label)
         formatted.append("</pre></div>")
 
-        if parameter_documentation:
-            formatted.append(parameter_documentation)
-
         if signature.documentation:
-            formatted.append(signature.documentation)
+            formatted.append("<p>{}</p>".format(signature.documentation))
+
+        if parameter_documentation:
+            formatted.append("<p><b>{}</b>: {}</p>".format(parameter_label, parameter_documentation))
 
         return "\n".join(formatted)
+
+    def has_overloads(self) -> bool:
+        return len(self._signatures) > 1
+
+    def select_signature(self, direction: int) -> None:
+        new_index = self._active_signature_index + direction
+
+        # clamp signature index
+        self._active_signature_index = max(0, min(new_index, len(self._signatures) - 1))
+
+    def _active_signature(self) -> 'SignatureInformation':
+        return self._signatures[self._active_signature_index]
+
+    def _build_overload_selector(self) -> str:
+        return "**{}** of **{}** overloads (use the ↑ ↓ keys to navigate):\n".format(
+            str(self._active_signature_index + 1), str(len(self._signatures)))
+
+    def _read_parameter(self, signature_label: str, param_info: ParameterInformation,
+                        start_at: int) -> 'Tuple[str, str, int]':
+        param_index = signature_label.find(param_info.label, start_at)
+        param_end = param_index + len(param_info.label)
+
+        comma_index = signature_label.find(',', param_end)
+        if comma_index > -1:
+            return signature_label[start_at:comma_index], ', ', comma_index + 2
+        else:
+            close_paren_index = signature_label.find(')', param_end)
+            if close_paren_index > -1:
+                return signature_label[start_at:close_paren_index], ')', close_paren_index + 1
+            else:
+                # we have no delimiters, just return param label.
+                return param_info.label, ' ', start_at
+
+    def _highlight_signature(self, signature_label: str) -> str:
+
+        rendered_signature = []  # type: List[str]
+        sig_info = self._active_signature()
+        # assumption - if there are parens, the first paren starts arguments
+        # (note: self argument in pyls-returned method calls not included in params!)
+        # if no parens, start detecting from first parameter instead.
+        # if paren, extract and highlight
+        first_paren_index = signature_label.find('(')
+        if first_paren_index > -1:
+            rendered_signature.append(
+                self._renderer.render_function(signature_label[:first_paren_index])
+            )
+            rendered_signature.append(
+                self._renderer.render_punctuation('(')
+            )
+        current_pos = first_paren_index + 1
+        if sig_info.parameters:
+            for index, param_info in enumerate(sig_info.parameters):
+                parameter, delimiter, current_pos = self._read_parameter(signature_label, param_info, current_pos)
+
+                # append parameter and punctuation
+                rendered_signature.append(
+                    self._renderer.render_parameter(parameter, index == self._active_parameter)
+                )
+                rendered_signature.append(
+                    self._renderer.render_punctuation(delimiter)
+                )
+
+        # append remainder
+        rendered_signature.append(
+            self._renderer.render_function(signature_label[current_pos:])
+        )
+
+        return "".join(rendered_signature)

--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -130,7 +130,7 @@ class SignatureHelp(object):
                  active_signature=0, active_parameter=0) -> None:
         self._signatures = signatures
         self._active_signature_index = active_signature
-        self._active_parameter = active_parameter
+        self._active_parameter_index = active_parameter
         self._renderer = renderer
 
     def build_popup_content(self) -> str:
@@ -153,8 +153,8 @@ class SignatureHelp(object):
         if signature.documentation:
             formatted.append("<p>{}</p>".format(signature.documentation))
 
-        if signature.parameters and self._active_parameter in range(0, len(signature.parameters)):
-            parameter = signature.parameters[self._active_parameter]
+        if signature.parameters and self._active_parameter_index in range(0, len(signature.parameters)):
+            parameter = signature.parameters[self._active_parameter_index]
             parameter_label = html.escape(parameter.label, quote=False)
             parameter_documentation = parameter.documentation
             if parameter_documentation:
@@ -194,7 +194,7 @@ class SignatureHelp(object):
             for index, param in enumerate(reversed(sig_info.parameters)):
                 if param.range:
                     start, end = param.range
-                    is_current = self._active_parameter == max_param_index - index
+                    is_current = self._active_parameter_index == max_param_index - index
                     label = label[:start] + self._renderer.render_parameter(label[start:end], is_current) + label[end:]
 
                     # todo: highlight commas between parameters as punctuation.

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -1,10 +1,9 @@
 from .signature_help import (
     create_signature_help, SignatureHelp, get_documentation,
-    parse_signature_information, ScopeRenderer
+    parse_signature_information, ScopeRenderer, render_signature_label
 )
 import unittest
 
-language_id = "python"
 signature = {
     'label': 'foo_bar(value: int) -> None',
     'documentation': {'value': 'The default function for foobaring'},
@@ -30,45 +29,47 @@ signature_overload = {
 }  # type: dict
 
 
-json_stringify = {
-    'activeParameter': 0,
-    'signatures': [
-        {
-            'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
-            'parameters': [
-                {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
-                 'label': 'value: any'},
-                {'documentation': 'A function that transforms the results.',
-                 'label': 'replacer?: (key: string, value: any) => any'},
-                {'documentation': """Adds indentation, white space, and line break characters to the return-value
- JSON text to make it easier to read.""", 'label': 'space?: string | number'}
-            ],
-            'label': """stringify(value: any, replacer?: (key: string, value: any) => any, space?:
- string | number): string"""
-        },
-        {
-            'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
-            'parameters': [
-                {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
-                 'label': 'value: any'},
-                {'documentation': """An array of strings and numbers that acts as a approved list for selecting the
-object properties that will be stringified.""", 'label': 'replacer?: (string | number)[]'},
-                {'documentation': """Adds indentation, white space, and line break characters to the return-value JSON
- text to make it easier to read.""", 'label': 'space?: string | number'}
-            ],
-            'label': 'stringify(value: any, replacer?: (string | number)[], space?: string | number): string'
-        }
-    ],
-    'activeSignature': 0
-}
+# json_stringify = {
+#     'activeParameter': 0,
+#     'signatures': [
+#         {
+#             'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
+#             'parameters': [
+#                 {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
+#                  'label': 'value: any'},
+#                 {'documentation': 'A function that transforms the results.',
+#                  'label': 'replacer?: (key: string, value: any) => any'},
+#                 {'documentation': """Adds indentation, white space, and line break characters to the return-value
+#  JSON text to make it easier to read.""", 'label': 'space?: string | number'}
+#             ],
+#             'label': """stringify(value: any, replacer?: (key: string, value: any) => any, space?:
+#  string | number): string"""
+#         },
+#         {
+#             'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
+#             'parameters': [
+#                 {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
+#                  'label': 'value: any'},
+#                 {'documentation': """An array of strings and numbers that acts as a approved list for selecting the
+# object properties that will be stringified.""", 'label': 'replacer?: (string | number)[]'},
+#                 {'documentation': """Adds indentation, white space, and line break characters to the return-value JSON
+#  text to make it easier to read.""", 'label': 'space?: string | number'}
+#             ],
+#             'label': 'stringify(value: any, replacer?: (string | number)[], space?: string | number): string'
+#         }
+#     ],
+#     'activeSignature': 0
+# }
 
 signature_information = parse_signature_information(signature)
 signature_overload_information = parse_signature_information(signature_overload)
 
 SINGLE_SIGNATURE = """<div class="highlight"><pre>
-<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span>\
-<span style="color: #f99157;font-weight: bold">value</span>: int<span \
-style="color: #5fb3b3">)</span> -> None</span>
+
+<entity.name.function>foo_bar
+<punctuation>(</punctuation>
+<variable.parameter emphasize>value</variable.parameter>: int
+<punctuation>)</punctuation> -&gt; None</entity.name.function>
 </pre></div>
 <p>The default function for foobaring</p>
 <p><b>value</b>: A number to foobar on</p>"""
@@ -76,9 +77,11 @@ style="color: #5fb3b3">)</span> -> None</span>
 OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate):
 
 <div class="highlight"><pre>
-<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span>\
-<span style="color: #f99157;font-weight: bold">value</span>: int\
-<span style="color: #5fb3b3">)</span> -> None</span>
+
+<entity.name.function>foo_bar
+<punctuation>(</punctuation>
+<variable.parameter emphasize>value</variable.parameter>: int
+<punctuation>)</punctuation> -&gt; None</entity.name.function>
 </pre></div>
 <p>The default function for foobaring</p>
 <p><b>value</b>: A number to foobar on</p>"""
@@ -87,10 +90,12 @@ OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate)
 OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
 
 <div class="highlight"><pre>
-<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span>\
-<span style="color: #f99157;font-weight: bold">value</span>: int, \
-<span style="color: #f99157">multiplier</span>: int<span style="color: #5fb3b3">)\
-</span> -> None</span>
+
+<entity.name.function>foo_bar
+<punctuation>(</punctuation>
+<variable.parameter emphasize>value</variable.parameter>: int,\
+ \n<variable.parameter>multiplier</variable.parameter>: int
+<punctuation>)</punctuation> -&gt; None</entity.name.function>
 </pre></div>
 <p>Foobaring with a multiplier</p>
 <p><b>value</b>: A number to foobar on</p>"""
@@ -98,35 +103,39 @@ OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate
 OVERLOADS_SECOND_SECOND_PARAMETER = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
 
 <div class="highlight"><pre>
-<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span><span style="color: #f99157">value</span>\
-: int, <span style="color: #f99157;font-weight: bold">multiplier</span>: int<span style="color: #5fb3b3">)</span>\
- -> None</span>
+
+<entity.name.function>foo_bar
+<punctuation>(</punctuation>
+<variable.parameter>value</variable.parameter>: int,\
+ \n<variable.parameter emphasize>multiplier</variable.parameter>: int
+<punctuation>)</punctuation> -&gt; None</entity.name.function>
 </pre></div>
 <p>Foobaring with a multiplier</p>
 <p><b>multiplier</b>: Change foobar to work on larger increments</p>"""
 
 
-class TestRenderer(ScopeRenderer):
-    def __init__(self) -> None:
-        self._scope_styles = {
-            'entity.name.function': {'background': '#1b2b34', 'color': '#6699cc', 'style': ''},
-            'variable.parameter': {'background': '#1b2b34', 'color': '#f99157', 'style': ''},
-            'punctuation': {'background': '#1b2b34', 'color': '#5fb3b3', 'style': ''}
-        }
+JSON_STRINGIFY = """"""
 
-    def render_function(self, content: str) -> str:
+
+def create_signature(label: str, *param_labels, **kwargs) -> dict:
+    raw = dict(label=label, parameters=list(dict(label=param_label) for param_label in param_labels))
+    raw.update(kwargs)
+    return raw
+
+
+class TestRenderer(ScopeRenderer):
+
+    def function(self, content: str, escape: bool = True) -> str:
         return self._wrap_with_scope_style(content, "entity.name.function")
 
-    def render_punctuation(self, content: str) -> str:
+    def punctuation(self, content: str) -> str:
         return self._wrap_with_scope_style(content, "punctuation")
 
-    def render_parameter(self, content: str, emphasize: bool = False) -> str:
+    def parameter(self, content: str, emphasize: bool = False) -> str:
         return self._wrap_with_scope_style(content, "variable.parameter", emphasize)
 
     def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False) -> str:
-        color = self._scope_styles[scope]["color"]
-        weight_style = ';font-weight: bold' if emphasize else ''
-        return '<span style="color: {}{}">{}</span>'.format(color, weight_style, content)
+        return '\n<{}{}>{}</{}>'.format(scope, " emphasize" if emphasize else "", content, scope)
 
 
 renderer = TestRenderer()
@@ -147,14 +156,14 @@ class GetDocumentationTests(unittest.TestCase):
 class CreateSignatureHelpTests(unittest.TestCase):
 
     def test_none(self):
-        self.assertIsNone(create_signature_help(None, renderer))
+        self.assertIsNone(create_signature_help(None))
 
     def test_empty(self):
-        self.assertIsNone(create_signature_help({}, renderer))
+        self.assertIsNone(create_signature_help({}))
 
     def test_default_indices(self):
 
-        help = create_signature_help({"signatures": [signature]}, renderer)
+        help = create_signature_help({"signatures": [signature]})
 
         self.assertIsNotNone(help)
         if help:
@@ -162,36 +171,102 @@ class CreateSignatureHelpTests(unittest.TestCase):
             self.assertEqual(help._active_parameter_index, -1)
 
 
+class RenderSignatureLabelTests(unittest.TestCase):
+
+    def test_no_parameters(self):
+        sig = create_signature("foobar()")
+        help = create_signature_help(dict(signatures=[sig]))
+        if help:
+            label = render_signature_label(renderer, help.active_signature(), 0)
+            self.assertEqual(label, "\n<entity.name.function>foobar()</entity.name.function>")
+
+    def test_params(self):
+        sig = create_signature("foobar(foo, foo)", "foo", "foo", activeParameter=1)
+        help = create_signature_help(dict(signatures=[sig]))
+        if help:
+            label = render_signature_label(renderer, help.active_signature(), 1)
+            self.assertEqual(label, """
+<entity.name.function>foobar
+<punctuation>(</punctuation>
+<variable.parameter>foo</variable.parameter>,\
+ \n<variable.parameter emphasize>foo</variable.parameter>
+<punctuation>)</punctuation></entity.name.function>""")
+
+    def test_params_are_substrings(self):
+        sig = create_signature("foobar(self, foo: str, foo: i32)", "foo", "foo", activeParameter=1)
+        help = create_signature_help(dict(signatures=[sig]))
+        if help:
+            label = render_signature_label(renderer, help.active_signature(), 1)
+            self.assertEqual(label, """
+<entity.name.function>foobar
+<punctuation>(</punctuation>self,\
+ \n<variable.parameter>foo</variable.parameter>: str,\
+ \n<variable.parameter emphasize>foo</variable.parameter>: i32
+<punctuation>)</punctuation></entity.name.function>""")
+
+    def test_params_with_range(self):
+        sig = create_signature("foobar(foo, foo)", [7, 10], [12, 15], activeParameter=1)
+        help = create_signature_help(dict(signatures=[sig]))
+        if help:
+            label = render_signature_label(renderer, help.active_signature(), 1)
+            self.assertEqual(label, """
+<entity.name.function>foobar
+<punctuation>(</punctuation>
+<variable.parameter>foo</variable.parameter>,\
+ \n<variable.parameter emphasize>foo</variable.parameter>
+<punctuation>)</punctuation></entity.name.function>""")
+
+    def test_params_no_parens(self):
+        # note: will not work without ranges: first "foo" param will match "foobar"
+        sig = create_signature("foobar foo foo", [7, 10], [11, 14], activeParameter=1)
+        help = create_signature_help(dict(signatures=[sig]))
+        if help:
+            label = render_signature_label(renderer, help.active_signature(), 1)
+            self.assertEqual(label, """
+<entity.name.function>foobar\
+ \n<variable.parameter>foo</variable.parameter>\
+ \n<variable.parameter emphasize>foo</variable.parameter></entity.name.function>""")
+
+    def test_escape_content(self):
+        sig = create_signature("foobar<T>(foo: Option<i32>) -> List<T>", "foo: Option<i32>", activeParameter=0)
+        help = create_signature_help(dict(signatures=[sig]))
+        if help:
+            label = render_signature_label(renderer, help.active_signature(), 0)
+            self.assertEqual(label, """
+<entity.name.function>foobar&lt;T&gt;
+<punctuation>(</punctuation>
+<variable.parameter emphasize>foo: Option&lt;i32&gt;</variable.parameter>
+<punctuation>)</punctuation> -&gt; List&lt;T&gt;</entity.name.function>""")
+
+
 class SignatureHelpTests(unittest.TestCase):
 
     def test_single_signature(self):
-        renderer
-        help = SignatureHelp([signature_information], renderer)
+        help = SignatureHelp([signature_information])
         self.assertIsNotNone(help)
         if help:
-            content = help.build_popup_content()
-            self.assertFalse(help.has_overloads())
+            content = help.build_popup_content(renderer)
+            self.assertFalse(help.has_multiple_signatures())
             self.assertEqual(content, SINGLE_SIGNATURE)
 
     def test_overload(self):
-        help = SignatureHelp([signature_information, signature_overload_information],
-                             renderer)
+        help = SignatureHelp([signature_information, signature_overload_information])
         self.assertIsNotNone(help)
         if help:
-            content = help.build_popup_content()
-            self.assertTrue(help.has_overloads())
+            content = help.build_popup_content(renderer)
+            self.assertTrue(help.has_multiple_signatures())
             self.assertEqual(content, OVERLOADS_FIRST)
 
             help.select_signature(1)
             help.select_signature(1)  # verify we don't go out of bounds,
-            content = help.build_popup_content()
+            content = help.build_popup_content(renderer)
             self.assertEqual(content, OVERLOADS_SECOND)
 
     def test_active_parameter(self):
-        help = SignatureHelp([signature_information, signature_overload_information], renderer, active_signature=1,
+        help = SignatureHelp([signature_information, signature_overload_information], active_signature=1,
                              active_parameter=1)
         self.assertIsNotNone(help)
         if help:
-            content = help.build_popup_content()
-            self.assertTrue(help.has_overloads())
+            content = help.build_popup_content(renderer)
+            self.assertTrue(help.has_multiple_signatures())
             self.assertEqual(content, OVERLOADS_SECOND_SECOND_PARAMETER)

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -1,4 +1,7 @@
-from .signature_help import create_signature_help, SignatureHelp, get_documentation, replace_active_parameter
+from .signature_help import (
+    create_signature_help, SignatureHelp, get_documentation, replace_active_parameter,
+    parse_signature_information
+)
 from .types import Settings
 import unittest
 
@@ -28,6 +31,8 @@ signature_overload = {
     }]
 }  # type: dict
 
+signature_information = parse_signature_information(signature)
+signature_overload_information = parse_signature_information(signature_overload)
 
 SUBLIME_SINGLE_SIGNATURE = """```python
 foo_bar(value: int) -> None
@@ -131,7 +136,7 @@ class CreateSignatureHelpTests(unittest.TestCase):
 class SublimeSignatureHelpTests(unittest.TestCase):
 
     def test_single_signature(self):
-        help = SignatureHelp([signature], language_id)
+        help = SignatureHelp([signature_information], language_id)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
@@ -139,7 +144,7 @@ class SublimeSignatureHelpTests(unittest.TestCase):
             self.assertEqual(content, SUBLIME_SINGLE_SIGNATURE)
 
     def test_overload(self):
-        help = SignatureHelp([signature, signature_overload], language_id)
+        help = SignatureHelp([signature_information, signature_overload_information], language_id)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
@@ -155,7 +160,7 @@ class SublimeSignatureHelpTests(unittest.TestCase):
 class VsCodeSignatureHelpTests(unittest.TestCase):
 
     def test_single_signature(self):
-        help = SignatureHelp([signature], language_id, highlight_parameter=True)
+        help = SignatureHelp([signature_information], language_id, highlight_parameter=True)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
@@ -163,7 +168,8 @@ class VsCodeSignatureHelpTests(unittest.TestCase):
             self.assertEqual(content, VSCODE_SINGLE_SIGNATURE)
 
     def test_overload(self):
-        help = SignatureHelp([signature, signature_overload], language_id, highlight_parameter=True)
+        help = SignatureHelp([signature_information, signature_overload_information], language_id,
+                             highlight_parameter=True)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
@@ -176,8 +182,8 @@ class VsCodeSignatureHelpTests(unittest.TestCase):
             self.assertEqual(content, VSCODE_OVERLOADS_SECOND)
 
     def test_active_parameter(self):
-        help = SignatureHelp([signature, signature_overload], language_id, active_signature=1, active_parameter=1,
-                             highlight_parameter=True)
+        help = SignatureHelp([signature_information, signature_overload_information], language_id, active_signature=1,
+                             active_parameter=1, highlight_parameter=True)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -14,6 +14,7 @@ signature = {
         }
     }]
 }  # type: dict
+
 signature_overload = {
     'label': 'foo_bar(value: int, multiplier: int) -> None',
     'documentation': {'value': 'Foobaring with a multiplier'},
@@ -27,39 +28,6 @@ signature_overload = {
         'documentation': 'Change foobar to work on larger increments'
     }]
 }  # type: dict
-
-
-# json_stringify = {
-#     'activeParameter': 0,
-#     'signatures': [
-#         {
-#             'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
-#             'parameters': [
-#                 {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
-#                  'label': 'value: any'},
-#                 {'documentation': 'A function that transforms the results.',
-#                  'label': 'replacer?: (key: string, value: any) => any'},
-#                 {'documentation': """Adds indentation, white space, and line break characters to the return-value
-#  JSON text to make it easier to read.""", 'label': 'space?: string | number'}
-#             ],
-#             'label': """stringify(value: any, replacer?: (key: string, value: any) => any, space?:
-#  string | number): string"""
-#         },
-#         {
-#             'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
-#             'parameters': [
-#                 {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
-#                  'label': 'value: any'},
-#                 {'documentation': """An array of strings and numbers that acts as a approved list for selecting the
-# object properties that will be stringified.""", 'label': 'replacer?: (string | number)[]'},
-#                 {'documentation': """Adds indentation, white space, and line break characters to the return-value JSON
-#  text to make it easier to read.""", 'label': 'space?: string | number'}
-#             ],
-#             'label': 'stringify(value: any, replacer?: (string | number)[], space?: string | number): string'
-#         }
-#     ],
-#     'activeSignature': 0
-# }
 
 signature_information = parse_signature_information(signature)
 signature_overload_information = parse_signature_information(signature_overload)

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -1,6 +1,6 @@
 from .signature_help import (
-    create_signature_help, SignatureHelp, get_documentation, replace_active_parameter,
-    parse_signature_information
+    create_signature_help, SignatureHelp, get_documentation,
+    parse_signature_information, ScopeRenderer
 )
 from .types import Settings
 import unittest
@@ -30,6 +30,39 @@ signature_overload = {
         'documentation': 'Change foobar to work on larger increments'
     }]
 }  # type: dict
+
+
+json_stringify = {
+    'activeParameter': 0,
+    'signatures': [
+        {
+            'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
+            'parameters': [
+                {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
+                 'label': 'value: any'},
+                {'documentation': 'A function that transforms the results.',
+                 'label': 'replacer?: (key: string, value: any) => any'},
+                {'documentation': """Adds indentation, white space, and line break characters to the return-value
+ JSON text to make it easier to read.""", 'label': 'space?: string | number'}
+            ],
+            'label': """stringify(value: any, replacer?: (key: string, value: any) => any, space?:
+ string | number): string"""
+        },
+        {
+            'documentation': 'Converts a JavaScript value to a JavaScript Object Notation (JSON) string.',
+            'parameters': [
+                {'documentation': 'A JavaScript value, usually an object or array, to be converted.',
+                 'label': 'value: any'},
+                {'documentation': """An array of strings and numbers that acts as a approved list for selecting the
+object properties that will be stringified.""", 'label': 'replacer?: (string | number)[]'},
+                {'documentation': """Adds indentation, white space, and line break characters to the return-value JSON
+ text to make it easier to read.""", 'label': 'space?: string | number'}
+            ],
+            'label': 'stringify(value: any, replacer?: (string | number)[], space?: string | number): string'
+        }
+    ],
+    'activeSignature': 0
+}
 
 signature_information = parse_signature_information(signature)
 signature_overload_information = parse_signature_information(signature_overload)
@@ -103,6 +136,32 @@ Change foobar to work on larger increments
 Foobaring with a multiplier"""
 
 
+class TestRenderer(ScopeRenderer):
+    def __init__(self) -> None:
+        self._scope_styles = {
+            'entity.name.function': {'background': '#1b2b34', 'color': '#6699cc', 'style': ''},
+            'variable.parameter': {'background': '#1b2b34', 'color': '#f99157', 'style': ''},
+            'punctuation': {'background': '#1b2b34', 'color': '#5fb3b3', 'style': ''}
+        }
+
+    def render_function(self, content: str) -> str:
+        return self._wrap_with_scope_style(content, "entity.name.function")
+
+    def render_punctuation(self, content: str) -> str:
+        return self._wrap_with_scope_style(content, "punctuation")
+
+    def render_parameter(self, content: str, emphasize: bool = False) -> str:
+        return self._wrap_with_scope_style(content, "variable.parameter", emphasize)
+
+    def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False) -> str:
+        color = self._scope_styles[scope]["color"]
+        weight_style = ';font-weight: bold' if emphasize else ''
+        return '<span style="color: {}{}">{}</span>'.format(color, weight_style, content)
+
+
+renderer = TestRenderer()
+
+
 class GetDocumentationTests(unittest.TestCase):
 
     def test_absent(self):
@@ -118,14 +177,14 @@ class GetDocumentationTests(unittest.TestCase):
 class CreateSignatureHelpTests(unittest.TestCase):
 
     def test_none(self):
-        self.assertIsNone(create_signature_help(None, language_id, settings))
+        self.assertIsNone(create_signature_help(None, renderer))
 
     def test_empty(self):
-        self.assertIsNone(create_signature_help({}, language_id, settings))
+        self.assertIsNone(create_signature_help({}, renderer))
 
     def test_default_indices(self):
 
-        help = create_signature_help({"signatures": [signature]}, language_id, settings)
+        help = create_signature_help({"signatures": [signature]}, renderer)
 
         self.assertIsNotNone(help)
         if help:
@@ -133,34 +192,11 @@ class CreateSignatureHelpTests(unittest.TestCase):
             self.assertEqual(help._active_parameter, -1)
 
 
-class SublimeSignatureHelpTests(unittest.TestCase):
+class SignatureHelpTests(unittest.TestCase):
 
     def test_single_signature(self):
-        help = SignatureHelp([signature_information], language_id)
-        self.assertIsNotNone(help)
-        if help:
-            content = help.build_popup_content()
-            self.assertFalse(help.has_overloads())
-            self.assertEqual(content, SUBLIME_SINGLE_SIGNATURE)
-
-    def test_overload(self):
-        help = SignatureHelp([signature_information, signature_overload_information], language_id)
-        self.assertIsNotNone(help)
-        if help:
-            content = help.build_popup_content()
-            self.assertTrue(help.has_overloads())
-            self.assertEqual(content, SUBLIME_OVERLOADS_FIRST)
-
-            help.select_signature(1)
-            help.select_signature(1)  # verify we don't go out of bounds,
-            content = help.build_popup_content()
-            self.assertEqual(content, SUBLIME_OVERLOADS_SECOND)
-
-
-class VsCodeSignatureHelpTests(unittest.TestCase):
-
-    def test_single_signature(self):
-        help = SignatureHelp([signature_information], language_id, highlight_parameter=True)
+        renderer
+        help = SignatureHelp([signature_information], renderer)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
@@ -168,8 +204,8 @@ class VsCodeSignatureHelpTests(unittest.TestCase):
             self.assertEqual(content, VSCODE_SINGLE_SIGNATURE)
 
     def test_overload(self):
-        help = SignatureHelp([signature_information, signature_overload_information], language_id,
-                             highlight_parameter=True)
+        help = SignatureHelp([signature_information, signature_overload_information],
+                             renderer)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
@@ -182,26 +218,10 @@ class VsCodeSignatureHelpTests(unittest.TestCase):
             self.assertEqual(content, VSCODE_OVERLOADS_SECOND)
 
     def test_active_parameter(self):
-        help = SignatureHelp([signature_information, signature_overload_information], language_id, active_signature=1,
-                             active_parameter=1, highlight_parameter=True)
+        help = SignatureHelp([signature_information, signature_overload_information], renderer, active_signature=1,
+                             active_parameter=1)
         self.assertIsNotNone(help)
         if help:
             content = help.build_popup_content()
             self.assertTrue(help.has_overloads())
             self.assertEqual(content, VSCODE_OVERLOADS_SECOND_SECOND_PARAMETER)
-
-
-class ReplaceActiveParameterTests(unittest.TestCase):
-
-    def test_simple(self):
-        # BUG: here fun(<-- triggers signature help in a string!
-        bold_format = "<b>{}</b>"
-        self.assertEqual(replace_active_parameter("def fun(param)", "param",
-                                                  highlight_format=bold_format), "def fun(<b>param</b>)")
-
-    def test_matching_substrings(self):
-        bold_format = "<b>{}</b>"
-        self.assertEqual(replace_active_parameter("def fun(param, parameter)", "param",
-                                                  highlight_format=bold_format), "def fun(<b>param</b>, parameter)")
-        self.assertEqual(replace_active_parameter("def fun(parameter, param)", "param",
-                                                  highlight_format=bold_format), "def fun(parameter, <b>param</b>)")

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -2,11 +2,9 @@ from .signature_help import (
     create_signature_help, SignatureHelp, get_documentation,
     parse_signature_information, ScopeRenderer
 )
-from .types import Settings
 import unittest
 
 language_id = "python"
-settings = Settings()
 signature = {
     'label': 'foo_bar(value: int) -> None',
     'documentation': {'value': 'The default function for foobaring'},
@@ -67,73 +65,45 @@ object properties that will be stringified.""", 'label': 'replacer?: (string | n
 signature_information = parse_signature_information(signature)
 signature_overload_information = parse_signature_information(signature_overload)
 
-SUBLIME_SINGLE_SIGNATURE = """```python
-foo_bar(value: int) -> None
-```
-
-**value**
-
-* *A number to foobar on*
-
-The default function for foobaring"""
-
-SUBLIME_OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate):
-
-```python
-foo_bar(value: int) -> None
-```
-
-**value**
-
-* *A number to foobar on*
-
-The default function for foobaring"""
-
-SUBLIME_OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
-
-```python
-foo_bar(value: int, multiplier: int) -> None
-```
-
-**value**
-
-* *A number to foobar on*
-
-**multiplier**
-
-* *Change foobar to work on larger increments*
-
-Foobaring with a multiplier"""
-
-VSCODE_SINGLE_SIGNATURE = """<div class="highlight"><pre>
-foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int) -&gt; None
+SINGLE_SIGNATURE = """<div class="highlight"><pre>
+<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span>\
+<span style="color: #f99157;font-weight: bold">value</span>: int<span \
+style="color: #5fb3b3">)</span> -> None</span>
 </pre></div>
-A number to foobar on
-The default function for foobaring"""
+<p>The default function for foobaring</p>
+<p><b>value</b>: A number to foobar on</p>"""
 
-VSCODE_OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate):
+OVERLOADS_FIRST = """**1** of **2** overloads (use the ↑ ↓ keys to navigate):
 
 <div class="highlight"><pre>
-foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int) -&gt; None
+<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span>\
+<span style="color: #f99157;font-weight: bold">value</span>: int\
+<span style="color: #5fb3b3">)</span> -> None</span>
 </pre></div>
-A number to foobar on
-The default function for foobaring"""
+<p>The default function for foobaring</p>
+<p><b>value</b>: A number to foobar on</p>"""
 
-VSCODE_OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
+
+OVERLOADS_SECOND = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
 
 <div class="highlight"><pre>
-foo_bar(<span style="font-weight: bold; text-decoration: underline">value</span>: int, multiplier: int) -&gt; None
+<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span>\
+<span style="color: #f99157;font-weight: bold">value</span>: int, \
+<span style="color: #f99157">multiplier</span>: int<span style="color: #5fb3b3">)\
+</span> -> None</span>
 </pre></div>
-A number to foobar on
-Foobaring with a multiplier"""
+<p>Foobaring with a multiplier</p>
+<p><b>value</b>: A number to foobar on</p>"""
 
-VSCODE_OVERLOADS_SECOND_SECOND_PARAMETER = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
+OVERLOADS_SECOND_SECOND_PARAMETER = """**2** of **2** overloads (use the ↑ ↓ keys to navigate):
 
 <div class="highlight"><pre>
-foo_bar(value: int, <span style="font-weight: bold; text-decoration: underline">multiplier</span>: int) -&gt; None
+<span style="color: #6699cc">foo_bar<span style="color: #5fb3b3">(</span><span style="color: #f99157">value</span>\
+: int, <span style="color: #f99157;font-weight: bold">multiplier</span>: int<span style="color: #5fb3b3">)</span>\
+ -> None</span>
 </pre></div>
-Change foobar to work on larger increments
-Foobaring with a multiplier"""
+<p>Foobaring with a multiplier</p>
+<p><b>multiplier</b>: Change foobar to work on larger increments</p>"""
 
 
 class TestRenderer(ScopeRenderer):
@@ -188,8 +158,8 @@ class CreateSignatureHelpTests(unittest.TestCase):
 
         self.assertIsNotNone(help)
         if help:
-            self.assertEqual(help._active_signature, 0)
-            self.assertEqual(help._active_parameter, -1)
+            self.assertEqual(help._active_signature_index, 0)
+            self.assertEqual(help._active_parameter_index, -1)
 
 
 class SignatureHelpTests(unittest.TestCase):
@@ -201,7 +171,7 @@ class SignatureHelpTests(unittest.TestCase):
         if help:
             content = help.build_popup_content()
             self.assertFalse(help.has_overloads())
-            self.assertEqual(content, VSCODE_SINGLE_SIGNATURE)
+            self.assertEqual(content, SINGLE_SIGNATURE)
 
     def test_overload(self):
         help = SignatureHelp([signature_information, signature_overload_information],
@@ -210,12 +180,12 @@ class SignatureHelpTests(unittest.TestCase):
         if help:
             content = help.build_popup_content()
             self.assertTrue(help.has_overloads())
-            self.assertEqual(content, VSCODE_OVERLOADS_FIRST)
+            self.assertEqual(content, OVERLOADS_FIRST)
 
             help.select_signature(1)
             help.select_signature(1)  # verify we don't go out of bounds,
             content = help.build_popup_content()
-            self.assertEqual(content, VSCODE_OVERLOADS_SECOND)
+            self.assertEqual(content, OVERLOADS_SECOND)
 
     def test_active_parameter(self):
         help = SignatureHelp([signature_information, signature_overload_information], renderer, active_signature=1,
@@ -224,4 +194,4 @@ class SignatureHelpTests(unittest.TestCase):
         if help:
             content = help.build_popup_content()
             self.assertTrue(help.has_overloads())
-            self.assertEqual(content, VSCODE_OVERLOADS_SECOND_SECOND_PARAMETER)
+            self.assertEqual(content, OVERLOADS_SECOND_SECOND_PARAMETER)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -21,7 +21,6 @@ class Settings(object):
         self.show_diagnostics_severity_level = 3
         self.only_show_lsp_completions = False
         self.diagnostics_highlight_style = "underline"
-        self.highlight_active_signature_parameter = True
         self.document_highlight_style = "stippled"
         self.document_highlight_scopes = {
             "unknown": "text",

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -1,5 +1,6 @@
 import mdpopups
 import sublime
+import html
 import sublime_plugin
 import webbrowser
 
@@ -16,11 +17,11 @@ from .core.events import global_events
 from .core.protocol import Request
 from .core.popups import popup_css, popup_class
 from .core.settings import client_configs
-from .core.signature_help import create_signature_help, SignatureHelp, ScopeRenderer
+from .core.signature_help import create_signature_help, SignatureHelp
 assert SignatureHelp
 
 
-class ColorSchemeScopeRenderer(ScopeRenderer):
+class ColorSchemeScopeRenderer(object):
     def __init__(self, view) -> None:
         self._scope_styles = {}  # type: dict
         for scope in ["entity.name.function", "variable.parameter", "punctuation"]:
@@ -38,7 +39,7 @@ class ColorSchemeScopeRenderer(ScopeRenderer):
     def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False) -> str:
         color = self._scope_styles[scope]["color"]
         weight_style = ';font-weight: bold' if emphasize else ''
-        return '<span style="color: {}{}">{}</span>'.format(color, weight_style, content)
+        return '<span style="color: {}{}">{}</span>'.format(color, weight_style, html.escape(content, quote=False))
 
 
 class SignatureHelpListener(sublime_plugin.ViewEventListener):

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -14,27 +14,10 @@ from .core.registry import config_for_scope, session_for_view, client_for_view
 from .core.documents import get_document_position
 from .core.events import global_events
 from .core.protocol import Request
-from .core.logging import debug
 from .core.popups import popup_css, popup_class
 from .core.settings import client_configs, settings
 from .core.signature_help import create_signature_help, SignatureHelp
 assert SignatureHelp
-
-
-def get_documentation(d: 'Dict[str, Any]') -> 'Optional[str]':
-    docs = d.get('documentation', None)
-    if docs is None:
-        return None
-    elif isinstance(docs, str):
-        # In older version of the protocol, documentation was just a string.
-        return docs
-    elif isinstance(docs, dict):
-        # This can be either "plaintext" or "markdown" format. For now, we can dump it into the popup box. It would
-        # be nice to handle the markdown in a special way.
-        return docs.get('value', None)
-    else:
-        debug('unknown documentation type:', str(d))
-        return None
 
 
 class SignatureHelpListener(sublime_plugin.ViewEventListener):

--- a/stubs/mdpopups.pyi
+++ b/stubs/mdpopups.pyi
@@ -24,6 +24,7 @@ def show_popup(
     allow_code_wrap=False
 ): ...
 
+
 def update_popup(
     view: sublime.View,
     content: str,
@@ -43,4 +44,12 @@ def md2html(
     template_env_options=None,  # type: Optional[dict]
     nl2br=True,
     allow_code_wrap=False
-): ...
+) -> str: ...
+
+
+def scope2style(
+    view: sublime.View,
+    scope: str,
+    selected: bool=False,
+    explicit_background: bool = False
+) -> str: ...


### PR DESCRIPTION
A single signature help implementation that does both (simple) syntax highlighting and active parameter highlighting.

Add support for language servers to send a [int, int] range instead of a string as parameter label (for  reliable highlighting): https://github.com/microsoft/language-server-protocol/commit/3854f1c503b3e1f1cab9b4f81e62fc47bc7d174a

Parses the signature label to classify three types of content:
* function
* parameter
* punctuation

Then uses mdpopups to get styles for relevant scopes, applied in `<span>` tags.

Although parentheses and parameters are detected, commas and text outside parameter labels are not detected - they inherit the "function" style.

<img width="465" alt="Screenshot 2019-05-18 at 23 13 28" src="https://user-images.githubusercontent.com/4395832/57975040-ab88db00-79c2-11e9-8d14-d3c31089ff9c.png">

So far tested with python-language-server and lsp-tsserver, would like more examples of servers that support signatureHelp!



 