### PR TITLE
Introduce "completion_trigger" setting

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -71,10 +71,12 @@
   // Disable Sublime Text's explicit and word completion.
   "only_show_lsp_completions": false,
 
-  // When presenting completions, prefer the "label" over the "filterText" key
-  // in the CompletionItem. By default, the "filterText" is chosen over the
-  // "label". If the "filterText" is not present, fall back to the "label".
-  "prefer_label_over_filter_text": false,
+  // When presenting completions, should LSP use the "label", the "filter_text",
+  // or the "replacement" for the trigger characters?
+  // "label": Use the `label` field of the CompletionItem.
+  // "filter_text": Use the `filterText` field of the CompletionItem.
+  // "replacement": The trigger is the same string as the replacement text.
+  "completion_trigger": "replacement",
 
   // Show symbol references in Sublime's quick panel instead of the bottom panel.
   "show_references_in_quick_panel": false,

--- a/docs/features.md
+++ b/docs/features.md
@@ -66,7 +66,7 @@ Global plugin settings and settings defined at project level are merged together
 * `complete_all_chars` `true` *request completions for all characters, not just trigger characters*
 * `only_show_lsp_completions` `false` *disable sublime word completion and snippets from autocomplete lists*
 * `completion_hint_type` `"auto"` *override automatic completion hints with "detail", "kind" or "none"*
-* `prefer_label_over_filter_text` `false` *always use the "label" key instead of the "filterText" key in CompletionItems*
+* `completion_trigger` `replacement` *Decide how to present completions from a language server with "label", "filter_text" or "replacement"*
 * `show_references_in_quick_panel` `false` *show symbol references in Sublime's quick panel instead of the bottom panel*
 * `quick_panel_monospace_font` `false` *use monospace font for the quick panel*
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -61,7 +61,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings):
     settings.only_show_lsp_completions = read_bool_setting(settings_obj, "only_show_lsp_completions", False)
     settings.complete_all_chars = read_bool_setting(settings_obj, "complete_all_chars", True)
     settings.completion_hint_type = read_str_setting(settings_obj, "completion_hint_type", "auto")
-    settings.prefer_label_over_filter_text = read_bool_setting(settings_obj, "prefer_label_over_filter_text", False)
+    settings.completion_trigger = read_str_setting(settings_obj, "completion_trigger", "replacement")
     settings.show_references_in_quick_panel = read_bool_setting(settings_obj, "show_references_in_quick_panel", False)
     settings.quick_panel_monospace_font = read_bool_setting(settings_obj, "quick_panel_monospace_font", False)
     settings.log_debug = read_bool_setting(settings_obj, "log_debug", False)

--- a/plugin/core/test_completion.py
+++ b/plugin/core/test_completion.py
@@ -20,6 +20,7 @@ intelephense_completion_sample = load_completion_sample("intelephense_completion
 
 
 settings = Settings()
+settings.completion_trigger = 'filter_text'
 
 
 class CompletionResponseParsingTests(unittest.TestCase):
@@ -44,7 +45,7 @@ class CompletionFormattingTests(unittest.TestCase):
 
     def test_prefer_label_over_filter_text(self):
         updated_settings = Settings()
-        updated_settings.prefer_label_over_filter_text = True
+        updated_settings.completion_trigger = "label"
         result = format_completion(
             {"label": "asdf", "insertText": "asdf", "filterText": "filterText"},
             0, updated_settings)

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -32,7 +32,7 @@ class Settings(object):
         self.show_code_actions_bulb = False
         self.complete_all_chars = False
         self.completion_hint_type = "auto"
-        self.prefer_label_over_filter_text = False
+        self.completion_trigger = "replacement"
         self.show_references_in_quick_panel = False
         self.quick_panel_monospace_font = False
         self.log_debug = True


### PR DESCRIPTION
Fixes #572.

The completion_trigger setting decides what the trigger of the completion will
be. It can be one of:

1) label,
2) filterText,
3) the replacement text.

By default, it is set to the replacement text. This results in a noisy
auto-complete widget. However, it makes most of the known language servers work
correctly, despite ST not supporting TextEdit.