### PR TITLE
Improve vue-language-server docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,20 +34,34 @@ Client configuration:
 ```
 "vue-ls":{
   "command": [
-    "node",
-    "/ABSOLUTE/PATH/TO/SERVER/.npm-global/bin/vls"
+    "vls"
+    // note: you may need to use the absolute path to the language server binary
   ],
   "enabled": true,
   "languageId": "vue",
-  "scopes": [
-    "text.html.vue"
-  ],
-  "syntaxes": [
-    // For ST3 builds < 3153
-    "Packages/Vue Syntax Highlight/vue.tmLanguage"
-    // For ST3 builds >= 3153
-    // "Packages/Vue Syntax Highlight/Vue Component.sublime-syntax"
-  ]
+  "scopes": ["text.html.vue"],
+  "syntaxes": ["Vue Component"],
+  "initializationOptions": {
+    "config": {
+      "vetur": {
+        "useWorkspaceDependencies": false,
+        "validation": { "template": true, "style": true, "script": true },
+        "completion": { "autoImport": false, "useScaffoldSnippets": false, "tagCasing": "kebab" },
+        "format": {
+          "defaultFormatter": {"js": "none", "ts": "none"},
+          "defaultFormatterOptions": {},
+          "scriptInitialIndent": false,
+          "styleInitialIndent": false
+        }
+      },
+      "css": {},
+      "html": {"suggest": {} },
+      "javascript": {"format": {} },
+      "typescript": {"format": {} },
+      "emmet": {},
+      "stylusSupremacy": {}
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
This closes #565 , and additionally improves the overall functionality of the language server.

Without the initializationOptions, the language-server often crashes or errors-out on trying to provide completions*. With this new config, things run quite well.

\* vue-language-server does a very poor job of checking for attributes on the `vetur` object, it just assumes it's being run from VSCode and those options are set