### PR TITLE
Add underline in active parameter

### DIFF
--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -38,9 +38,9 @@ class ColorSchemeScopeRenderer(object):
 
     def _wrap_with_scope_style(self, content: str, scope: str, emphasize: bool = False, escape: bool = True) -> str:
         color = self._scope_styles[scope]["color"]
-        weight_style = ';font-weight: bold' if emphasize else ''
+        additional_styles = 'font-weight: bold; text-decoration: underline;' if emphasize else ''
         content = html.escape(content, quote=False) if escape else content
-        return '<span style="color: {}{}">{}</span>'.format(color, weight_style, content)
+        return '<span style="color: {};{}">{}</span>'.format(color, additional_styles, content)
 
 
 class SignatureHelpListener(sublime_plugin.ViewEventListener):


### PR DESCRIPTION
Hello,

I just noticed that we now have syntax highlighting and active parameter in signature help, which is great! :)  (although I don't use a very colorful colorscheme)

But I had some problems with determining visually what the active parameter is. 
Here are a few screenshots... By first glance it is hard to tell what is the active parameter, right?
<img width="1150" alt="Screen Shot 2019-05-26 at 12 07 36 PM" src="https://user-images.githubusercontent.com/22029477/58380325-05376980-7fb0-11e9-92da-c9537ca711aa.png">
<img width="871" alt="Screen Shot 2019-05-26 at 12 06 27 PM" src="https://user-images.githubusercontent.com/22029477/58380330-0f596800-7fb0-11e9-8fd4-11878e4728a9.png">
<img width="944" alt="Screen Shot 2019-05-26 at 12 06 43 PM" src="https://user-images.githubusercontent.com/22029477/58380333-141e1c00-7fb0-11e9-8ac9-d66c692b730b.png">

With this PR, I just add a underline. The result is that you can immediately see what the active parameter is.
<img width="984" alt="Screen Shot 2019-05-26 at 12 08 27 PM" src="https://user-images.githubusercontent.com/22029477/58380354-57788a80-7fb0-11e9-9a3e-20823009435a.png">
<img width="993" alt="Screen Shot 2019-05-26 at 12 05 48 PM" src="https://user-images.githubusercontent.com/22029477/58380356-5b0c1180-7fb0-11e9-94f3-e5f01e6c3038.png">


