### PR TITLE
Test and fix completion label/replacement mismatches

### DIFF
--- a/plugin/core/completion.py
+++ b/plugin/core/completion.py
@@ -32,6 +32,16 @@ def format_completion(item: dict, last_col: int, settings: 'Settings') -> 'Tuple
             hint = completion_item_kind_names.get(kind)
     # label is an alternative for insertText if neither textEdit nor insertText is provided
     replacement = text_edit_text(item, last_col) or item.get("insertText") or trigger
+
+    if replacement[0] != trigger[0]:
+        # fix some common cases when server sends different start on label and replacement.
+        if replacement[0] == '$':
+            trigger = '$' + trigger  # add missing $
+        elif trigger[0] == '$':
+            trigger = trigger[1:]  # remove leading $
+        elif trigger[0] == ' ' or trigger[0] == '•':
+            trigger = trigger[1:]  # remove clangd insertion indicator
+
     if len(replacement) > 0 and replacement[0] == '$':  # sublime needs leading '$' escaped.
         replacement = '\\$' + replacement[1:]
     # only return trigger with a hint if available

--- a/plugin/core/test_completion.py
+++ b/plugin/core/test_completion.py
@@ -85,7 +85,7 @@ class CompletionFormattingTests(unittest.TestCase):
 
         result = format_completion(item, 0, settings)
         self.assertEqual(len(result), 2)
-        self.assertEqual("true", result[0])
+        self.assertEqual("$true", result[0])
         self.assertEqual("\\$true", result[1])
 
     def test_ignore_label(self):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,22 +1,39 @@
 from unittesting import DeferrableTestCase
 import sublime
 from LSP.plugin.completion import CompletionHandler, CompletionState
-from setup import (
-    SUPPORTED_SYNTAX, text_config, add_config, remove_config, TextDocumentTestCase
-)
+from setup import (SUPPORTED_SYNTAX, text_config, add_config, remove_config,
+                   TextDocumentTestCase)
 
 try:
-    from typing import Dict, Optional
-    assert Dict and Optional
+    from typing import Dict, Optional, List
+    assert Dict and Optional and List
 except ImportError:
     pass
 
-
-completions = [dict(label='asdf'), dict(label='efgh')]
+label_completions = [dict(label='asdf'), dict(label='efgh')]
+insert_text_completions = [dict(label='asdf', insertText='asdf()')]
+var_completion_using_label = [dict(label='$what')]
+var_prefix_added_in_insertText = [dict(label='$what', insertText='what')]
+var_prefix_added_in_label = [
+    dict(label='$what',
+         textEdit={
+             'range': {
+                 'start': {
+                     'line': 0,
+                     'character': 1
+                 },
+                 'end': {
+                     'line': 0,
+                     'character': 1
+                 }
+             },
+             'newText': 'what'
+         })
+]
+space_added_in_label = [dict(label=' const', insertText='const')]
 
 
 class InitializationTests(DeferrableTestCase):
-
     def setUp(self):
         self.view = sublime.active_window().new_file()
         add_config(text_config)
@@ -25,7 +42,8 @@ class InitializationTests(DeferrableTestCase):
         self.assertFalse(CompletionHandler.is_applicable(dict()))
 
     def test_is_applicable(self):
-        self.assertTrue(CompletionHandler.is_applicable(dict(syntax=SUPPORTED_SYNTAX)))
+        self.assertTrue(
+            CompletionHandler.is_applicable(dict(syntax=SUPPORTED_SYNTAX)))
 
     def test_not_enabled(self):
         handler = CompletionHandler(self.view)
@@ -46,10 +64,8 @@ class InitializationTests(DeferrableTestCase):
 
 
 class QueryCompletionsTests(TextDocumentTestCase):
-
-    def test_enabled(self):
+    def _verify_completes_to(self, completions: 'List[Dict]', result: str):
         yield 100
-
         self.client.responses['textDocument/completion'] = completions
 
         handler = self.get_view_event_listener("on_query_completions")
@@ -74,4 +90,120 @@ class QueryCompletionsTests(TextDocumentTestCase):
 
             # verify insertion works
             self.view.run_command("insert_best_completion")
-            self.assertEquals(self.view.substr(sublime.Region(0, self.view.size())), completions[0]["label"])
+            self.assertEquals(
+                self.view.substr(sublime.Region(0, self.view.size())), result)
+
+    def test_simple_label(self):
+        yield 100
+        self.client.responses['textDocument/completion'] = label_completions
+
+        handler = self.get_view_event_listener("on_query_completions")
+        self.assertIsNotNone(handler)
+        if handler:
+            # todo: want to test trigger chars instead?
+            # self.view.run_command('insert', {"characters": '.'})
+            result = handler.on_query_completions("", [1])
+
+            # synchronous response
+            self.assertTrue(handler.initialized)
+            self.assertTrue(handler.enabled)
+            self.assertIsNotNone(result)
+            items, mask = result
+            self.assertEquals(len(items), 0)
+            # self.assertEquals(mask, 0)
+
+            # now wait for server response
+            yield 100
+            self.assertEquals(handler.state, CompletionState.IDLE)
+            self.assertEquals(len(handler.completions), 2)
+
+            # verify insertion works
+            self.view.run_command("insert_best_completion")
+            self.assertEquals(
+                self.view.substr(sublime.Region(0, self.view.size())), 'asdf')
+
+    def test_simple_inserttext(self):
+        yield 100
+        self.client.responses[
+            'textDocument/completion'] = insert_text_completions
+        handler = self.get_view_event_listener("on_query_completions")
+        self.assertIsNotNone(handler)
+        if handler:
+            handler.on_query_completions("", [1])
+            yield 100
+            self.view.run_command("insert_best_completion")
+            self.assertEquals(
+                self.view.substr(sublime.Region(0, self.view.size())),
+                insert_text_completions[0]["insertText"])
+
+    def test_var_prefix_using_label(self):
+        yield 100
+        self.view.run_command('append', {'characters': '$'})
+        self.view.run_command('move_to', {'to': 'eol'})
+        self.client.responses[
+            'textDocument/completion'] = var_completion_using_label
+        handler = self.get_view_event_listener("on_query_completions")
+        self.assertIsNotNone(handler)
+        if handler:
+            handler.on_query_completions("", [1])
+            yield 100
+            self.view.run_command("insert_best_completion")
+            self.assertEquals(
+                self.view.substr(sublime.Region(0, self.view.size())), '$what')
+
+    def test_var_prefix_added_in_insertText(self):
+        """
+
+        Powershell: label='true', insertText='$true' (see https://github.com/tomv564/LSP/issues/294)
+
+        """
+        yield 100
+        self.view.run_command('append', {'characters': '$'})
+        self.view.run_command('move_to', {'to': 'eol'})
+        self.client.responses[
+            'textDocument/completion'] = var_prefix_added_in_insertText
+        handler = self.get_view_event_listener("on_query_completions")
+        self.assertIsNotNone(handler)
+        if handler:
+            handler.on_query_completions("", [1])
+            yield 100
+            self.view.run_command("insert_best_completion")
+            self.assertEquals(
+                self.view.substr(sublime.Region(0, self.view.size())), '$what')
+
+    def test_var_prefix_added_in_label(self):
+        """
+
+        PHP language server: label='$someParam', textEdit='someParam' (https://github.com/tomv564/LSP/issues/368)
+
+        """
+        yield 100
+        self.view.run_command('append', {'characters': '$'})
+        self.view.run_command('move_to', {'to': 'eol'})
+        self.client.responses[
+            'textDocument/completion'] = var_prefix_added_in_label
+        handler = self.get_view_event_listener("on_query_completions")
+        self.assertIsNotNone(handler)
+        if handler:
+            handler.on_query_completions("", [1])
+            yield 100
+            self.view.run_command("insert_best_completion")
+            self.assertEquals(
+                self.view.substr(sublime.Region(0, self.view.size())), '$what')
+
+    def test_space_added_in_label(self):
+        """
+
+        Clangd: label=" const", insertText="const" (https://github.com/tomv564/LSP/issues/368)
+
+        """
+        yield 100
+        self.client.responses['textDocument/completion'] = space_added_in_label
+        handler = self.get_view_event_listener("on_query_completions")
+        self.assertIsNotNone(handler)
+        if handler:
+            handler.on_query_completions("", [1])
+            yield 100
+            self.view.run_command("insert_best_completion")
+            self.assertEquals(
+                self.view.substr(sublime.Region(0, self.view.size())), 'const')


### PR DESCRIPTION
Using `label` for `trigger` works with many language servers.
Clangd and languages with `$` variable prefixes (Powershell and PHP) are notable exceptions where label and insertText/textEdit don't match. Here LSP will try to take off or re-add mismatching leading characters.

Hope is that this will improve completions for the next release without introducing new settings.