### PR TITLE
Allow LSP clients to operate in project sub-paths

### DIFF
--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -38,6 +38,7 @@ def get_window_env(window: sublime.Window, config: ClientConfig) -> 'Tuple[List[
 
 def start_window_config(window: sublime.Window,
                         project_path: str,
+                        client_path: str,
                         config: ClientConfig,
                         on_pre_initialize: 'Callable[[Session], None]',
                         on_post_initialize: 'Callable[[Session], None]',
@@ -46,6 +47,7 @@ def start_window_config(window: sublime.Window,
     config.binary_args = args
     return create_session(config=config,
                           project_path=project_path,
+                          client_path=client_path,
                           env=env,
                           settings=settings,
                           on_pre_initialize=on_pre_initialize,

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -83,6 +83,7 @@ def apply_window_settings(client_config: 'ClientConfig', window: 'sublime.Window
             client_settings,
             client_env,
             overrides.get("tcp_host", client_config.tcp_host),
+            overrides.get("client_path", client_config.client_path),
         )
 
     return client_config

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -66,7 +66,7 @@ class ClientConfig(object):
     def __init__(self, name: str, binary_args: 'List[str]', tcp_port: 'Optional[int]', scopes=[],
                  syntaxes=[], languageId: 'Optional[str]' = None,
                  languages: 'List[LanguageConfig]' = [], enabled: bool = True, init_options=dict(),
-                 settings=dict(), env=dict(), tcp_host: 'Optional[str]' = None) -> None:
+                 settings=dict(), env=dict(), tcp_host: 'Optional[str]' = None, client_path: 'Optional[str]' = None) -> None:
         self.name = name
         self.binary_args = binary_args
         self.tcp_port = tcp_port
@@ -78,6 +78,7 @@ class ClientConfig(object):
         self.init_options = init_options
         self.settings = settings
         self.env = env
+        self.client_path = client_path
 
 
 class ViewLike(Protocol):

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -9,6 +9,8 @@ from .url import filename_to_uri
 from .workspace import get_project_path, get_active_view_path
 from .rpc import Client
 import threading
+import re
+import os
 try:
     from typing_extensions import Protocol
     from typing import Optional, List, Callable, Dict, Any, Iterator
@@ -389,13 +391,16 @@ class WindowManager(object):
         if not self._handlers.on_start(config.name, self._window):
             return
 
+        client_path = project_path if config.client_path == None else os.path.join(project_path, config.client_path)
+
         self._window.status_message("Starting " + config.name + "...")
-        debug("starting in", project_path)
+        debug("starting {} in {}".format(config.name, client_path))
         session = None  # type: Optional[Session]
         try:
             session = self._start_session(
                 window=self._window,
                 project_path=project_path,
+                client_path=client_path,
                 config=config,
                 on_pre_initialize=self._handle_pre_initialize,
                 on_post_initialize=self._handle_post_initialize,


### PR DESCRIPTION
This PR addresses #443.

I’ve been using this patch for quite some time, but figured I’d contribute it here and see what people think. It’s pretty naive and hacked in but if there is interest I’m keen to get this shippable. I think there was some resistance to this approach initially so I’m keen to gauge interest before I go too deep.

It allows for configuring LSP client to operate at sub-paths, for example the following project config would configure the flow client 

```json
{
  "settings": {
    "LSP": {
      "flow": {
        "enabled": true,
        "client_path": "vendor/frontend"
      }
    }
  }
}
```