### PR TITLE
Completion with text edits

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -246,7 +246,9 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
         # response = test_response
 
         if self.state == CompletionState.REQUESTING:
-            last_start = self.last_location - len(self.last_prefix)
+            word = self.view.word(self.last_location)
+
+            last_start = word.begin()  # self.last_location - len(self.last_prefix)
             last_row, last_col = self.view.rowcol(last_start)
             self.response = parse_completion_response(response)
             self.completions = list(format_completion(item, last_col, settings) for item in self.response)

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -167,7 +167,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
                     self.fixing = False
                 additional_edits = item.get('additionalTextEdits')
                 if additional_edits:
-                    self.apply_additional_edits(item)
+                    self.apply_additional_edits(additional_edits)
                 elif self.resolve:
                     self.do_resolve(item)
                 else:

--- a/plugin/core/completion.py
+++ b/plugin/core/completion.py
@@ -1,8 +1,9 @@
 from .protocol import CompletionItemKind, Range
 from .types import Settings
+from .logging import debug
 try:
     from typing import Tuple, Optional, Dict, List, Union
-    assert Tuple and Optional and Dict and List and Union
+    assert Tuple and Optional and Dict and List and Union and Settings
 except ImportError:
     pass
 
@@ -10,12 +11,7 @@ except ImportError:
 completion_item_kind_names = {v: k for k, v in CompletionItemKind.__dict__.items()}
 
 
-def format_completion(item: dict, last_col: int, settings: 'Settings') -> 'Tuple[str, str]':
-    # Sublime handles snippets automatically, so we don't have to care about insertTextFormat.
-    if settings.prefer_label_over_filter_text:
-        trigger = item["label"]
-    else:
-        trigger = item.get("filterText") or item["label"]
+def get_completion_hint(item: dict, settings: 'Settings') -> 'Optional[str]':
     # choose hint based on availability and user preference
     hint = None
     if settings.completion_hint_type == "auto":
@@ -30,8 +26,30 @@ def format_completion(item: dict, last_col: int, settings: 'Settings') -> 'Tuple
         kind = item.get("kind")
         if kind:
             hint = completion_item_kind_names.get(kind)
+    return hint
+
+
+def format_completion(item: dict, last_col: int, settings: 'Settings') -> 'Tuple[str, str]':
+    # Sublime handles snippets automatically, so we don't have to care about insertTextFormat.
+    if settings.prefer_label_over_filter_text:
+        trigger = item["label"]
+    else:
+        trigger = item.get("filterText") or item["label"]
+
+    hint = get_completion_hint(item, settings)
+
     # label is an alternative for insertText if neither textEdit nor insertText is provided
-    replacement = text_edit_text(item, last_col) or item.get("insertText") or trigger
+    # replacement = text_edit_text(item, last_col) or item.get("insertText") or trigger
+
+    text_edit = item.get("textEdit")
+    replacement = None
+    if text_edit:
+        # if edit starts with current word,
+        # if edit starts before current word, use the whole thing and we'll fix it up later.
+        replacement = text_edit.get('newText')
+
+    if replacement is None:
+        replacement = item.get("insertText") or trigger
 
     if replacement[0] != trigger[0]:
         # fix some common cases when server sends different start on label and replacement.
@@ -43,6 +61,9 @@ def format_completion(item: dict, last_col: int, settings: 'Settings') -> 'Tuple
             trigger = trigger[1:]  # remove leading $
         elif trigger[0] == ' ' or trigger[0] == '•':
             trigger = trigger[1:]  # remove clangd insertion indicator
+        else:
+            debug("replacement prefix does not match trigger!")
+            replacement = item.get("insertText") or trigger
 
     if len(replacement) > 0 and replacement[0] == '$':  # sublime needs leading '$' escaped.
         replacement = '\\$' + replacement[1:]
@@ -57,6 +78,8 @@ def text_edit_text(item: dict, last_col: int) -> 'Optional[str]':
         if edit_range and edit_text:
             edit_range = Range.from_lsp(edit_range)
 
+            debug('textEdit from col {}, {} applied at col {}'.format(edit_range.start.col, edit_range.end.col, last_col))
+
             if edit_range.start.col <= last_col:
                 # sublime does not support explicit replacement with completion
                 # at given range, but we try to trim the textEdit range and text
@@ -65,11 +88,11 @@ def text_edit_text(item: dict, last_col: int) -> 'Optional[str]':
     return None
 
 
-def parse_completion_response(response: 'Optional[Union[Dict,List]]', last_col: int, settings: Settings):
+def parse_completion_response(response: 'Optional[Union[Dict,List]]'):
     items = []  # type: List[Dict]
     if isinstance(response, dict):
         items = response["items"] or []
     elif isinstance(response, list):
         items = response
     items = sorted(items, key=lambda item: item.get("sortText") or item["label"])
-    return list(format_completion(item, last_col, settings) for item in items)
+    return items

--- a/plugin/core/test_completion.py
+++ b/plugin/core/test_completion.py
@@ -25,13 +25,13 @@ settings = Settings()
 class CompletionResponseParsingTests(unittest.TestCase):
 
     def test_no_response(self):
-        self.assertEqual(parse_completion_response(None, 0, settings), [])
+        self.assertEqual(parse_completion_response(None), [])
 
     def test_array_response(self):
-        self.assertEqual(parse_completion_response([], 0, settings), [])
+        self.assertEqual(parse_completion_response([]), [])
 
     def test_dict_response(self):
-        self.assertEqual(parse_completion_response({'items': []}, 0, settings), [])
+        self.assertEqual(parse_completion_response({'items': []}), [])
 
 
 class CompletionFormattingTests(unittest.TestCase):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -267,9 +267,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
         self.assertIsNotNone(handler)
         if handler:
             handler.on_query_completions("myF", [7])
-            # self.view.run_command("auto_complete")
             yield 100
-            # todo: this command listener should be invoked??
+            # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('insert_best_completion', {})
             self.view.run_command("insert_best_completion", {})
             yield 100
@@ -278,9 +277,6 @@ class QueryCompletionsTests(TextDocumentTestCase):
                 '  override def myFunction(): Unit = ???')
 
     def test_additional_edits(self):
-        """
-
-        """
         yield 100
         self.client.responses[
             'textDocument/completion'] = completion_with_additional_edits
@@ -288,9 +284,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
         self.assertIsNotNone(handler)
         if handler:
             handler.on_query_completions("", [1])
-            # self.view.run_command("auto_complete")
             yield 100
-            # todo: this command listener should be invoked??
+            # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('insert_best_completion', {})
             self.view.run_command("insert_best_completion", {})
             yield 100
@@ -299,12 +294,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
                 'import asdf;\nasdf')
 
     def test_resolve_for_additional_edits(self):
-        """
-
-        """
         yield 100
-        # capabilities = dict(completionProvider=dict(triggerCharacters=['.'],
-        #                                             resolveProvider=True))
         self.client.responses['textDocument/completion'] = label_completions
         self.client.responses[
             'completionItem/resolve'] = completion_with_additional_edits[0]
@@ -314,12 +304,11 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
 
-            # todo: filthy hack
+            # note: ideally the handler is initialized with resolveProvider capability
             handler.resolve = True
 
-            # self.view.run_command("auto_complete")
             yield 100
-            # todo: this command listener should be invoked??
+            # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('insert_best_completion', {})
             self.view.run_command("insert_best_completion", {})
             yield 100

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,5 +1,6 @@
 import sublime
 from LSP.plugin.completion import CompletionHandler, CompletionState
+from unittesting import DeferrableTestCase
 from setup import (SUPPORTED_SYNTAX, text_config, add_config, remove_config,
                    TextDocumentTestCase)
 
@@ -67,34 +68,34 @@ edit_before_cursor = [
 ]
 
 
-# class InitializationTests(DeferrableTestCase):
-#     def setUp(self):
-#         self.view = sublime.active_window().new_file()
-#         add_config(text_config)
+class InitializationTests(DeferrableTestCase):
+    def setUp(self):
+        self.view = sublime.active_window().new_file()
+        add_config(text_config)
 
-#     def test_is_not_applicable(self):
-#         self.assertFalse(CompletionHandler.is_applicable(dict()))
+    def test_is_not_applicable(self):
+        self.assertFalse(CompletionHandler.is_applicable(dict()))
 
-#     def test_is_applicable(self):
-#         self.assertTrue(
-#             CompletionHandler.is_applicable(dict(syntax=SUPPORTED_SYNTAX)))
+    def test_is_applicable(self):
+        self.assertTrue(
+            CompletionHandler.is_applicable(dict(syntax=SUPPORTED_SYNTAX)))
 
-#     def test_not_enabled(self):
-#         handler = CompletionHandler(self.view)
-#         self.assertFalse(handler.initialized)
-#         self.assertFalse(handler.enabled)
-#         result = handler.on_query_completions("", [0])
-#         yield 100
-#         self.assertTrue(handler.initialized)
-#         self.assertFalse(handler.enabled)
-#         self.assertIsNone(result)
+    def test_not_enabled(self):
+        handler = CompletionHandler(self.view)
+        self.assertFalse(handler.initialized)
+        self.assertFalse(handler.enabled)
+        result = handler.on_query_completions("", [0])
+        yield 100
+        self.assertTrue(handler.initialized)
+        self.assertFalse(handler.enabled)
+        self.assertIsNone(result)
 
-#     def tearDown(self):
-#         remove_config(text_config)
-#         if self.view:
-#             self.view.set_scratch(True)
-#             self.view.window().focus_view(self.view)
-#             self.view.window().run_command("close_file")
+    def tearDown(self):
+        remove_config(text_config)
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
+            self.view.window().run_command("close_file")
 
 
 class QueryCompletionsTests(TextDocumentTestCase):


### PR DESCRIPTION
Sets up a post-completion hook so we can:
* Fix the completion using the item's textEdit (issue #536)
* Apply additionalTextEdits (issue #529)

`completionItem/resolve` is used to get the additionalTextEdits if the server indicates support.

Code is tested using examples given in issues, but more live testing with specific servers is needed!
Assumptions:
* If a command like `'commit_completion', 'insert_best_completion', 'auto_complete'` runs, the next `on_modified` is the insertion of the completion.
* It is always safe to trim the difference between the start of the current word and the textEdit's start.
* All additionalTextEdits should be immediately applied after the completion is inserted.

To do:
- [x] Get feedback from clangd , metals and others?
- [x] Clean up code
- [x] Look for holes / add tests
- [x] UX considerations