### PR TITLE
We are escaping the parameter of the signature help too many times

### DIFF
--- a/plugin/core/signature_help.py
+++ b/plugin/core/signature_help.py
@@ -144,7 +144,7 @@ def render_signature_label(renderer: ScopeRenderer, sig_info: SignatureInformati
             if param.range:
                 start, end = param.range
                 is_current = active_parameter_index == max_param_index - index
-                rendered_param = renderer.parameter(html.escape(label[start:end], quote=False), is_current)
+                rendered_param = renderer.parameter(content=label[start:end], emphasize=is_current)
                 label = label[:start] + rendered_param + label[end:]
 
                 # todo: highlight commas between parameters as punctuation.

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -195,17 +195,6 @@ class RenderSignatureLabelTests(unittest.TestCase):
  \n<variable.parameter>foo</variable.parameter>\
  \n<variable.parameter emphasize>foo</variable.parameter></entity.name.function>""")
 
-    def test_escape_content(self):
-        sig = create_signature("foobar<T>(foo: Option<i32>) -> List<T>", "foo: Option<i32>", activeParameter=0)
-        help = create_signature_help(dict(signatures=[sig]))
-        if help:
-            label = render_signature_label(renderer, help.active_signature(), 0)
-            self.assertEqual(label, """
-<entity.name.function>foobar&lt;T&gt;
-<punctuation>(</punctuation>
-<variable.parameter emphasize>foo: Option&lt;i32&gt;</variable.parameter>
-<punctuation>)</punctuation> -&gt; List&lt;T&gt;</entity.name.function>""")
-
 
 class SignatureHelpTests(unittest.TestCase):
 


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/2431823/59146838-679e5a00-89f3-11e9-924b-e70ee6a05c3d.gif)

after:
![after](https://user-images.githubusercontent.com/2431823/59146843-7422b280-89f3-11e9-90ef-9bc3345224e5.gif)
