### PR TITLE
Handle incomplete completion lists

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -160,11 +160,9 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
         else:
             if self.view.is_auto_complete_visible():
                 if self.response_incomplete:
-                    debug('incomplete, triggering new completions')
+                    # debug('incomplete, triggering new completions')
                     self.view.run_command("hide_auto_complete")
                     sublime.set_timeout(self.run_auto_complete, 0)
-                else:
-                    debug('buffer modified but response was complete')
 
     def on_completion_inserted(self):
         # get text inserted from last completion
@@ -210,7 +208,6 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
 
         if self.enabled:
             reuse_completion = self.is_same_completion(prefix, locations)
-            debug('on_query_completions', prefix, locations, 'state', self.state, 'reuse', reuse_completion)
             if self.state == CompletionState.IDLE:
                 if not reuse_completion:
                     self.last_prefix = prefix

--- a/plugin/core/completion.py
+++ b/plugin/core/completion.py
@@ -79,11 +79,13 @@ def text_edit_text(item: dict, word_col: int) -> 'Optional[str]':
     return None
 
 
-def parse_completion_response(response: 'Optional[Union[Dict,List]]'):
+def parse_completion_response(response: 'Optional[Union[Dict,List]]') -> 'Tuple[List[Dict], bool]':
     items = []  # type: List[Dict]
+    is_incomplete = False
     if isinstance(response, dict):
         items = response["items"] or []
+        is_incomplete = response.get("isIncomplete", False)
     elif isinstance(response, list):
         items = response
     items = sorted(items, key=lambda item: item.get("sortText") or item["label"])
-    return items
+    return items, is_incomplete

--- a/plugin/core/test_completion.py
+++ b/plugin/core/test_completion.py
@@ -25,13 +25,16 @@ settings = Settings()
 class CompletionResponseParsingTests(unittest.TestCase):
 
     def test_no_response(self):
-        self.assertEqual(parse_completion_response(None), [])
+        self.assertEqual(parse_completion_response(None), ([], False))
 
     def test_array_response(self):
-        self.assertEqual(parse_completion_response([]), [])
+        self.assertEqual(parse_completion_response([]), ([], False))
 
     def test_dict_response(self):
-        self.assertEqual(parse_completion_response({'items': []}), [])
+        self.assertEqual(parse_completion_response({'items': []}), ([], False))
+
+    def test_incomplete_dict_response(self):
+        self.assertEqual(parse_completion_response({'items': [], 'isIncomplete': True}), ([], True))
 
 
 class CompletionFormattingTests(unittest.TestCase):


### PR DESCRIPTION
The implementation for #299 and possibly a fix for #523 ?

If a language server responds with `isIncomplete: true`, then the completion handler will request fresh completions in `on_modified` as long as the completion list stays open. 

Tested somewhat with lsp-tsserver but I'd really like to hear how this works with real-life projects with intelephense and other servers!