### PR TITLE
Fix dropping a leading colon when accepting a completion

### DIFF
--- a/plugin/core/completion.py
+++ b/plugin/core/completion.py
@@ -47,6 +47,8 @@ def format_completion(item: dict, word_col: int, settings: 'Settings') -> 'Tuple
             trigger = '$' + trigger  # add missing $
         elif replacement[0] == '-':
             trigger = '-' + trigger  # add missing -
+        elif trigger[0] == ':':
+            replacement = ':' + replacement  # add missing :
         elif trigger[0] == '$':
             trigger = trigger[1:]  # remove leading $
         elif trigger[0] == ' ' or trigger[0] == '•':


### PR DESCRIPTION
Addresses #623. In Ruby, symbols are denoted with a leading colon (like `:my_symbol`). This fixes the colon being dropped from the auto complete as described in the mentioned issue.

I noticed that there were similar fixes in the 0.8.4 release:

> Fix double '$' or removal of leading characters in some completions (clangd/PHP/Powershell)

I saw that those fixes were implemented pretty simply so I tried to follow the same format. Let me know if you think there might be any other issues with this, I'm happy to try to fix them if they are within my limited realm of Python knowledge.