### PR TITLE
Add empty codeActionKind entry

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -136,7 +136,11 @@ def get_initialize_params(project_path: str, config: ClientConfig):
                 "rangeFormatting": {},
                 "definition": {},
                 "codeAction": {
-                    "codeActionLiteralSupport": {}
+                    "codeActionLiteralSupport": {
+                        "codeActionKind": {
+                            "valueSet": []
+                        }
+                    }
                 },
                 "rename": {}
             },


### PR DESCRIPTION
RLS now requires a `codeActionKind` entry. An empty `valueSet` will
satisfy the requirement for now, allowing RLS to start normally. Fixes #630