### PR TITLE
Add LaTeX language server (TexLab) to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Documentation is available at [LSP.readthedocs.io](https://LSP.readthedocs.io).
 * [JSON](https://lsp.readthedocs.io/en/latest/#json)
 * [Julia](https://lsp.readthedocs.io/en/latest/#julia)
 * [Kotlin](https://lsp.readthedocs.io/en/latest/#kotlin)
+* [LaTeX](https://lsp.readthedocs.io/en/latest/#latex)
 * [PHP](https://lsp.readthedocs.io/en/latest/#php)
 * [Polymer](https://lsp.readthedocs.io/en/latest/#polymer)
 * [Python](https://lsp.readthedocs.io/en/latest/#python)

--- a/docs/index.md
+++ b/docs/index.md
@@ -297,6 +297,30 @@ Requires IntelliJ to be running.
 }
 ```
 
+### LaTeX<a name="latex"></a>
+
+Download a [precompiled binary](https://github.com/latex-lsp/texlab/releases) (Windows/Linux/macOS) of the [TexLab](https://texlab.netlify.com/) Language Server and place it in a directory that is in your `PATH`.
+
+Add to LSP settings' clients:
+```json
+"texlab": {
+  "command": ["texlab"],
+  "languages": [{
+    "scopes": ["text.tex.latex"],
+    "syntaxes": ["Packages/LaTeX/LaTeX.sublime-syntax"],
+    "languageId": "latex"
+  }, {
+    "scopes": ["text.bibtex"],
+    "syntaxes": ["Packages/LaTeX/Bibtex.sublime-syntax"],
+    "languageId": "bibtex"
+  }],
+  "enabled": true
+}
+```
+
+To enable code completions while typing, ensure to have `text.tex.latex` (for LaTeX files) and/or `text.bibtex` (for BibTeX files) included in the `auto_complete_selector` setting in your `Preferences.sublime-settings` file.
+For further requirements see the [TexLab Docs](https://texlab.netlify.com/docs#requirements).
+
 ### Other<a name="other"></a>
 
 Please create issues / pull requests so we can get support for more languages.


### PR DESCRIPTION
I have tested the language server under Windows.