### PR TITLE
Escape the hover text.

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -139,9 +139,9 @@ class LspHoverCommand(LspTextCommand):
             value = ""
             language = None
             if isinstance(item, str):
-                value = item
+                value = escape(item)
             else:
-                value = item.get("value")
+                value = escape(item.get("value"))
                 language = item.get("language")
             if language:
                 formatted.append("```{}\n{}\n```\n".format(language, value))


### PR DESCRIPTION
In C#, you can get hover text that contains angle brackets.  Angle brackets don't need to be escaped in markdown.  The problem is that mdpopups.md2html doesn't escape our angle brackets and causes invalid HTML to be generated, so let's escape our hover text before we toss it into md2html.