### PR TITLE
Add settings id

### DIFF
--- a/Menus/Main.sublime-menu
+++ b/Menus/Main.sublime-menu
@@ -9,6 +9,7 @@
         "children": [
           {
             "caption": "LSP",
+            "id": "lsp-settings",
             "children": [
               {
                 "caption": "Settings",


### PR DESCRIPTION
So other LSP Handler Plugins settings can be added to the same sublime menu.

<img width="1440" alt="Screen Shot 2019-07-27 at 9 38 36 AM" src="https://user-images.githubusercontent.com/22029477/61991596-a72c0e80-b052-11e9-8891-69544427df10.png">
