### PR TITLE
Fix new line to break

### DIFF
--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -167,6 +167,7 @@ class LspHoverCommand(LspTextCommand):
         return mdpopups.md2html(self.view, "\n".join(formatted))
 
     def show_hover(self, point, contents):
+        contents = contents.replace('\n', '<br>')
         mdpopups.show_popup(
             self.view,
             contents,

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -119,10 +119,11 @@ class LspHoverCommand(LspTextCommand):
         return "<p>" + " | ".join(actions) + "</p>"
 
     def format_diagnostic(self, diagnostic):
+        diagnostic_message = escape(diagnostic.message, False).replace('\n', '<br>')
         if diagnostic.source:
-            return "<pre>[{}] {}</pre>".format(diagnostic.source, escape(diagnostic.message, False))
+            return "<pre>[{}] {}</pre>".format(diagnostic.source, diagnostic_message)
         else:
-            return "<pre>{}</pre>".format(escape(diagnostic.message, False))
+            return "<pre>{}</pre>".format(diagnostic_message)
 
     def diagnostics_content(self, diagnostics):
         by_severity = {}  # type: Dict[int, List[str]]
@@ -167,7 +168,6 @@ class LspHoverCommand(LspTextCommand):
         return mdpopups.md2html(self.view, "\n".join(formatted))
 
     def show_hover(self, point, contents):
-        contents = contents.replace('\n', '<br>')
         mdpopups.show_popup(
             self.view,
             contents,


### PR DESCRIPTION
I tried the elm language server, and noticed one thing.
The diagnostics for errors were really hard tor read. They were all concatenated into one big hard to read string. 

So this PR fixes that.

Before
![2019-08-01-073810_653x728_scrot](https://user-images.githubusercontent.com/22029477/62269302-ed0e1b80-b432-11e9-92c5-0b45ee1c29eb.png)

After
![2019-08-01-080238_1366x768_scrot](https://user-images.githubusercontent.com/22029477/62269308-f1d2cf80-b432-11e9-8182-2582666fd2f4.png)

I know  mdpopups has a `nl2br` option, but setting it won't cause the new lines to translate to breaks.
https://github.com/tomv564/LSP/blob/67a55b7978651f29d8c7d1e0873c8f20deff8ce1/plugin/hover.py#L169-L179

So if you know a better way how to fix this, please close this PR :)