### PR TITLE
Add color provider support

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -58,7 +58,7 @@
   "show_code_actions_bulb": false,
 
   // Show a box next to the color if the language server provides color support.
-  "show_color_box": false,
+  "show_color_box": true,
 
   // Request completions for all characters if set to true,
   // or just after trigger characters only otherwise.

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -57,6 +57,9 @@
   // Show a bulb in the gutter when code actions are available
   "show_code_actions_bulb": false,
 
+  // Show a color box if the language server provides color support.
+  "show_color_box": false,
+
   // Request completions for all characters if set to true,
   // or just after trigger characters only otherwise.
   "complete_all_chars": true,

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -57,7 +57,7 @@
   // Show a bulb in the gutter when code actions are available
   "show_code_actions_bulb": false,
 
-  // Show a color box if the language server provides color support.
+  // Show a box next to the color if the language server provides color support.
   "show_color_box": false,
 
   // Request completions for all characters if set to true,

--- a/boot.py
+++ b/boot.py
@@ -15,6 +15,7 @@ from .plugin.hover import *
 from .plugin.references import *
 from .plugin.signature_help import *
 from .plugin.code_actions import *
+from .plugin.color import *
 from .plugin.symbols import *
 from .plugin.rename import *
 from .plugin.execute_command import *

--- a/boot.py
+++ b/boot.py
@@ -27,4 +27,3 @@ def plugin_loaded():
 
 def plugin_unloaded():
     shutdown()
-    remove_all_highlights()

--- a/docs/features.md
+++ b/docs/features.md
@@ -81,7 +81,7 @@ Global plugin settings and settings defined at project level are merged together
 * `document_highlight_scopes`: *customize your sublime text scopes for document highlighting*
 * `diagnostics_gutter_marker` `"dot"` *gutter marker for code diagnostics: "dot", "circle", "bookmark", "cross" or ""*
 * `show_code_actions_bulb` `false` *show a bulb in the gutter when code actions are available*
-* `show_color_box` `false` *Show a color box if the language server provides color support*
+* `show_color_box` `false` *Show a box next to the color if the language server provides color support*
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `true` *show server/logMessage notifications from language servers in the console*
 * `log_stderr` `false` *show language server stderr output in the console*

--- a/docs/features.md
+++ b/docs/features.md
@@ -81,6 +81,7 @@ Global plugin settings and settings defined at project level are merged together
 * `document_highlight_scopes`: *customize your sublime text scopes for document highlighting*
 * `diagnostics_gutter_marker` `"dot"` *gutter marker for code diagnostics: "dot", "circle", "bookmark", "cross" or ""*
 * `show_code_actions_bulb` `false` *show a bulb in the gutter when code actions are available*
+* `show_color_box` `false` *Show a color box if the language server provides color support*
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `true` *show server/logMessage notifications from language servers in the console*
 * `log_stderr` `false` *show language server stderr output in the console*

--- a/docs/features.md
+++ b/docs/features.md
@@ -81,7 +81,7 @@ Global plugin settings and settings defined at project level are merged together
 * `document_highlight_scopes`: *customize your sublime text scopes for document highlighting*
 * `diagnostics_gutter_marker` `"dot"` *gutter marker for code diagnostics: "dot", "circle", "bookmark", "cross" or ""*
 * `show_code_actions_bulb` `false` *show a bulb in the gutter when code actions are available*
-* `show_color_box` `false` *Show a box next to the color if the language server provides color support*
+* `show_color_box` `true` *Show a box next to the color if the language server provides color support*
 * `log_debug` `false` *show debug logging in the sublime console*
 * `log_server` `true` *show server/logMessage notifications from language servers in the console*
 * `log_stderr` `false` *show language server stderr output in the console*

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -1,0 +1,95 @@
+import sublime_plugin
+import sublime
+
+try:
+    from typing import Any, List, Dict, Callable, Optional
+    assert Any and List and Dict and Callable and Optional
+except ImportError:
+    pass
+
+from .core.protocol import Request
+from .core.url import filename_to_uri
+from .core.registry import session_for_view
+from .core.settings import settings
+from .core.views import range_to_region
+from .core.protocol import Range
+
+
+def send_color_request(view, on_response_recieved: 'Callable'):
+    session = session_for_view(view)
+    if not session or not session.has_capability('colorProvider'):
+        # the server doesn't support colors, just return
+        return
+
+    params = {
+        "textDocument": {
+            "uri": filename_to_uri(view.file_name())
+        }
+    }
+    session.client.send_request(
+        Request.color(params),
+        lambda response: on_response_recieved(response))
+
+
+color_phantom_sets_by_id = {}
+
+
+class LspColorListener(sublime_plugin.ViewEventListener):
+    def __init__(self, view: sublime.View) -> None:
+        super().__init__(view)
+        self._stored_point = -1
+
+    @classmethod
+    def is_applicable(cls, _settings):
+        if settings.show_color_box:
+            return True
+        return False
+
+    def on_activated_async(self):
+        self.schedule_request()
+
+    def on_modified_async(self):
+        self.schedule_request()
+
+    def schedule_request(self):
+        current_point = self.view.sel()[0].begin()
+        if self._stored_point != current_point:
+            self._stored_point = current_point
+            sublime.set_timeout_async(lambda: self.fire_request(current_point), 800)
+
+    def fire_request(self, current_point: int) -> None:
+        if current_point == self._stored_point:
+            send_color_request(self.view, self.handle_response)
+
+    def handle_response(self, response) -> None:
+        global color_phantom_sets_by_id
+        id = self.view.id()
+
+        phantoms = []
+        for val in response:
+            color = val['color']
+            red = color['red'] * 255
+            green = color['green'] * 255
+            blue = color['blue'] * 255
+            alpha = color['alpha']
+
+            content = """
+            <div style='padding: 0.5rem;
+                        margin-top: 0.1rem;
+                        border: 1px solid color(var(--foreground) alpha(0.25));
+                        background-color: rgba({}, {}, {}, {})'>
+            </div>""".format(red, green, blue, alpha)
+
+            range = Range.from_lsp(val['range'])
+            region = range_to_region(range, self.view)
+
+            phantoms.append(sublime.Phantom(region, content, sublime.LAYOUT_INLINE))
+
+        if phantoms:
+            phantom_set = color_phantom_sets_by_id.get(id)
+            if not phantom_set:
+                phantom_set = sublime.PhantomSet(self.view, "lsp_color")
+                color_phantom_sets_by_id[id] = phantom_set
+            phantom_set.update(phantoms)
+        else:
+            color_phantom_sets_by_id.pop(id, None)

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -93,3 +93,7 @@ class LspColorListener(sublime_plugin.ViewEventListener):
             phantom_set.update(phantoms)
         else:
             color_phantom_sets_by_id.pop(id, None)
+
+
+def remove_color_boxes(view):
+    view.erase_phantoms('lsp_color')

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -27,7 +27,7 @@ def send_color_request(view, on_response_recieved: 'Callable'):
         }
     }
     session.client.send_request(
-        Request.color(params),
+        Request.documentColor(params),
         lambda response: on_response_recieved(response))
 
 

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -34,7 +34,7 @@ def send_color_request(view, on_response_recieved: 'Callable'):
 class LspColorListener(sublime_plugin.ViewEventListener):
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)
-        self.color_phantom_set = {}  # type: Optional[sublime.PhantomSet]
+        self.color_phantom_set = None  # type: Optional[sublime.PhantomSet]
         self._stored_point = -1
 
     @classmethod

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -31,7 +31,7 @@ def send_color_request(view, on_response_recieved: 'Callable'):
         lambda response: on_response_recieved(response))
 
 
-color_phantom_sets_by_id = {}
+color_phantom_sets_by_id = {}  # type: Dict[int, sublime.PhantomSet]
 
 
 class LspColorListener(sublime_plugin.ViewEventListener):

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -1,5 +1,5 @@
-from LSP.plugin.highlights import remove_highlights
-from LSP.plugin.color import remove_color_boxes
+from ..highlights import remove_highlights
+from ..color import remove_color_boxes
 
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional, Set

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -1,3 +1,5 @@
+from LSP.plugin.highlights import remove_highlights
+from LSP.plugin.color import remove_color_boxes
 
 try:
     from typing import Any, List, Dict, Tuple, Callable, Optional, Set
@@ -31,13 +33,15 @@ def shutdown():
     # Also needs to handle package being disabled or removed
     # https://github.com/tomv564/LSP/issues/375
     unload_settings()
-    unload_sessions()  # unloads view state from document sync and diagnostics
-    unload_panels()  # references and diagnostics panels
 
-
-def unload_panels():
     for window in sublime.windows():
-        destroy_output_panels(window)
+        unload_sessions(window)  # unloads view state from document sync and diagnostics
+        destroy_output_panels(window)  # references and diagnostics panels
+
+        for view in window.views():
+            if view.file_name():
+                remove_highlights(view)
+                remove_color_boxes(view)
 
 
 def start_active_window():

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -138,6 +138,10 @@ class Request:
         return Request("textDocument/codeAction", params)
 
     @classmethod
+    def color(cls, params: dict) -> 'Request':
+        return Request('textDocument/documentColor', params)
+
+    @classmethod
     def executeCommand(cls, params: dict) -> 'Request':
         return Request("workspace/executeCommand", params)
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -138,7 +138,7 @@ class Request:
         return Request("textDocument/codeAction", params)
 
     @classmethod
-    def color(cls, params: dict) -> 'Request':
+    def documentColor(cls, params: dict) -> 'Request':
         return Request('textDocument/documentColor', params)
 
     @classmethod

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -94,10 +94,9 @@ def _client_for_view_and_window(view: sublime.View, window: 'Optional[sublime.Wi
         return None
 
 
-def unload_sessions():
-    for window in sublime.windows():
-        wm = windows.lookup(window)
-        wm.end_sessions()
+def unload_sessions(window):
+    wm = windows.lookup(window)
+    wm.end_sessions()
 
 
 configs = ConfigManager(client_configs.all)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -96,7 +96,8 @@ def get_initialize_params(project_path: str, config: ClientConfig):
                         }
                     }
                 },
-                "rename": {}
+                "rename": {},
+                "colorProvider": {}
             },
             "workspace": {
                 "applyEdit": True,

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -58,7 +58,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings):
                                                            settings.document_highlight_scopes)
     settings.diagnostics_gutter_marker = read_str_setting(settings_obj, "diagnostics_gutter_marker", "dot")
     settings.show_code_actions_bulb = read_bool_setting(settings_obj, "show_code_actions_bulb", False)
-    settings.show_color_box = read_bool_setting(settings_obj, "show_color_box", False)
+    settings.show_color_box = read_bool_setting(settings_obj, "show_color_box", True)
     settings.only_show_lsp_completions = read_bool_setting(settings_obj, "only_show_lsp_completions", False)
     settings.complete_all_chars = read_bool_setting(settings_obj, "complete_all_chars", True)
     settings.completion_hint_type = read_str_setting(settings_obj, "completion_hint_type", "auto")

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -58,6 +58,7 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings):
                                                            settings.document_highlight_scopes)
     settings.diagnostics_gutter_marker = read_str_setting(settings_obj, "diagnostics_gutter_marker", "dot")
     settings.show_code_actions_bulb = read_bool_setting(settings_obj, "show_code_actions_bulb", False)
+    settings.show_color_box = read_bool_setting(settings_obj, "show_color_box", False)
     settings.only_show_lsp_completions = read_bool_setting(settings_obj, "only_show_lsp_completions", False)
     settings.complete_all_chars = read_bool_setting(settings_obj, "complete_all_chars", True)
     settings.completion_hint_type = read_str_setting(settings_obj, "completion_hint_type", "auto")

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -30,7 +30,7 @@ class Settings(object):
         }
         self.diagnostics_gutter_marker = "dot"
         self.show_code_actions_bulb = False
-        self.show_color_box = False
+        self.show_color_box = True
         self.complete_all_chars = False
         self.completion_hint_type = "auto"
         self.prefer_label_over_filter_text = False

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -30,6 +30,7 @@ class Settings(object):
         }
         self.diagnostics_gutter_marker = "dot"
         self.show_code_actions_bulb = False
+        self.show_color_box = False
         self.complete_all_chars = False
         self.completion_hint_type = "auto"
         self.prefer_label_over_filter_text = False

--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -24,16 +24,9 @@ _kind2name = {
 }
 
 
-def remove_all_highlights():
-    for window in sublime.windows():
-        remove_highlights(window)
-
-
-def remove_highlights(window: sublime.Window):
-    for view in window.views():
-        if view.file_name():
-            for kind in settings.document_highlight_scopes.keys():
-                view.erase_regions("lsp_highlight_{}".format(kind))
+def remove_highlights(view: sublime.View):
+    for kind in settings.document_highlight_scopes.keys():
+        view.erase_regions("lsp_highlight_{}".format(kind))
 
 
 class DocumentHighlightListener(sublime_plugin.ViewEventListener):


### PR DESCRIPTION
![2019-08-19-001432_752x712_scrot](https://user-images.githubusercontent.com/22029477/63279563-80f03c00-c2a9-11e9-9c50-a368c139f434.png)

This PR brings support for `textDocument/documentColor` request.
It will display a box next to the color. 
By default I have set  `show_color_box` to `false`.

Also, one thing I did with this PR is a little bit of cleanup in the unload_plugin logic.
Before:
We iterated multiple times though the windows to do the cleanup.

Now:
We will iterate only once thought the windows and views. and in that one iteration do the cleanup.

Although in reality, the user would have max 3 sublime windows open. :) 
But still. I think it is a small nice clean up.





 


