### PR TITLE
Exclude docs/ folder while packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/ export-ignore


### PR DESCRIPTION
The current master of `LSP.sublime-package` has a size of ~725KB. Almost all size comes from images in the `docs/` directory, which is not useful at local imho.

After excluding it, the packed size is ~120KB.