### PR TITLE
Add ruby RuboCop linting to initialization options

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -452,7 +452,11 @@
         "Packages/Rails/Ruby on Rails.sublime-syntax",
         "Packages/Rails/HTML (Rails).sublime-syntax"
       ],
-      "tcp_port": 7658
+      "tcp_port": 7658,
+      // Enable RuboCop linting
+      // "initializationOptions": {
+      //   "diagnostics": true
+      // },
     },
     "vscode-css":
       {


### PR DESCRIPTION
Must be enabled manually, documented:
https://github.com/castwide/solargraph/issues/37#issuecomment-380520595