### PR TITLE
Preserve the order in the array of text edits if they have the same location

### DIFF
--- a/plugin/core/edit.py
+++ b/plugin/core/edit.py
@@ -35,7 +35,7 @@ def sort_by_application_order(changes: 'Iterable[TextEdit]') -> 'List[TextEdit]'
 
     def get_start_position(pair: 'Tuple[int, TextEdit]'):
         index, change = pair
-        return change[0][0], change[0][1], index
+        return change[0][0], change[0][1], -index
 
     # The spec reads:
     # > However, it is possible that multiple edits have the same start position: multiple

--- a/plugin/core/test_edit.py
+++ b/plugin/core/test_edit.py
@@ -64,8 +64,8 @@ class SortByApplicationOrderTests(unittest.TestCase):
             ((0, 0), (0, 0), 'a'),
             ((0, 2), (0, 2), 'c')
         ]
-        # expect 'c' (higher start), 'a' now reverse order before 'b'
+        # expect 'c' (higher start), but 'b' still before 'a' because the array order is preserved.
         sorted = sort_by_application_order(edits)
         self.assertEqual(sorted[0][2], 'c')
-        self.assertEqual(sorted[1][2], 'a')
-        self.assertEqual(sorted[2][2], 'b')
+        self.assertEqual(sorted[1][2], 'b')
+        self.assertEqual(sorted[2][2], 'a')

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -63,8 +63,8 @@ class ApplyDocumentEditTests(DeferrableTestCase):
             'c'
         )
         file_changes = [
-            ((1,0), (2,0), ''),
-            ((2,0), (2,0), 'x\n')
+            ((1, 0), (2, 0), ''),
+            ((2, 0), (2, 0), 'x\n')
         ]
         expected = (
             'a\n'


### PR DESCRIPTION
Related to #690.

There's a bug in our sorting of the text edits. The original order in the array should be preserved if text edits have the same start location. Consequently, a test was wrong :) but is now fixed.

This does not end #690 because I'm pretty sure now that it is a bug in gopls. Or at least, gopls assumes there is an "infinite buffer" which ST doesn't have. One may argue gopls sends invalid positions outside of the text buffer. I have documented this behavior in the form of a skipped test called test_remove_line_and_then_insert_at_that_line_at_end.