### PR TITLE
Fix inline color phantom makes line height larger a little bit

### DIFF
--- a/plugin/color.py
+++ b/plugin/color.py
@@ -69,8 +69,8 @@ class LspColorListener(sublime_plugin.ViewEventListener):
             alpha = color['alpha']
 
             content = """
-            <div style='padding: 0.5rem;
-                        margin-top: 0.1rem;
+            <div style='padding: 0.4em;
+                        margin-top: 0.1em;
                         border: 1px solid color(var(--foreground) alpha(0.25));
                         background-color: rgba({}, {}, {}, {})'>
             </div>""".format(red, green, blue, alpha)


### PR DESCRIPTION
The phantom created by LSP is make the height of the line larger a little bit.

- Similar issue that I reported to ColorHelp weeks ago: https://github.com/facelessuser/ColorHelper/pull/122