### PR TITLE
Client config handling improvements / cleanup

### DIFF
--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from .types import ClientConfig, LanguageConfig, ViewLike, WindowLike, ConfigRegistry
 from .logging import debug
 from .types import config_supports_syntax, syntax_language
-from .workspace import get_project_config
+from .workspace import get_project_config, enable_in_project, disable_in_project
 
 assert ClientConfig
 
@@ -56,11 +56,11 @@ def get_global_client_config(view: 'sublime.View', global_configs: 'List[ClientC
     return get_scope_client_config(view, global_configs)
 
 
-def create_window_configs(window: 'sublime.Window', global_configs: 'List[ClientConfig]') -> 'List[ClientConfig]':
-    return list(map(lambda c: apply_window_settings(c, window), global_configs))
+def create_window_configs(window: 'WindowLike', global_configs: 'List[ClientConfig]') -> 'List[ClientConfig]':
+    return list(map(lambda c: apply_project_overrides(c, window), global_configs))
 
 
-def apply_window_settings(client_config: 'ClientConfig', window: 'sublime.Window') -> 'ClientConfig':
+def apply_project_overrides(client_config: 'ClientConfig', window: 'WindowLike') -> 'ClientConfig':
     window_config = get_project_config(window)
 
     if client_config.name in window_config:
@@ -100,20 +100,22 @@ class ConfigManager(object):
         self._configs = global_configs
         self._managers = {}  # type: Dict[int, ConfigRegistry]
 
-    def for_window(self, window: 'Any') -> 'ConfigRegistry':
-        window_configs = WindowConfigManager(create_window_configs(window, self._configs))
+    def for_window(self, window: 'WindowLike') -> 'ConfigRegistry':
+        window_configs = WindowConfigManager(window, self._configs)
         self._managers[window.id()] = window_configs
         return window_configs
 
     def update(self) -> None:
         for window in sublime.windows():
             if window.id() in self._managers:
-                self._managers[window.id()].update(create_window_configs(window, self._configs))
+                self._managers[window.id()].update()
 
 
 class WindowConfigManager(object):
-    def __init__(self, configs: 'List[ClientConfig]') -> None:
-        self.all = configs
+    def __init__(self, window: 'WindowLike', global_configs: 'List[ClientConfig]') -> None:
+        self._window = window
+        self._global_configs = global_configs
+        self.all = create_window_configs(window, global_configs)
 
     def is_supported(self, view: 'Any') -> bool:
         return any(self.scope_configs(view))
@@ -141,10 +143,20 @@ class WindowConfigManager(object):
                     config_languages[config.name] = language
         return config_languages
 
-    def update(self, configs: 'List[ClientConfig]') -> None:
-        self.all = configs
+    def update(self) -> None:
+        self.all = create_window_configs(self._window, self._global_configs)
+        # debug('window {} client configs'.format(self._window.id()), list('{}={}'.format(c.name, c.enabled)
+        # for c in self.all))
 
-    def disable(self, config_name: str) -> None:
+    def enable_config(self, config_name: str) -> None:
+        enable_in_project(self._window, config_name)
+        self.update()
+
+    def disable_config(self, config_name: str) -> None:
+        disable_in_project(self._window, config_name)
+        self.update()
+
+    def disable_temporarily(self, config_name: str) -> None:
         for config in self.all:
             if config.name == config_name:
                 config.enabled = False

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -144,8 +144,6 @@ class WindowConfigManager(object):
 
     def update(self) -> None:
         self.all = create_window_configs(self._window, self._global_configs)
-        # debug('window {} client configs'.format(self._window.id()), list('{}={}'.format(c.name, c.enabled)
-        # for c in self.all))
 
     def enable_config(self, config_name: str) -> None:
         enable_in_project(self._window, config_name)

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -57,15 +57,14 @@ def get_global_client_config(view: 'sublime.View', global_configs: 'List[ClientC
 
 
 def create_window_configs(window: 'WindowLike', global_configs: 'List[ClientConfig]') -> 'List[ClientConfig]':
-    return list(map(lambda c: apply_project_overrides(c, window), global_configs))
-
-
-def apply_project_overrides(client_config: 'ClientConfig', window: 'WindowLike') -> 'ClientConfig':
     window_config = get_project_config(window)
+    return list(map(lambda c: apply_project_overrides(c, window_config), global_configs))
 
-    if client_config.name in window_config:
-        overrides = window_config[client_config.name]
-        debug('window {} has override for {}'.format(window.id(), client_config.name), overrides)
+
+def apply_project_overrides(client_config: 'ClientConfig', lsp_project_settings: dict) -> 'ClientConfig':
+    if client_config.name in lsp_project_settings:
+        overrides = lsp_project_settings[client_config.name]
+        debug('window has override for {}'.format(client_config.name), overrides)
         client_settings = _merge_dicts(client_config.settings, overrides.get("settings", {}))
         client_env = _merge_dicts(client_config.env, overrides.get("env", {}))
         return ClientConfig(

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -122,9 +122,9 @@ class WindowConfigManager(object):
     def scope_configs(self, view: 'Any', point: 'Optional[int]' = None) -> 'Iterator[ClientConfig]':
         return get_scope_client_configs(view, self.all, point)
 
-    def syntax_configs(self, view: 'Any') -> 'List[ClientConfig]':
+    def syntax_configs(self, view: 'Any', include_disabled: bool=False) -> 'List[ClientConfig]':
         syntax = view.settings().get("syntax")
-        return list(filter(lambda c: config_supports_syntax(c, syntax) and c.enabled, self.all))
+        return list(filter(lambda c: config_supports_syntax(c, syntax) and (c.enabled or include_disabled), self.all))
 
     def syntax_supported(self, view: ViewLike) -> bool:
         syntax = view.settings().get("syntax")

--- a/plugin/core/test_configurations.py
+++ b/plugin/core/test_configurations.py
@@ -52,13 +52,13 @@ class WindowConfigManagerTests(unittest.TestCase):
 
     def test_no_configs(self):
         view = MockView(__file__)
-        manager = WindowConfigManager([])
+        manager = WindowConfigManager(MockWindow(), [])
         self.assertFalse(manager.is_supported(view))
         self.assertFalse(manager.syntax_supported(view))
 
     def test_with_single_config(self):
         view = MockView(__file__)
-        manager = WindowConfigManager([TEST_CONFIG])
+        manager = WindowConfigManager(MockWindow(), [TEST_CONFIG])
         self.assertTrue(manager.is_supported(view))
         self.assertEqual(list(manager.scope_configs(view)), [TEST_CONFIG])
         self.assertTrue(manager.syntax_supported(view))

--- a/plugin/core/test_mocks.py
+++ b/plugin/core/test_mocks.py
@@ -220,10 +220,16 @@ class MockConfigs(object):
         else:
             return {}
 
-    def update(self, configs: 'List[ClientConfig]') -> None:
+    def update(self) -> None:
         pass
 
-    def disable(self, config_name: str) -> None:
+    def enable_config(self, config_name: str) -> None:
+        pass
+
+    def disable_config(self, config_name: str) -> None:
+        pass
+
+    def disable_temporarily(self, config_name: str) -> None:
         pass
 
 

--- a/plugin/core/test_mocks.py
+++ b/plugin/core/test_mocks.py
@@ -203,7 +203,7 @@ class MockConfigs(object):
         else:
             return [TEST_CONFIG]
 
-    def syntax_configs(self, view):
+    def syntax_configs(self, view, include_disabled: bool=False):
         if view.settings().get("syntax") == "Plain Text":
             return [TEST_CONFIG]
         else:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -183,10 +183,10 @@ class ConfigRegistry(Protocol):
     def syntax_config_languages(self, view: ViewLike) -> 'Dict[str, LanguageConfig]':
         ...
 
-    def update(self, configs: 'List[ClientConfig]') -> None:
+    def update(self) -> None:
         ...
 
-    def disable(self, config_name: str) -> None:
+    def disable_temporarily(self, config_name: str) -> None:
         ...
 
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -174,7 +174,7 @@ class ConfigRegistry(Protocol):
     def scope_configs(self, view: ViewLike, point: 'Optional[int]' = None) -> 'Iterator[ClientConfig]':
         ...
 
-    def syntax_configs(self, view: ViewLike) -> 'List[ClientConfig]':
+    def syntax_configs(self, view: ViewLike, include_disabled: bool=False) -> 'List[ClientConfig]':
         ...
 
     def syntax_supported(self, view: ViewLike) -> bool:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -35,7 +35,7 @@ def inject_session(wm, config, client):
 
     session = Session(config, "", client)
     # session.state = ClientStates.READY
-    wm.update_configs(client_configs.all)
+    wm.update_configs()
     wm._sessions[config.name] = session
     wm._handle_post_initialize(session)
 


### PR DESCRIPTION
This PR tries to improve the logic and implementation details around config management:
- [x] Poor encapsulation of window configuration (`apply_window_settings` should be done by the WindowConfigManager itself) 
- [x] Do we still want windows to hold global instances of client configs (with risk that they get mutated?)
- [x] DRY some of the enable/disable command logic
- [x] Make sure project settings are applied to a window's client configs when quick switching (issue #792)

Not investigated:
* ClientConfig.enabled can be in (absent, True, False) for global and project settings: This means 9 combinations. Which ones make sense and which ones do we want to avoid?

