### PR TITLE
Expand variables on initializationOptions

### DIFF
--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -47,14 +47,15 @@ def get_expanding_variables(window: sublime.Window) -> dict:
     return variables
 
 
-def expand_variables_for_dict(window: sublime.Window, dict_: dict) -> dict:
-    for key, value in dict_.items():
+def expand_variables_for_dict(window: sublime.Window,
+                              d: Dict[str, Any]) -> Dict[str, Any]:
+    for key, value in d.items():
         if isinstance(value, dict):
-            dict_[key] = expand_variables_for_dict(window, value)
+            d[key] = expand_variables_for_dict(window, value)
         elif isinstance(value, str):
-            dict_[key] = sublime.expand_variables(value, get_expanding_variables(window))
+            d[key] = sublime.expand_variables(value, get_expanding_variables(window))
 
-    return dict_
+    return d
 
 
 def start_window_config(window: sublime.Window,

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -22,7 +22,7 @@ except ImportError:
 def get_window_env(window: sublime.Window, config: ClientConfig) -> 'Tuple[List[str], Dict[str, str]]':
 
     # Create a dictionary of Sublime Text variables
-    variables = window.extract_variables()
+    variables = get_expanding_variables(window)
 
     # Expand language server command line environment variables
     expanded_args = list(


### PR DESCRIPTION
This PR adds the ability to use some variables in `initializationOptions`.

This PR comes from the following use case. In the settings of `intelephense` server, there are some path-related settings in the `initializationOptions`. The `licenceKey` can be a path of a file containing a license key. I would like to keep it cross-platform and portable so I want it to be in ST's directory (or at least, in user's home directory `~`).

```js
"intelephense": {
    // ...
    "initializationOptions": {
        "clearCache": false,
        "storagePath": "${temp_dir}/intelephense",
        "globalStoragePath": "${temp_dir}/intelephense",
        "licenceKey": "${packages}/User/intelephense-license.txt",
    },
},
``` 