### PR TITLE
ConfigManager listens for  and propagates global client config changes to windows

### DIFF
--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -67,7 +67,6 @@ class LspEnableLanguageServerGloballyCommand(sublime_plugin.WindowCommand):
             # too much work
             client_configs.enable(config_name)
             wm = windows.lookup(self.window)
-            wm.update_configs(create_window_configs(self.window, client_configs.all))
             sublime.set_timeout_async(lambda: wm.start_active_views(), 500)
             self.window.status_message("{} enabled, starting server...".format(config_name))
 
@@ -119,7 +118,6 @@ class LspDisableLanguageServerGloballyCommand(sublime_plugin.WindowCommand):
             config_name = self._items[index][0]
             client_configs.disable(config_name)
             wm = windows.lookup(self.window)
-            wm.update_configs(create_window_configs(self.window, client_configs.all))
             sublime.set_timeout_async(lambda: wm.end_session(config_name), 500)
             self.window.status_message("{} disabled, shutting down server...".format(config_name))
 

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -100,12 +100,22 @@ def syntax_language(config: 'ClientConfig', syntax: str) -> 'Optional[LanguageCo
 
 
 class ConfigManager(object):
+    """Distributes language client configuration between windows"""
 
     def __init__(self, global_configs: 'List[ClientConfig]') -> None:
         self._configs = global_configs
+        self._managers = {}  # type: Dict[int, ConfigRegistry]
 
     def for_window(self, window: 'Any') -> 'ConfigRegistry':
-        return WindowConfigManager(create_window_configs(window, self._configs))
+        window_configs = WindowConfigManager(create_window_configs(window, self._configs))
+        self._managers[window.id()] = window_configs
+        return window_configs
+
+    def update(self) -> None:
+        for window in sublime.windows():
+            if window.id() in self._managers:
+                debug('Pushing global client configs to window', window.id())
+                self._managers[window.id()].update(create_window_configs(window, self._configs))
 
 
 class WindowConfigManager(object):

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -114,7 +114,6 @@ class ConfigManager(object):
     def update(self) -> None:
         for window in sublime.windows():
             if window.id() in self._managers:
-                debug('Pushing global client configs to window', window.id())
                 self._managers[window.id()].update(create_window_configs(window, self._configs))
 
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -100,6 +100,7 @@ def unload_sessions(window):
 
 
 configs = ConfigManager(client_configs.all)
+client_configs.set_listener(configs.update)
 documents = DocumentHandlerFactory(sublime, settings)
 handlers_dispatcher = LanguageHandlerDispatcher()
 windows = WindowRegistry(configs, documents, start_window_config, sublime, handlers_dispatcher)

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -5,8 +5,8 @@ from .logging import debug
 PLUGIN_NAME = 'LSP'
 
 try:
-    from typing import List, Optional, Dict, Any
-    assert List and Optional and Dict and Any
+    from typing import List, Optional, Dict, Any, Callable
+    assert List and Optional and Dict and Any and Callable
 except ImportError:
     pass
 
@@ -86,6 +86,7 @@ class ClientConfigs(object):
         self._global_settings = dict()  # type: Dict[str, dict]
         self._external_configs = dict()  # type: Dict[str, ClientConfig]
         self.all = []  # type: List[ClientConfig]
+        self._listener = None  # type: Optional[Callable]
 
     def update(self, settings_obj: sublime.Settings):
         self._default_settings = read_dict_setting(settings_obj, "default_clients", {})
@@ -111,6 +112,8 @@ class ClientConfigs(object):
             self.all.append(read_client_config(config_name, merged_settings))
 
         debug('global configs', list('{}={}'.format(c.name, c.enabled) for c in self.all))
+        if self._listener:
+            self._listener()
 
     def _set_enabled(self, config_name: str, is_enabled: bool):
         if _settings_obj:
@@ -124,6 +127,9 @@ class ClientConfigs(object):
 
     def disable(self, config_name: str):
         self._set_enabled(config_name, False)
+
+    def set_listener(self, recipient: 'Callable') -> None:
+        self._listener = recipient
 
 
 _settings_obj = None  # type: Optional[sublime.Settings]


### PR DESCRIPTION
This PR contains only direct fixes where change global client configs would not propagate to windows. #708 will look into more cleanups and improvements

The issues below were caused by all windows sharing values from `client_configs.all` so all windows would pick up changes instantly for free. But when project overrides were in place we would copy the global config, orphaning the copy from global changes.

- [x] verify fix: configs with project overrides get updates from global configs (#477)
- [x] verify fix: enable/disable globally _also_ enables configs in non-active windows
