### PR TITLE
Lookup session by capability

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     pass
 
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.protocol import Request
 from .diagnostics import get_point_diagnostics
 from .core.edit import parse_workspace_edit
@@ -17,9 +17,9 @@ from .core.registry import session_for_view
 from .core.settings import settings
 
 
-def send_code_action_request(view, on_response_recieved: 'Callable'):
-    session = session_for_view(view)
-    if not session or not session.has_capability('codeActionProvider'):
+def send_code_action_request(view, on_response_recieved: 'Callable') -> None:
+    session = session_for_view(view, 'codeActionProvider')
+    if not session:
         # the server doesn't support code actions, just return
         return
 
@@ -129,7 +129,7 @@ class LspCodeActionsCommand(LspTextCommand):
                     self.run_command(maybe_command)
 
     def run_command(self, command) -> None:
-        client = client_for_view(self.view)
+        client = self.client_with_capability('codeActionProvider')
         if client:
             client.send_request(
                 Request.executeCommand(command),

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from .core.protocol import Request
 from .core.url import filename_to_uri
-from .core.registry import session_for_view, config_for_scope
+from .core.registry import session_for_view, sessions_for_view, client_from_session, configs_for_scope
 from .core.settings import settings, client_configs
 from .core.views import range_to_region
 from .core.protocol import Range
@@ -37,15 +37,15 @@ class LspColorListener(sublime_plugin.ViewEventListener):
             self.initialize()
 
     def initialize(self, is_retry=False):
-        config = config_for_scope(self.view)
-        if not config:
+        configs = configs_for_scope(self.view)
+        if not configs:
             self.initialized = True  # no server enabled, re-open file to activate feature.
 
-        session = session_for_view(self.view)
-        if session:
+        sessions = sessions_for_view(self.view)
+        if sessions:
             self.initialized = True
-            self.enabled = session.has_capability('colorProvider')
-            if self.enabled:
+            if next((session for session in sessions if session.has_capability('colorProvider')), None):
+                self.enabled = True
                 self.send_color_request()
         elif not is_retry:
             # session may be starting, try again once in a second.
@@ -75,19 +75,17 @@ class LspColorListener(sublime_plugin.ViewEventListener):
         if is_transient_view(self.view):
             return
 
-        session = session_for_view(self.view)
-        if not session:
-            return
-
-        params = {
-            "textDocument": {
-                "uri": filename_to_uri(self.view.file_name())
+        client = client_from_session(session_for_view(self.view, 'colorProvider'))
+        if client:
+            params = {
+                "textDocument": {
+                    "uri": filename_to_uri(self.view.file_name())
+                }
             }
-        }
-        session.client.send_request(
-            Request.documentColor(params),
-            self.handle_response
-        )
+            client.send_request(
+                Request.documentColor(params),
+                self.handle_response
+            )
 
     def handle_response(self, response) -> None:
         phantoms = []

--- a/plugin/color.py
+++ b/plugin/color.py
@@ -40,11 +40,10 @@ class LspColorListener(sublime_plugin.ViewEventListener):
         configs = configs_for_scope(self.view)
         if not configs:
             self.initialized = True  # no server enabled, re-open file to activate feature.
-
-        sessions = sessions_for_view(self.view)
+        sessions = list(sessions_for_view(self.view))
         if sessions:
             self.initialized = True
-            if next((session for session in sessions if session.has_capability('colorProvider')), None):
+            if any(session.has_capability('colorProvider') for session in sessions):
                 self.enabled = True
                 self.send_color_request()
         elif not is_retry:

--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -8,7 +8,7 @@ from .core.configurations import (
     create_window_configs,
     get_global_client_config
 )
-from .core.registry import config_for_scope, windows
+from .core.registry import configs_for_scope, windows
 from .core.events import global_events
 from .core.workspace import enable_in_project, disable_in_project
 
@@ -19,8 +19,9 @@ except ImportError:
     pass
 
 
+# todo: delete this feature
 def detect_supportable_view(view: sublime.View):
-    config = config_for_scope(view)
+    config = configs_for_scope(view)
     if not config:
         available_config = get_global_client_config(view, client_configs.all)
         if available_config:

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -48,9 +48,10 @@ def get_scope_client_configs(view: 'sublime.View', configs: 'List[ClientConfig]'
                             score = view.score_selector(point, scope)
                         if score > 0:
                             scope_configs.append((config, score))
-                            debug('scope {} score {}'.format(scope, score))
+                            # debug('scope {} score {}'.format(scope, score))
 
-    return map(lambda pair: pair[0], sorted(scope_configs, key=lambda config_score: config_score[1], reverse=True))
+    return (config_score[0] for config_score in sorted(
+        scope_configs, key=lambda config_score: config_score[1], reverse=True))
 
 
 def get_global_client_config(view: 'sublime.View', global_configs: 'List[ClientConfig]') -> 'Optional[ClientConfig]':

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -43,11 +43,12 @@ def get_scope_client_configs(view: 'sublime.View', configs: 'List[ClientConfig]'
             if languages is None or config.name in languages:
                 for language in config.languages:
                     for scope in language.scopes:
-                        score = None
+                        score = 0
                         if point is not None:
                             score = view.score_selector(point, scope)
-                        scope_configs.append((config, score))
-                        debug('scope {} score {}'.format(scope, score))
+                        if score > 0:
+                            scope_configs.append((config, score))
+                            debug('scope {} score {}'.format(scope, score))
 
     return map(lambda pair: pair[0], sorted(scope_configs, key=lambda config_score: config_score[1], reverse=True))
 

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -11,9 +11,9 @@ assert ClientConfig
 
 try:
     import sublime
-    from typing import Any, List, Dict, Tuple, Callable, Optional
+    from typing import Any, List, Dict, Tuple, Callable, Optional, Iterator
     assert sublime
-    assert Any and List and Dict and Tuple and Callable and Optional
+    assert Any and List and Dict and Tuple and Callable and Optional and Iterator
     assert ViewLike and WindowLike and ConfigRegistry and LanguageConfig
 except ImportError:
     pass
@@ -21,33 +21,35 @@ except ImportError:
 
 def get_scope_client_config(view: 'sublime.View', configs: 'List[ClientConfig]',
                             point: 'Optional[int]' = None) -> 'Optional[ClientConfig]':
+    return next(get_scope_client_configs(view, configs, point), None)
+
+
+def get_scope_client_configs(view: 'sublime.View', configs: 'List[ClientConfig]',
+                             point: 'Optional[int]' = None) -> 'Iterator[ClientConfig]':
     # When there are multiple server configurations, all of which are for
     # similar scopes (e.g. 'source.json', 'source.json.sublime.settings') the
     # configuration with the most specific scope (highest ranked selector)
     # in the current position is preferred.
-    scope_score = 0
-    scope_client_config = None
     if point is None:
         sel = view.sel()
         if len(sel) > 0:
             point = sel[0].begin()
 
     languages = view.settings().get('lsp_language', None)
+    scope_configs = []  # type: List[Tuple[ClientConfig, Optional[int]]]
 
     for config in configs:
         if config.enabled:
             if languages is None or config.name in languages:
                 for language in config.languages:
                     for scope in language.scopes:
+                        score = None
                         if point is not None:
                             score = view.score_selector(point, scope)
-                            # if score > 0:
-                            #     debug('scope match score', scope, config.name, score)
-                            if score > scope_score:
-                                scope_score = score
-                                scope_client_config = config
-    # debug('chose ', scope_client_config.name if scope_client_config else None)
-    return scope_client_config
+                        scope_configs.append((config, score))
+                        debug('scope {} score {}'.format(scope, score))
+
+    return map(lambda pair: pair[0], sorted(scope_configs, key=lambda config_score: config_score[1], reverse=True))
 
 
 def get_global_client_config(view: 'sublime.View', global_configs: 'List[ClientConfig]') -> 'Optional[ClientConfig]':
@@ -122,10 +124,10 @@ class WindowConfigManager(object):
         self.all = configs
 
     def is_supported(self, view: 'Any') -> bool:
-        return self.scope_config(view) is not None
+        return any(self.scope_configs(view))
 
-    def scope_config(self, view: 'Any', point=None) -> 'Optional[ClientConfig]':
-        return get_scope_client_config(view, self.all, point)
+    def scope_configs(self, view: 'Any', point=None) -> 'Iterator[ClientConfig]':
+        return get_scope_client_configs(view, self.all, point)
 
     def syntax_configs(self, view: 'Any') -> 'List[ClientConfig]':
         syntax = view.settings().get("syntax")

--- a/plugin/core/test_configurations.py
+++ b/plugin/core/test_configurations.py
@@ -55,7 +55,7 @@ class WindowConfigManagerTests(unittest.TestCase):
         view = MockView(__file__)
         manager = WindowConfigManager([test_config])
         self.assertTrue(manager.is_supported(view))
-        self.assertEqual(manager.scope_config(view), test_config)
+        self.assertEqual(list(manager.scope_configs(view)), [test_config])
         self.assertTrue(manager.syntax_supported(view))
         self.assertEqual(manager.syntax_configs(view), [test_config])
         lang_configs = manager.syntax_config_languages(view)

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -163,13 +163,13 @@ class MockConfigs(object):
         self.all = [test_config]
 
     def is_supported(self, view):
-        return self.scope_config(view) is not None
+        return any(self.scope_configs(view))
 
-    def scope_config(self, view, point=None):
+    def scope_configs(self, view, point=None):
         if view.file_name() is None:
-            return None
+            return [None]
         else:
-            return test_config
+            return [test_config]
 
     def syntax_configs(self, view):
         if view.settings().get("syntax") == "Plain Text":

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -11,9 +11,9 @@ from .rpc import Client
 import threading
 try:
     from typing_extensions import Protocol
-    from typing import Optional, List, Callable, Dict, Any
+    from typing import Optional, List, Callable, Dict, Any, Iterator
     from types import ModuleType
-    assert Optional and List and Callable and Dict and Session and Any and ModuleType
+    assert Optional and List and Callable and Dict and Session and Any and ModuleType and Iterator
     assert LanguageConfig
 except ImportError:
     pass
@@ -27,7 +27,7 @@ class ConfigRegistry(Protocol):
     def is_supported(self, view: ViewLike) -> bool:
         ...
 
-    def scope_config(self, view: ViewLike, point: 'Optional[int]' = None) -> 'Optional[ClientConfig]':
+    def scope_configs(self, view: ViewLike, point: 'Optional[int]' = None) -> 'Iterator[ClientConfig]':
         ...
 
     def syntax_configs(self, view: ViewLike) -> 'List[ClientConfig]':

--- a/plugin/execute_command.py
+++ b/plugin/execute_command.py
@@ -1,5 +1,5 @@
 import sublime
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.protocol import Request
 from .core.rpc import Client
 
@@ -15,7 +15,7 @@ class LspExecuteCommand(LspTextCommand):
         super().__init__(view)
 
     def run(self, edit, command_name=None, command_args=None) -> None:
-        client = client_for_view(self.view)
+        client = self.client_with_capability('executeCommandProvider')
         if client and command_name:
             self.view.window().status_message("Running command {}".format(command_name))
             self._send_command(client, command_name, command_args)

--- a/plugin/formatting.py
+++ b/plugin/formatting.py
@@ -1,6 +1,6 @@
 from .core.protocol import Request
 from .core.edit import parse_text_edit
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.types import ViewLike
 from .core.url import filename_to_uri
 from .core.views import region_to_range
@@ -32,7 +32,7 @@ class LspFormatDocumentCommand(LspTextCommand):
         return self.has_client_with_capability('documentFormattingProvider')
 
     def run(self, edit):
-        client = client_for_view(self.view)
+        client = self.client_with_capability('documentFormattingProvider')
         if client:
             params = {
                 "textDocument": {
@@ -57,8 +57,8 @@ class LspFormatDocumentRangeCommand(LspTextCommand):
                     return True
         return False
 
-    def run(self, _):
-        client = client_for_view(self.view)
+    def run(self, _) -> None:
+        client = self.client_with_capability('documentRangeFormattingProvider')
         if client:
             region = self.view.sel()[0]
             params = {

--- a/plugin/goto.py
+++ b/plugin/goto.py
@@ -1,6 +1,6 @@
 import sublime
 
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.protocol import Request, Point
 from .core.documents import get_document_position, get_position, is_at_word
 from .core.url import uri_to_filename
@@ -27,7 +27,7 @@ class LspGotoCommand(LspTextCommand):
         return False
 
     def run(self, _, event=None) -> None:
-        client = client_for_view(self.view)
+        client = self.client_with_capability(self.goto_kind + "Provider")
         if client:
             pos = get_position(self.view, event)
             document_position = get_document_position(self.view, pos)

--- a/plugin/highlights.py
+++ b/plugin/highlights.py
@@ -3,7 +3,7 @@ import sublime_plugin
 
 from .core.configurations import is_supported_syntax
 from .core.protocol import Request, Range, DocumentHighlightKind
-from .core.registry import session_for_view, client_for_view
+from .core.registry import session_for_view, client_from_session
 from .core.documents import get_document_position
 from .core.settings import settings, client_configs
 from .core.views import range_to_region
@@ -53,9 +53,9 @@ class DocumentHighlightListener(sublime_plugin.ViewEventListener):
 
     def _initialize(self) -> None:
         self._initialized = True
-        session = session_for_view(self.view)
+        session = session_for_view(self.view, "documentHighlightProvider")
         if session:
-            self._enabled = session.get_capability("documentHighlightProvider")
+            self._enabled = True
 
     def _queue(self) -> None:
         current_point = self.view.sel()[0].begin()
@@ -81,7 +81,7 @@ class DocumentHighlightListener(sublime_plugin.ViewEventListener):
         if word_at_sel & SUBLIME_WORD_MASK:
             if self.view.match_selector(point, NO_HIGHLIGHT_SCOPES):
                 return
-            client = client_for_view(self.view)
+            client = client_from_session(session_for_view(self.view, "documentHighlightProvider"))
             if client:
                 params = get_document_position(self.view, point)
                 if params:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -84,15 +84,16 @@ class LspHoverCommand(LspTextCommand):
             self.show_hover(point, self.diagnostics_content(point_diagnostics))
 
     def request_symbol_hover(self, point) -> None:
-        session = session_for_view(self.view, point)
+        # todo: session_for_view looks up windowmanager twice (config and for sessions)
+        # can we memoize some part (eg. where no point is provided?)
+        session = session_for_view(self.view, 'hoverProvider', point)
         if session:
-            if session.has_capability('hoverProvider'):
-                document_position = get_document_position(self.view, point)
-                if document_position:
-                    if session.client:
-                        session.client.send_request(
-                            Request.hover(document_position),
-                            lambda response: self.handle_response(response, point))
+            document_position = get_document_position(self.view, point)
+            if document_position:
+                if session.client:
+                    session.client.send_request(
+                        Request.hover(document_position),
+                        lambda response: self.handle_response(response, point))
 
     def handle_response(self, response: 'Optional[Any]', point) -> None:
         all_content = ""

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -5,7 +5,7 @@ import linecache
 from .core.documents import is_at_word, get_position, get_document_position
 from .core.panels import ensure_panel
 from .core.protocol import Request, Point
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.settings import PLUGIN_NAME, settings
 from .core.url import uri_to_filename
 from .core.workspace import get_project_path
@@ -33,7 +33,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
         return False
 
     def run(self, edit, event=None):
-        client = client_for_view(self.view)
+        client = self.client_with_capability('referencesProvider')
         if client:
             pos = get_position(self.view, event)
             document_position = get_document_position(self.view, pos)

--- a/plugin/rename.py
+++ b/plugin/rename.py
@@ -1,5 +1,5 @@
 import sublime_plugin
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.protocol import Request
 from .core.edit import parse_workspace_edit
 from .core.documents import get_document_position, get_position, is_at_word
@@ -58,7 +58,7 @@ class LspSymbolRenameCommand(LspTextCommand):
         self.request_rename(params, new_name)
 
     def request_rename(self, params, new_name) -> None:
-        client = client_for_view(self.view)
+        client = self.client_with_capability('renameProvider')
         if client:
             params["newName"] = new_name
             client.send_request(Request.rename(params), self.handle_response)

--- a/plugin/signature_help.py
+++ b/plugin/signature_help.py
@@ -11,7 +11,7 @@ except ImportError:
     pass
 
 from .core.configurations import is_supported_syntax
-from .core.registry import session_for_view, client_for_view
+from .core.registry import session_for_view, client_from_session
 from .core.documents import get_document_position
 from .core.events import global_events
 from .core.protocol import Request
@@ -65,7 +65,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
         return syntax and is_supported_syntax(syntax, client_configs.all)
 
     def initialize(self):
-        session = session_for_view(self.view)
+        session = session_for_view(self.view, 'signatureHelpProvider')
         if session:
             signatureHelpProvider = session.get_capability(
                 'signatureHelpProvider')
@@ -93,7 +93,7 @@ class SignatureHelpListener(sublime_plugin.ViewEventListener):
                     self.view.hide_popup()
 
     def request_signature_help(self, point) -> None:
-        client = client_for_view(self.view)
+        client = client_from_session(session_for_view(self.view, 'signatureHelpProvider', point))
         if client:
             global_events.publish("view.on_purge_changes", self.view)
             document_position = get_document_position(self.view, point)

--- a/plugin/symbols.py
+++ b/plugin/symbols.py
@@ -1,7 +1,7 @@
 from .core.logging import debug
 from .core.protocol import Request, Range
 from .core.protocol import SymbolKind
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.url import filename_to_uri
 from .core.views import range_to_region
 
@@ -63,7 +63,7 @@ class LspDocumentSymbolsCommand(LspTextCommand):
         return self.has_client_with_capability('documentSymbolProvider')
 
     def run(self, edit) -> None:
-        client = client_for_view(self.view)
+        client = self.client_with_capability('documentSymbolProvider')
         if client:
             params = {
                 "textDocument": {

--- a/plugin/workspace_symbol.py
+++ b/plugin/workspace_symbol.py
@@ -1,7 +1,7 @@
 import sublime_plugin
 import sublime
 from .core.protocol import Request
-from .core.registry import client_for_view, LspTextCommand
+from .core.registry import LspTextCommand
 from .core.url import uri_to_filename
 from .symbols import format_symbol_kind
 import os
@@ -63,7 +63,7 @@ class LspWorkspaceSymbolsCommand(LspTextCommand):
     def run(self, edit, symbol_query_input: str = "") -> None:
         if symbol_query_input:
             request = Request.workspaceSymbol({"query": symbol_query_input})
-            client = client_for_view(self.view)
+            client = self.client_with_capability('workspaceSymbolProvider')
             if client:
                 self.view.set_status("lsp_workspace_symbols", "Searching for '{}'...".format(symbol_query_input))
                 client.send_request(request, lambda r: self._handle_response(symbol_query_input, r), self._handle_error)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,3 +1,4 @@
+import os
 import sublime
 from LSP.plugin.completion import CompletionHandler, CompletionState
 from LSP.plugin.core.registry import is_supported_view
@@ -10,6 +11,9 @@ try:
     assert Dict and Optional and List
 except ImportError:
     pass
+
+OPEN_DOCUMENT_DELAY = 100
+AFTER_INSERT_COMPLETION_DELAY = 1000 if os.getenv("TRAVIS") else 100
 
 label_completions = [dict(label='asdf'), dict(label='efgh')]
 completion_with_additional_edits = [
@@ -135,7 +139,7 @@ class InitializationTests(DeferrableTestCase):
 
 class QueryCompletionsTests(TextDocumentTestCase):
     def test_simple_label(self):
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.client.responses['textDocument/completion'] = label_completions
 
         handler = self.get_view_event_listener("on_query_completions")
@@ -164,7 +168,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
                 self.view.substr(sublime.Region(0, self.view.size())), 'asdf')
 
     def test_simple_inserttext(self):
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.client.responses[
             'textDocument/completion'] = insert_text_completions
         handler = self.get_view_event_listener("on_query_completions")
@@ -178,7 +182,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
                 insert_text_completions[0]["insertText"])
 
     def test_var_prefix_using_label(self):
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.view.run_command('append', {'characters': '$'})
         self.view.run_command('move_to', {'to': 'eol'})
         self.client.responses[
@@ -198,7 +202,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         Powershell: label='true', insertText='$true' (see https://github.com/tomv564/LSP/issues/294)
 
         """
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.view.run_command('append', {'characters': '$'})
         self.view.run_command('move_to', {'to': 'eol'})
         self.client.responses[
@@ -218,7 +222,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         PHP language server: label='$someParam', textEdit='someParam' (https://github.com/tomv564/LSP/issues/368)
 
         """
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.view.run_command('append', {'characters': '$'})
         self.view.run_command('move_to', {'to': 'eol'})
         self.client.responses[
@@ -238,7 +242,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         Clangd: label=" const", insertText="const" (https://github.com/tomv564/LSP/issues/368)
 
         """
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.client.responses['textDocument/completion'] = space_added_in_label
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)
@@ -255,7 +259,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         Powershell: label="UniqueId", insertText="-UniqueId" (https://github.com/tomv564/LSP/issues/572)
 
         """
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.view.run_command('append', {'characters': '-'})
         self.view.run_command('move_to', {'to': 'eol'})
 
@@ -277,7 +281,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         Metals: label="override def myFunction(): Unit"
 
         """
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.view.run_command('append', {'characters': '  def myF'})
         self.view.run_command('move_to', {'to': 'eol'})
 
@@ -290,7 +294,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
             # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('insert_best_completion', {})
             self.view.run_command("insert_best_completion", {})
-            yield 100
+            yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
                 '  override def myFunction(): Unit = ???')
@@ -302,7 +306,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         See https://github.com/tomv564/LSP/issues/645
 
         """
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.view.run_command('append', {'characters': 'List.'})
         self.view.run_command('move_to', {'to': 'eol'})
 
@@ -315,13 +319,13 @@ class QueryCompletionsTests(TextDocumentTestCase):
             # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('insert_best_completion', {})
             self.view.run_command("insert_best_completion", {})
-            yield 100
+            yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
                 'List.apply()')
 
     def test_additional_edits(self):
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.client.responses[
             'textDocument/completion'] = completion_with_additional_edits
         handler = self.get_view_event_listener("on_query_completions")
@@ -332,13 +336,13 @@ class QueryCompletionsTests(TextDocumentTestCase):
             # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('insert_best_completion', {})
             self.view.run_command("insert_best_completion", {})
-            yield 100
+            yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
                 'import asdf;\nasdf')
 
     def test_resolve_for_additional_edits(self):
-        yield 100
+        yield OPEN_DOCUMENT_DELAY
         self.client.responses['textDocument/completion'] = label_completions
         self.client.responses[
             'completionItem/resolve'] = completion_with_additional_edits[0]
@@ -355,7 +359,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
             # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('insert_best_completion', {})
             self.view.run_command("insert_best_completion", {})
-            yield 100
+            yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
                 'import asdf;\nasdf')

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,5 +1,6 @@
 import sublime
 from LSP.plugin.completion import CompletionHandler, CompletionState
+from LSP.plugin.core.registry import is_supported_view
 from unittesting import DeferrableTestCase
 from setup import (SUPPORTED_SYNTAX, text_config, add_config, remove_config,
                    TextDocumentTestCase)
@@ -114,6 +115,7 @@ class InitializationTests(DeferrableTestCase):
             CompletionHandler.is_applicable(dict(syntax=SUPPORTED_SYNTAX)))
 
     def test_not_enabled(self):
+        self.assertTrue(is_supported_view(self.view))
         handler = CompletionHandler(self.view)
         self.assertFalse(handler.initialized)
         self.assertFalse(handler.enabled)


### PR DESCRIPTION
Fixes #562 where view and command-based LSP code only looks at scope to find the most suitable session. 
In a case where two servers run for the same scope (eg. typescript and eslint server on `source.js`), LSP would pick the first session, instead of checking which server provides the relevant capability.

Implementation details:
* Forced all lookups to consider multiple servers by changing `scope_config` -> `scope_configs`
* `session_for_view` and `LspTextCommand.client_with_capability` take capability parameter.
* Use iterators to save some effort of calculating 2nd, 3rd matching session if only the first session is needed.
* Attempt to fix some timings on completion tests on travis.
