### PR TITLE
Simplify projectless sessions

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -451,6 +451,9 @@ class WindowManager(object):
                 self._projectless_root_path = get_active_view_path(self._window)
         return self._project_path or self._projectless_root_path
 
+    def get_project_path(self) -> 'Optional[str]':
+        return self._project_path or self._projectless_root_path
+
     def _end_old_sessions(self):
         current_project_path = get_project_path(self._window)
         if current_project_path != self._project_path:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -6,7 +6,7 @@ from .protocol import Notification, Response
 from .edit import parse_workspace_edit
 from .sessions import Session
 from .url import filename_to_uri
-from .workspace import get_project_path
+from .workspace import get_project_path, get_active_view_path
 from .rpc import Client
 import threading
 try:
@@ -324,6 +324,7 @@ class WindowManager(object):
         self._handlers = handler_dispatcher
         self._restarting = False
         self._project_path = get_project_path(self._window)
+        self._projectless_root_path = None  # type: Optional[str]
         self._diagnostics.set_on_updated(
             lambda file_path, client_name:
                 global_events.publish("document.diagnostics",
@@ -375,7 +376,8 @@ class WindowManager(object):
                 self._start_client(config)
 
     def _start_client(self, config: ClientConfig):
-        project_path = get_project_path(self._window)
+        project_path = self._ensure_project_path()
+
         if project_path is None:
             debug('Cannot start without a project folder')
             return
@@ -440,6 +442,14 @@ class WindowManager(object):
         if config_name in self._sessions:
             debug("unloading session", config_name)
             self._sessions[config_name].end()
+
+    def _ensure_project_path(self) -> 'Optional[str]':
+        if self._project_path is None:
+            self._project_path = get_project_path(self._window)
+            if self._project_path is None and self._projectless_root_path is None:
+                # the projectless fallback will only be set once per window.
+                self._projectless_root_path = get_active_view_path(self._window)
+        return self._project_path or self._projectless_root_path
 
     def _end_old_sessions(self):
         current_project_path = get_project_path(self._window)

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -23,20 +23,19 @@ def get_active_view_path(window: 'Any') -> 'Optional[str]':
     """
     Returns the path containing the active view, if any.
     """
+    debug("couldn't determine project directory since no folders are open!")
     view = window.active_view()
     if view:
         filename = view.file_name()
         if filename and os.path.exists(filename):  # https://github.com/tomv564/LSP/issues/644
             project_path = os.path.dirname(filename)
-            debug("Couldn't determine project directory since no folders are open!",
-                  "Using", project_path, "as a fallback.")
+            debug("using", project_path, "as a fallback.")
             return project_path
         else:
-            debug("Couldn't determine project directory since no folders are open",
-                  "and the current file isn't saved on the disk.")
+            debug("no fallback path possible because the current file isn't saved to disk.")
             return None
     else:
-        debug("No view is active in current window")
+        debug("no view is active in current window")
         return None  # https://github.com/tomv564/LSP/issues/219
 
 

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -11,27 +11,33 @@ from .logging import debug
 
 def get_project_path(window: 'Any') -> 'Optional[str]':
     """
-    Returns the first project folder or the parent folder of the active view
+    Returns the first project folder
     """
     if len(window.folders()):
         folder_paths = window.folders()
         return folder_paths[0]
-    else:
-        view = window.active_view()
-        if view:
-            filename = view.file_name()
-            if filename and os.path.exists(filename):  # https://github.com/tomv564/LSP/issues/644
-                project_path = os.path.dirname(filename)
-                debug("Couldn't determine project directory since no folders are open!",
-                      "Using", project_path, "as a fallback.")
-                return project_path
-            else:
-                debug("Couldn't determine project directory since no folders are open",
-                      "and the current file isn't saved on the disk.")
-                return None
+    return None
+
+
+def get_active_view_path(window: 'Any') -> 'Optional[str]':
+    """
+    Returns the path containing the active view, if any.
+    """
+    view = window.active_view()
+    if view:
+        filename = view.file_name()
+        if filename and os.path.exists(filename):  # https://github.com/tomv564/LSP/issues/644
+            project_path = os.path.dirname(filename)
+            debug("Couldn't determine project directory since no folders are open!",
+                  "Using", project_path, "as a fallback.")
+            return project_path
         else:
-            debug("No view is active in current window")
-            return None  # https://github.com/tomv564/LSP/issues/219
+            debug("Couldn't determine project directory since no folders are open",
+                  "and the current file isn't saved on the disk.")
+            return None
+    else:
+        debug("No view is active in current window")
+        return None  # https://github.com/tomv564/LSP/issues/219
 
 
 def get_common_parent(paths: 'List[str]') -> str:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -39,25 +39,6 @@ def get_active_view_path(window: 'Any') -> 'Optional[str]':
         return None  # https://github.com/tomv564/LSP/issues/219
 
 
-def get_common_parent(paths: 'List[str]') -> str:
-    """
-    Get the common parent directory of multiple paths.
-
-    Python 3.5+ includes os.path.commonpath which does this, however Sublime
-    currently embeds Python 3.3.
-    """
-    return os.path.commonprefix([path + '/' for path in paths]).rstrip('/')
-
-
-def is_in_workspace(window: 'Any', file_path: str) -> bool:
-    workspace_path = get_project_path(window)
-    if workspace_path is None:
-        return False
-
-    common_dir = get_common_parent([workspace_path, file_path])
-    return workspace_path == common_dir
-
-
 def enable_in_project(window, config_name: str) -> None:
     project_data = window.project_data()
     if isinstance(project_data, dict):

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -19,7 +19,6 @@ from .core.panels import ensure_panel
 from .core.protocol import Diagnostic, DiagnosticSeverity
 from .core.settings import settings, PLUGIN_NAME, client_configs
 from .core.views import range_to_region
-from .core.workspace import get_project_path
 from .core.registry import windows
 
 
@@ -309,7 +308,7 @@ def update_diagnostics_panel(window: sublime.Window):
         debug('ignoring update to closed window')
         return
 
-    base_dir = get_project_path(window)
+    base_dir = windows.lookup(window).get_project_path()
 
     diagnostics_by_file = get_window_diagnostics(window)
     if diagnostics_by_file is not None:

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -5,10 +5,9 @@ import linecache
 from .core.documents import is_at_word, get_position, get_document_position
 from .core.panels import ensure_panel
 from .core.protocol import Request, Point
-from .core.registry import LspTextCommand
+from .core.registry import LspTextCommand, windows
 from .core.settings import PLUGIN_NAME, settings
 from .core.url import uri_to_filename
-from .core.workspace import get_project_path
 
 try:
     from typing import List, Dict, Optional
@@ -61,7 +60,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
         word_region = self.view.word(pos)
         word = self.view.substr(word_region)
 
-        base_dir = get_project_path(window)
+        base_dir = windows.lookup(window).get_project_path()
         formatted_references = self._get_formatted_references(response, base_dir)
 
         if settings.show_references_in_quick_panel:


### PR DESCRIPTION
As logs in #668 show, when running sublime without a project, sessions get restarted every time you open a file from a different folder. 

The "switch project" detection logic was firing accidentally when switching files. The solution effectively disables this logic by not setting `_project_path` - instead a separate `_projectless_root_path` member is used.

`_projectless_root_path` will only be set once per window.