### PR TITLE
Use log_server setting

### DIFF
--- a/plugin/core/logging.py
+++ b/plugin/core/logging.py
@@ -2,6 +2,7 @@ import traceback
 
 log_debug = False
 log_exceptions = True
+log_server = True
 
 
 def set_debug_logging(logging_enabled: bool) -> None:
@@ -12,6 +13,11 @@ def set_debug_logging(logging_enabled: bool) -> None:
 def set_exception_logging(logging_enabled: bool) -> None:
     global log_exceptions
     log_exceptions = logging_enabled
+
+
+def set_server_logging(logging_enabled: bool) -> None:
+    global log_server
+    log_server = logging_enabled
 
 
 def debug(*args):
@@ -28,7 +34,8 @@ def exception_log(message: str, ex) -> None:
 
 
 def server_log(server_name, *args) -> None:
-    printf(*args, prefix=server_name)
+    if log_server:
+        printf(*args, prefix=server_name)
 
 
 def printf(*args, prefix='LSP'):

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -12,7 +12,7 @@ import sublime
 from .settings import (
     settings, load_settings, unload_settings
 )
-from .logging import set_debug_logging
+from .logging import set_debug_logging, set_server_logging
 from .events import global_events
 from .registry import windows, load_handlers, unload_sessions
 from .panels import destroy_output_panels
@@ -21,6 +21,7 @@ from .panels import destroy_output_panels
 def startup():
     load_settings()
     set_debug_logging(settings.log_debug)
+    set_server_logging(settings.log_server)
     load_handlers()
     global_events.subscribe("view.on_load_async", on_view_activated)
     global_events.subscribe("view.on_activated_async", on_view_activated)


### PR DESCRIPTION
The use of the `log_server` setting seems to have been removed at some point. This reintroduces it it again.

Just out of curiosity, would it not be possible to import `settings.settings` in logging.py and read the various log settings directly instead of setting it from main?