### PR TITLE
Use sublime's auto_complete_selector setting for filtering completions

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -18,8 +18,6 @@ from .core.documents import get_document_position, is_at_word
 from .core.sessions import Session
 from .core.edit import parse_text_edit
 
-NO_COMPLETION_SCOPES = 'comment, string'
-
 
 class CompletionState(object):
     IDLE = 0
@@ -52,6 +50,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
         self.initialized = False
         self.enabled = False
         self.trigger_chars = []  # type: List[str]
+        self.auto_complete_selector = view.settings().get("auto_complete_selector")
         self.resolve = False
         self.state = CompletionState.IDLE
         self.completions = []  # type: List[Any]
@@ -202,8 +201,7 @@ class CompletionHandler(sublime_plugin.ViewEventListener):
             self.initialize()
 
         if self.enabled:
-            if prefix != "" and self.view.match_selector(locations[0], NO_COMPLETION_SCOPES):
-                # debug('discarding completion because no completion scope with prefix {}'.format(prefix))
+            if not self.view.match_selector(locations[0], self.auto_complete_selector):
                 return (
                     [],
                     0 if not settings.only_show_lsp_completions

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -55,6 +55,7 @@ class TextDocumentTestCase(DeferrableTestCase):
 
     def setUp(self) -> None:
         self.view = sublime.active_window().open_file(test_file_path)
+        self.view.settings().set("auto_complete_selector", "text.plain")
         self.wm = windows.lookup(self.view.window())
         self.client = MockClient(async_response=sublime_delayer(100))
         add_config(text_config)


### PR DESCRIPTION
Sublime has a pretty good scope-based filter for determining if we need completions. 

Switching to this setting:
* Allows the user to change the completion scopes without editing the package source
* Disables completion in comments (no more completion on '.' in comments)
* Allows completion in string literals (at least, works in typescript for me)