### PR TITLE
Pre-request code actions

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -63,6 +63,7 @@ class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)
         self._stored_point = -1
+        self._actions = []  # type: List[Dict]
 
     @classmethod
     def is_applicable(cls, _settings: 'Any') -> bool:
@@ -82,14 +83,14 @@ class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
 
     def fire_request(self, current_point: int) -> None:
         if current_point == self._stored_point:
+            self._actions = []
             request_code_actions(self.view, current_point, self.handle_response)
 
     def handle_response(self, config_name: str, response: 'Any') -> None:
-        if settings.show_code_actions_bulb:
-            if len(response) > 0:
-                self.show_bulb()
-            else:
-                self.hide_bulb()
+        if response:
+            self._actions.extend(response)
+        if len(self._actions) > 0:
+            self.show_bulb()
 
     def show_bulb(self) -> None:
         region = self.view.sel()[0]

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -2,44 +2,61 @@ import sublime_plugin
 import sublime
 
 try:
-    from typing import Any, List, Dict, Callable, Optional
-    assert Any and List and Dict and Callable and Optional
+    from typing import Any, List, Dict, Callable, Optional, Tuple
+    from .core.sessions import Session
+    from .core.protocol import Diagnostic
+    assert Any and List and Dict and Callable and Optional and Session and Tuple and Diagnostic
 except ImportError:
     pass
 
 from .core.registry import LspTextCommand
 from .core.protocol import Request
-from .diagnostics import get_point_diagnostics
+from .diagnostics import point_diagnostics_by_config
 from .core.edit import parse_workspace_edit
 from .core.url import filename_to_uri
 from .core.views import region_to_range
-from .core.registry import session_for_view, client_from_session
+from .core.registry import sessions_for_view, client_from_session
 from .core.settings import settings
 
 
-def send_code_action_request(view: sublime.View, on_response_recieved: 'Callable') -> None:
-    session = session_for_view(view, 'codeActionProvider')
-    if not session:
-        # the server doesn't support code actions, just return
-        return
+def request_code_actions(view: sublime.View, point: int,
+                         actions_handler: 'Callable[[str, Optional[List[Dict]]], None]') -> 'List[str]':
+    diagnostics_by_config = point_diagnostics_by_config(view, point)
+    return request_code_actions_with_diagnostics(view, diagnostics_by_config, point, actions_handler)
 
-    region = view.sel()[0]
-    pos = region.begin()
-    point_diagnostics = get_point_diagnostics(view, pos)
-    file_name = view.file_name()
-    if file_name:
-        params = {
-            "textDocument": {
-                "uri": filename_to_uri(file_name)
-            },
-            "range": region_to_range(view, region).to_lsp(),
-            "context": {
-                "diagnostics": list(diagnostic.to_lsp() for diagnostic in point_diagnostics)
-            }
-        }
-        session.client.send_request(
-            Request.codeAction(params),
-            lambda response: on_response_recieved(response))
+
+def request_code_actions_with_diagnostics(view: sublime.View, diagnostics_by_config: 'Dict[str, List[Diagnostic]]',
+                                          point: int, actions_handler: 'Callable[[str, Optional[List[Dict]]], None]'
+                                          ) -> 'List[str]':
+    configs = []  # type: List[str]
+    for session in sessions_for_view(view, point):
+
+        def handle_response(response: 'Optional[List[Dict]]', config_name: str = session.config.name) -> None:
+            actions_handler(config_name, response)
+
+        if session.has_capability('codeActionProvider'):
+            if session.config.name in diagnostics_by_config:
+                point_diagnostics = diagnostics_by_config[session.config.name]
+                file_name = view.file_name()
+                relevant_range = point_diagnostics[0].range if point_diagnostics else region_to_range(
+                    view,
+                    view.sel()[0])
+                if file_name:
+                    configs.append(session.config.name)
+                    params = {
+                        "textDocument": {
+                            "uri": filename_to_uri(file_name)
+                        },
+                        "range": relevant_range.to_lsp(),
+                        "context": {
+                            "diagnostics": list(diagnostic.to_lsp() for diagnostic in point_diagnostics)
+                        }
+                    }
+                    if session.client:
+                        session.client.send_request(
+                            Request.codeAction(params),
+                            handle_response)
+    return configs
 
 
 class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
@@ -65,9 +82,9 @@ class LspCodeActionBulbListener(sublime_plugin.ViewEventListener):
 
     def fire_request(self, current_point: int) -> None:
         if current_point == self._stored_point:
-            send_code_action_request(self.view, self.handle_response)
+            request_code_actions(self.view, current_point, self.handle_response)
 
-    def handle_response(self, response: 'Any') -> None:
+    def handle_response(self, config_name: str, response: 'Any') -> None:
         if settings.show_code_actions_bulb:
             if len(response) > 0:
                 self.show_bulb()
@@ -88,8 +105,9 @@ def is_command(command_or_code_action: dict) -> bool:
     return isinstance(command_field, str)
 
 
-def execute_server_command(view: sublime.View, command: dict) -> None:
-    client = client_from_session(session_for_view(view, 'codeActionProvider'))
+def execute_server_command(view: sublime.View, config_name: str, command: dict) -> None:
+    session = next((session for session in sessions_for_view(view) if session.config.name == config_name), None)
+    client = client_from_session(session)
     if client:
         client.send_request(
             Request.executeCommand(command),
@@ -100,9 +118,9 @@ def handle_command_response(response: 'Any') -> None:
     pass
 
 
-def run_code_action_or_command(view: sublime.View, command_or_code_action: dict) -> None:
+def run_code_action_or_command(view: sublime.View, config_name: str, command_or_code_action: dict) -> None:
     if is_command(command_or_code_action):
-        execute_server_command(view, command_or_code_action)
+        execute_server_command(view, config_name, command_or_code_action)
     else:
         # CodeAction can have an edit and/or command.
         maybe_edit = command_or_code_action.get('edit')
@@ -113,7 +131,7 @@ def run_code_action_or_command(view: sublime.View, command_or_code_action: dict)
                 window.run_command("lsp_apply_workspace_edit", {'changes': changes})
         maybe_command = command_or_code_action.get('command')
         if maybe_command:
-            execute_server_command(view, maybe_command)
+            execute_server_command(view, config_name, maybe_command)
 
 
 class LspCodeActionsCommand(LspTextCommand):
@@ -121,31 +139,31 @@ class LspCodeActionsCommand(LspTextCommand):
         return self.has_client_with_capability('codeActionProvider')
 
     def run(self, edit: 'Any') -> None:
-        self.commands = []  # type: List[Dict]
+        self.commands = []  # type: List[Tuple[str, str, Dict]]
+        self.commands_by_config = {}  # type: Dict[str, List[Dict]]
+        self.requested_server_configs = request_code_actions(self.view,
+                                                             self.view.sel()[0].begin(), self.handle_response)
 
-        send_code_action_request(self.view, self.handle_response)
+    def combine_commands(self) -> 'List[Tuple[str, str, Dict]]':
+        results = []
+        for config, commands in self.commands_by_config.items():
+            for command in commands:
+                results.append((config, command['title'], command))
+        return results
 
-    def get_titles(self) -> 'List[str]':
-        ''' Return a list of all command titles. '''
-        titles = []
-        for command in self.commands:
-            title = command['title']
-            if title:
-                titles.append(title)
-            # TODO parse command and arguments
-        return titles
-
-    def handle_response(self, response: 'Optional[List[Dict]]') -> None:
-        self.commands = response or []
-        self.show_popup_menu()
+    def handle_response(self, config_name: str, response: 'Optional[List[Dict]]') -> None:
+        self.commands_by_config[config_name] = response or []
+        if len(self.requested_server_configs) == len(self.commands_by_config):
+            self.commands = self.combine_commands()
+            self.show_popup_menu()
 
     def show_popup_menu(self) -> None:
         if len(self.commands) > 0:
-            self.view.show_popup_menu(self.get_titles(), self.handle_select)
+            self.view.show_popup_menu([command[1] for command in self.commands], self.handle_select)
         else:
             self.view.show_popup('No actions available', sublime.HIDE_ON_MOUSE_MOVE_AWAY)
 
     def handle_select(self, index: int) -> None:
         if index > -1:
             selected = self.commands[index]
-            run_code_action_or_command(self.view, selected)
+            run_code_action_or_command(self.view, selected[0], selected[2])

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -44,15 +44,8 @@ popup_css = '''
         padding: 0.5rem;
     }
     .lsp_popup .actions {
-        /* font-weight: bold; */
         border-width: 0;
         background-color: color(var(--foreground) alpha(0.1));
-        color: var(--whitish);
         padding: 0.5rem;
     }
-    .lsp_popup .actions a {
-        text-decoration: none;
-        color: var(--foreground);
-    }
-
 '''

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -16,33 +16,43 @@ popup_css = '''
     .lsp_popup li {
         font-family: system;
     }
+    .lsp_popup .diagnostics {
+        margin-bottom: 0.5rem;
+    }
     .lsp_popup .errors {
         border-width: 0;
         background-color: color(var(--redish) alpha(0.25));
         color: var(--whitish);
-        margin-bottom: 0.5rem;
         padding: 0.5rem;
     }
     .lsp_popup .warnings {
         border-width: 0;
         background-color: color(var(--yellowish) alpha(0.25));
         color: var(--whitish);
-        margin-bottom: 0.5rem;
         padding: 0.5rem;
     }
     .lsp_popup .info {
         border-width: 0;
         background-color: color(var(--bluish) alpha(0.25));
         color: var(--whitish);
-        margin-bottom: 0.5rem;
         padding: 0.5rem;
     }
     .lsp_popup .hints {
         border-width: 0;
         background-color: color(var(--bluish) alpha(0.25));
         color: var(--whitish);
-        margin-bottom: 0.5rem;
         padding: 0.5rem;
+    }
+    .lsp_popup .actions {
+        font-weight: bold;
+        border-width: 0;
+        background-color: color(var(--accent) alpha(0.25));
+        color: var(--whitish);
+        padding: 0.5rem;
+    }
+    .lsp_popup .actions a {
+        text-decoration: none;
+        color: var(--whitish);
     }
 
 '''

--- a/plugin/core/popups.py
+++ b/plugin/core/popups.py
@@ -44,15 +44,15 @@ popup_css = '''
         padding: 0.5rem;
     }
     .lsp_popup .actions {
-        font-weight: bold;
+        /* font-weight: bold; */
         border-width: 0;
-        background-color: color(var(--accent) alpha(0.25));
+        background-color: color(var(--foreground) alpha(0.1));
         color: var(--whitish);
         padding: 0.5rem;
     }
     .lsp_popup .actions a {
         text-decoration: none;
-        color: var(--whitish);
+        color: var(--foreground);
     }
 
 '''

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -1,6 +1,6 @@
 try:
-    from typing import Any, List, Dict, Tuple, Callable, Optional, Union
-    assert Any and List and Dict and Tuple and Callable and Optional and Union
+    from typing import Any, List, Dict, Tuple, Callable, Optional, Union, Mapping
+    assert Any and List and Dict and Tuple and Callable and Optional and Union and Mapping
 except ImportError:
     pass
 
@@ -88,7 +88,7 @@ class DocumentHighlightKind(object):
 
 
 class Request:
-    def __init__(self, method: str, params: 'Optional[dict]') -> None:
+    def __init__(self, method: str, params: 'Optional[Mapping[str, Any]]') -> None:
         self.method = method
         self.params = params
         self.jsonrpc = "2.0"
@@ -142,7 +142,7 @@ class Request:
         return Request('textDocument/documentColor', params)
 
     @classmethod
-    def executeCommand(cls, params: dict) -> 'Request':
+    def executeCommand(cls, params: 'Mapping[str, Any]') -> 'Request':
         return Request("workspace/executeCommand", params)
 
     @classmethod

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -154,6 +154,24 @@ def get_point_diagnostics(view: sublime.View, point: int) -> 'List[Diagnostic]':
     ]
 
 
+def point_diagnostics_by_config(view: sublime.View, point: int) -> 'Dict[str, List[Diagnostic]]':
+    diagnostics_by_config = {}
+    if view.window():
+        file_name = view.file_name()
+        if file_name:
+            window_diagnostics = windows.lookup(view.window())._diagnostics.get()
+            file_diagnostics = window_diagnostics.get(file_name, {})
+            for config_name, diagnostics in file_diagnostics.items():
+                point_diagnostics = [
+                    diagnostic for diagnostic in diagnostics
+                    if range_to_region(diagnostic.range, view).contains(point)
+                ]
+                if point_diagnostics:
+                    diagnostics_by_config[config_name] = point_diagnostics
+
+    return diagnostics_by_config
+
+
 def update_diagnostics_regions(view: sublime.View, diagnostics: 'List[Diagnostic]', severity: int) -> None:
     region_name = "lsp_" + format_severity(severity)
     if settings.show_diagnostics_phantoms and not view.is_dirty():

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -154,7 +154,7 @@ class LspHoverCommand(LspTextCommand):
                 action_count = len(self._actions_by_config[config_name])
                 if action_count > 0:
                     formatted.append("<div class=\"actions\"><a href='{}:{}'>{} ({})</a></div>".format(
-                        'code-actions', config_name, ' -> Code Actions', action_count))
+                        'code-actions', config_name, 'Code Actions', action_count))
 
             formatted.append("</div>")
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -134,7 +134,7 @@ class LspHoverCommand(LspTextCommand):
             return "<pre class=\"{}\">[{}] {}</pre>".format(class_for_severity[diagnostic.severity], diagnostic.source,
                                                             diagnostic_message)
         else:
-            return "<pre class=\"{}\">{}</pre>".format(diagnostic_message)
+            return "<pre class=\"{}\">{}</pre>".format(class_for_severity[diagnostic.severity], diagnostic_message)
 
     def diagnostics_content(self) -> str:
         formatted = []
@@ -197,16 +197,17 @@ class LspHoverCommand(LspTextCommand):
         _test_contents.clear()
         _test_contents.append(contents)  # for testing only
 
-        mdpopups.show_popup(
-            self.view,
-            contents,
-            css=popup_css,
-            md=False,
-            flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
-            location=point,
-            wrapper_class=popup_class,
-            max_width=800,
-            on_navigate=lambda href: self.on_hover_navigate(href, point))
+        if contents:
+            mdpopups.show_popup(
+                self.view,
+                contents,
+                css=popup_css,
+                md=False,
+                flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+                location=point,
+                wrapper_class=popup_class,
+                max_width=800,
+                on_navigate=lambda href: self.on_hover_navigate(href, point))
 
     def on_hover_navigate(self, href: str, point: int) -> None:
         for goto_kind in goto_kinds:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -134,7 +134,7 @@ class LspHoverCommand(LspTextCommand):
             return "<pre class=\"{}\">[{}] {}</pre>".format(class_for_severity[diagnostic.severity], diagnostic.source,
                                                             diagnostic_message)
         else:
-            return "<pre>{}</pre>".format(diagnostic_message)
+            return "<pre class=\"{}\">{}</pre>".format(diagnostic_message)
 
     def diagnostics_content(self) -> str:
         formatted = []

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -194,6 +194,8 @@ class LspHoverCommand(LspTextCommand):
 
     def show_hover(self, point: int) -> None:
         contents = self.diagnostics_content() + self.hover_content()
+        if settings.show_symbol_action_links:
+            contents += self.symbol_actions_content()
 
         _test_contents.clear()
         _test_contents.append(contents)  # for testing only

--- a/tests/test_hover.py
+++ b/tests/test_hover.py
@@ -19,7 +19,7 @@ class LspHoverCommandTests(TextDocumentTestCase):
         self.view.run_command('insert', {"characters": ORIGINAL_CONTENT})
         self.view.run_command('lsp_hover', {'point': 3})
 
-        yield 100  # popup should be visible eventually
+        yield 200  # popup should be visible eventually
         self.assertTrue(self.view.is_popup_visible())
 
         last_content = _test_contents[-1]


### PR DESCRIPTION
The Hover popup currently always shows a Code Actions link, even if no code actions are available. This PR aims to query the server, then show information about available code actions in the popup.

This shows an initial implementation, running with a typescript and eslint server.
[
<img width="639" alt="Screenshot 2019-10-01 at 11 30 23" src="https://user-images.githubusercontent.com/4395832/65950717-e99d0d80-e43e-11e9-8bbd-29eaf9b55bfc.png">
](url)

**Two functional issues need to be resolved:**
- [x] The list of code actions is long - change to a "Code Actions (3)" link?
- [x] Only the first codeActionProvider for the document is being queried - we should query all and show a "Code Actions" link for each.
  - (I'm hesitant to get into this, but of all places to combine LSP results, this use case probably makes the most sense)

**UI opinions wanted**

The hover UI is getting messy. Code actions feel like they "belong" to the diagnostics, but there can be many blocks of diagnostics (errors and warnings, per server) so it's unclear where to place the links.

**Technical fixes**
- [x] Potentially cooperating with the bulb logic (so fetched actions can be used at once)