### PR TITLE
Diagnostics rework

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -5,7 +5,8 @@
 
   // Open and close the diagnostics panel automatically,
   // depending on available diagnostics.
-  "auto_show_diagnostics_panel": true,
+  // Valid values are "never", "always" and "saved"
+  "auto_show_diagnostics_panel": "saved",
 
   // Open the diagnostics panel automatically
   // when diagnostics level is equal to or less than:

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -15,9 +15,6 @@
   // hint: 4
   "auto_show_diagnostics_panel_level": 3,
 
-  // Show in-line diagnostics using phantoms for unchanged files.
-  "show_diagnostics_phantoms": false,
-
   // Show errors and warnings count in the status bar
   "show_diagnostics_count_in_view_status": false,
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -79,7 +79,6 @@ Add these settings to your Sublime settings, Syntax-specific settings and/or in 
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
 * `auto_show_diagnostics_panel` `true` *open the diagnostics panel automatically if there are diagnostics*
-* `show_diagnostics_phantoms` `false` *show diagnostics as phantoms while the file has no changes*
 * `show_diagnostics_count_in_view_status` `false` *show errors and warnings count in the status bar*
 * `show_diagnostics_in_view_status` `true` *when on a diagnostic with the cursor, show the text in the status bar*
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics, `"underline"` or `"box"`*

--- a/docs/features.md
+++ b/docs/features.md
@@ -78,7 +78,7 @@ Add these settings to your Sublime settings, Syntax-specific settings and/or in 
 * `quick_panel_monospace_font` `false` *use monospace font for the quick panel*
 * `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
-* `auto_show_diagnostics_panel` `true` *open the diagnostics panel automatically if there are diagnostics*
+* `auto_show_diagnostics_panel` `always` (`never`, `saved`) *open the diagnostics panel automatically if there are diagnostics*
 * `show_diagnostics_count_in_view_status` `false` *show errors and warnings count in the status bar*
 * `show_diagnostics_in_view_status` `true` *when on a diagnostic with the cursor, show the text in the status bar*
 * `diagnostics_highlight_style` `"underline"` *highlight style of code diagnostics, `"underline"` or `"box"`*

--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -19,8 +19,8 @@ except ImportError:
     pass
 
 from .core.registry import LspTextCommand
-from .core.protocol import Request
-from .diagnostics import point_diagnostics_by_config
+from .core.protocol import Request, Point
+from .diagnostics import filter_by_point, view_diagnostics
 from .core.edit import parse_workspace_edit
 from .core.url import filename_to_uri
 from .core.views import region_to_range
@@ -62,7 +62,7 @@ class CodeActionsManager(object):
         else:
             self._requests.clear()
             if diagnostics_by_config is None:
-                diagnostics_by_config = point_diagnostics_by_config(view, point)
+                diagnostics_by_config = filter_by_point(view_diagnostics(view), Point(*view.rowcol(point)))
             self._requests[current_location] = request_code_actions(view, point, actions_handler)
 
     def get_location_key(self, view: sublime.View, point: int) -> str:
@@ -74,7 +74,7 @@ actions_manager = CodeActionsManager()
 
 def request_code_actions(view: sublime.View, point: int,
                          actions_handler: 'Callable[[CodeActionsByConfigName], None]') -> 'CodeActionsAtLocation':
-    diagnostics_by_config = point_diagnostics_by_config(view, point)
+    diagnostics_by_config = filter_by_point(view_diagnostics(view), Point(*view.rowcol(point)))
     return request_code_actions_with_diagnostics(view, diagnostics_by_config, point, actions_handler)
 
 

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -5,32 +5,29 @@ assert Diagnostic
 
 try:
     import sublime
+    from typing_extensions import Protocol
     from typing import Any, List, Dict, Tuple, Callable, Optional
     assert sublime
     assert Any and List and Dict and Tuple and Callable and Optional
 except ImportError:
     pass
+    Protocol = object  # type: ignore
 
 
-class DiagnosticsUpdate(object):
-    def __init__(self, window: 'Any', client_name: str,
-                 file_path: str) -> 'None':
-        self.window = window
-        self.client_name = client_name
-        self.file_path = file_path
+class DiagnosticsUpdateable(Protocol):
+
+    def update(self, file_name: str, config_name: str) -> None:
+        ...
 
 
 class WindowDiagnostics(object):
 
-    def __init__(self) -> None:
+    def __init__(self, updateable: 'DiagnosticsUpdateable') -> None:
         self._diagnostics = {}  # type: Dict[str, Dict[str, List[Diagnostic]]]
-        self._on_updated = None  # type: Optional[Callable]
+        self._updatable = updateable
 
     def get(self) -> 'Dict[str, Dict[str, List[Diagnostic]]]':
         return self._diagnostics
-
-    def set_on_updated(self, update_handler: 'Callable') -> None:
-        self._on_updated = update_handler
 
     def get_by_path(self, file_path: str) -> 'List[Diagnostic]':
         view_diagnostics = []
@@ -57,9 +54,8 @@ class WindowDiagnostics(object):
     def clear(self) -> None:
         for file_path in list(self._diagnostics):
             for client_name in list(self._diagnostics[file_path]):
-                self.update(file_path, client_name, [])
-                if self._on_updated:
-                    self._on_updated(file_path, client_name)
+                if self.update(file_path, client_name, []):
+                    self.publish_update(file_path, client_name)
 
     def handle_client_diagnostics(self, client_name: str, update: dict) -> None:
         maybe_file_uri = update.get('uri')
@@ -70,10 +66,13 @@ class WindowDiagnostics(object):
                 Diagnostic.from_lsp(item) for item in update.get('diagnostics', []))
 
             if self.update(file_path, client_name, diagnostics):
-                if self._on_updated:
-                    self._on_updated(file_path, client_name)
+                self.publish_update(file_path, client_name)
         else:
             debug('missing uri in diagnostics update')
+
+    def publish_update(self, file_path: str, client_name: str) -> None:
+        if self._updatable:
+            self._updatable.update(file_path, client_name)
 
     def remove(self, file_path: str, client_name: str) -> None:
         self.update(file_path, client_name, [])

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -16,7 +16,7 @@ except ImportError:
 
 class DiagnosticsUpdateable(Protocol):
 
-    def update(self, file_name: str, config_name: str) -> None:
+    def update(self, file_name: str, config_name: str, diagnostics: 'Dict[str, Dict[str, List[Diagnostic]]]') -> None:
         ...
 
 
@@ -28,6 +28,9 @@ class DiagnosticsStorage(object):
 
     def get(self) -> 'Dict[str, Dict[str, List[Diagnostic]]]':
         return self._diagnostics
+
+    def get_by_file(self, file_path: str) -> 'Dict[str, List[Diagnostic]]':
+        return self._diagnostics.get(file_path, {})
 
     def update(self, file_path: str, client_name: str, diagnostics: 'List[Diagnostic]') -> bool:
         updated = False
@@ -65,7 +68,7 @@ class DiagnosticsStorage(object):
 
     def notify(self, file_path: str, client_name: str) -> None:
         if self._updatable:
-            self._updatable.update(file_path, client_name)
+            self._updatable.update(file_path, client_name, self._diagnostics)
 
     def remove(self, file_path: str, client_name: str) -> None:
         self.update(file_path, client_name, [])

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -29,13 +29,6 @@ class DiagnosticsStorage(object):
     def get(self) -> 'Dict[str, Dict[str, List[Diagnostic]]]':
         return self._diagnostics
 
-    def get_by_path(self, file_path: str) -> 'List[Diagnostic]':
-        view_diagnostics = []
-        if file_path in self._diagnostics:
-            for origin in self._diagnostics[file_path]:
-                view_diagnostics.extend(self._diagnostics[file_path][origin])
-        return view_diagnostics
-
     def update(self, file_path: str, client_name: str, diagnostics: 'List[Diagnostic]') -> bool:
         updated = False
         if diagnostics:

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -16,12 +16,14 @@ from .logging import set_debug_logging, set_server_logging
 from .events import global_events
 from .registry import windows, load_handlers, unload_sessions
 from .panels import destroy_output_panels
+from ..diagnostics import DiagnosticsUI
 
 
 def startup() -> None:
     load_settings()
     set_debug_logging(settings.log_debug)
     set_server_logging(settings.log_server)
+    windows.set_diagnostics_ui(DiagnosticsUI)
     load_handlers()
     global_events.subscribe("view.on_load_async", on_view_activated)
     global_events.subscribe("view.on_activated_async", on_view_activated)

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -16,14 +16,14 @@ from .logging import set_debug_logging, set_server_logging
 from .events import global_events
 from .registry import windows, load_handlers, unload_sessions
 from .panels import destroy_output_panels
-from ..diagnostics import DiagnosticsUI
+from ..diagnostics import DiagnosticsPresenter
 
 
 def startup() -> None:
     load_settings()
     set_debug_logging(settings.log_debug)
     set_server_logging(settings.log_server)
-    windows.set_diagnostics_ui(DiagnosticsUI)
+    windows.set_diagnostics_ui(DiagnosticsPresenter)
     load_handlers()
     global_events.subscribe("view.on_load_async", on_view_activated)
     global_events.subscribe("view.on_activated_async", on_view_activated)

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -292,6 +292,13 @@ class Range(object):
             'end': self.end.to_lsp()
         }
 
+    def contains(self, point: Point) -> bool:
+        return self.start.row <= point.row <= self.end.row and self.start.col <= point.col <= self.end.col
+
+    def intersects(self, rge: 'Range') -> bool:
+        return rge.start.row <= self.end.row and rge.start.col <= self.end.col and \
+               rge.end.row >= self.start.row and rge.end.col >= self.start.col
+
 
 class ContentChange(object):
     def __init__(self, text: str, range: 'Optional[Range]'=None, range_length: 'Optional[int]'=None) -> None:

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -55,7 +55,6 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.show_view_status = read_bool_setting(settings_obj, "show_view_status", True)
     settings.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", True)
     settings.auto_show_diagnostics_panel_level = read_int_setting(settings_obj, "auto_show_diagnostics_panel_level", 3)
-    settings.show_diagnostics_phantoms = read_bool_setting(settings_obj, "show_diagnostics_phantoms", False)
     settings.show_diagnostics_count_in_view_status = read_bool_setting(settings_obj,
                                                                        "show_diagnostics_count_in_view_status", False)
     settings.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -51,7 +51,7 @@ def read_str_setting(settings_obj: sublime.Settings, key: str, default: str) -> 
         return default
 
 
-def read_auto_show_setting(settings_obj: sublime.Settings, key: str, default: str) -> str:
+def read_auto_show_diagnostics_panel_setting(settings_obj: sublime.Settings, key: str, default: str) -> str:
     val = settings_obj.get(key)
     if isinstance(val, bool):
         return 'always' if val else 'never'
@@ -63,7 +63,9 @@ def read_auto_show_setting(settings_obj: sublime.Settings, key: str, default: st
 
 def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.show_view_status = read_bool_setting(settings_obj, "show_view_status", True)
-    settings.auto_show_diagnostics_panel = read_auto_show_setting(settings_obj, "auto_show_diagnostics_panel", 'always')
+    settings.auto_show_diagnostics_panel = read_auto_show_diagnostics_panel_setting(settings_obj,
+                                                                                    "auto_show_diagnostics_panel",
+                                                                                    'always')
     settings.auto_show_diagnostics_panel_level = read_int_setting(settings_obj, "auto_show_diagnostics_panel_level", 3)
     settings.show_diagnostics_count_in_view_status = read_bool_setting(settings_obj,
                                                                        "show_diagnostics_count_in_view_status", False)

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -51,9 +51,19 @@ def read_str_setting(settings_obj: sublime.Settings, key: str, default: str) -> 
         return default
 
 
+def read_auto_show_setting(settings_obj: sublime.Settings, key: str, default: str) -> str:
+    val = settings_obj.get(key)
+    if isinstance(val, bool):
+        return 'always' if val else 'never'
+    if isinstance(val, str):
+        return val
+    else:
+        return default
+
+
 def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.show_view_status = read_bool_setting(settings_obj, "show_view_status", True)
-    settings.auto_show_diagnostics_panel = read_bool_setting(settings_obj, "auto_show_diagnostics_panel", True)
+    settings.auto_show_diagnostics_panel = read_auto_show_setting(settings_obj, "auto_show_diagnostics_panel", 'always')
     settings.auto_show_diagnostics_panel_level = read_int_setting(settings_obj, "auto_show_diagnostics_panel_level", 3)
     settings.show_diagnostics_count_in_view_status = read_bool_setting(settings_obj,
                                                                        "show_diagnostics_count_in_view_status", False)

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -10,7 +10,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
 
     def test_empty_diagnostics(self):
         wd = DiagnosticsStorage(None)
-        self.assertEqual(wd.get_by_path(__file__), [])
+        self.assertEqual(wd.get_by_file(__file__), {})
 
         # todo: remove
 
@@ -21,12 +21,12 @@ class DiagnosticsStorageTest(unittest.TestCase):
         diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict())
 
         wd.update(test_file_path, "test_server", [diag])
-        view_diags = wd.get_by_path(test_file_path)
-        self.assertEqual(len(view_diags), 1)
-        self.assertEqual(view_diags[0], diag)
+        view_diags = wd.get_by_file(test_file_path)
+        self.assertEqual(len(view_diags["test_server"]), 1)
+        self.assertEqual(view_diags["test_server"][0], diag)
 
         wd.update(test_file_path, "test_server", [])
-        view_diags = wd.get_by_path(test_file_path)
+        view_diags = wd.get_by_file(test_file_path)
         self.assertEqual(len(view_diags), 0)
 
     def test_handle_diagnostics_update(self):
@@ -40,8 +40,8 @@ class DiagnosticsStorageTest(unittest.TestCase):
 
         wd.receive("test_server", update)
 
-        view_diags = wd.get_by_path(test_file_path)
-        self.assertEqual(len(view_diags), 1)
+        view_diags = wd.get_by_file(test_file_path)
+        self.assertEqual(len(view_diags["test_server"]), 1)
 
     def test_remove_diagnostics(self):
         wd = DiagnosticsStorage(None)
@@ -50,10 +50,10 @@ class DiagnosticsStorageTest(unittest.TestCase):
         diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict())
 
         wd.update(test_file_path, "test_server", [diag])
-        view_diags = wd.get_by_path(test_file_path)
-        self.assertEqual(len(view_diags), 1)
+        view_diags = wd.get_by_file(test_file_path)
+        self.assertEqual(len(view_diags["test_server"]), 1)
 
         wd.remove(test_file_path, "test_server")
 
-        view_diags = wd.get_by_path(test_file_path)
+        view_diags = wd.get_by_file(test_file_path)
         self.assertEqual(len(view_diags), 0)

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -1,21 +1,21 @@
 import unittest
-from .diagnostics import WindowDiagnostics
+from .diagnostics import DiagnosticsStorage
 from .protocol import Diagnostic, Range, Point
 # from .configurations import WindowConfigManager, _merge_dicts, ConfigManager, is_supported_syntax
 # from .test_session import test_config, test_language
 from .test_protocol import LSP_MINIMAL_DIAGNOSTIC
 
 
-class WindowDiagnosticsTest(unittest.TestCase):
+class DiagnosticsStorageTest(unittest.TestCase):
 
     def test_empty_diagnostics(self):
-        wd = WindowDiagnostics()
+        wd = DiagnosticsStorage(None)
         self.assertEqual(wd.get_by_path(__file__), [])
 
         # todo: remove
 
     def test_updated_diagnostics(self):
-        wd = WindowDiagnostics()
+        wd = DiagnosticsStorage(None)
 
         test_file_path = "test.py"
         diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict())
@@ -30,7 +30,7 @@ class WindowDiagnosticsTest(unittest.TestCase):
         self.assertEqual(len(view_diags), 0)
 
     def test_handle_diagnostics_update(self):
-        wd = WindowDiagnostics()
+        wd = DiagnosticsStorage(None)
 
         test_file_path = "/test.py"
         update = {
@@ -38,13 +38,13 @@ class WindowDiagnosticsTest(unittest.TestCase):
             'diagnostics': [LSP_MINIMAL_DIAGNOSTIC]
         }
 
-        wd.handle_client_diagnostics("test_server", update)
+        wd.receive("test_server", update)
 
         view_diags = wd.get_by_path(test_file_path)
         self.assertEqual(len(view_diags), 1)
 
     def test_remove_diagnostics(self):
-        wd = WindowDiagnostics()
+        wd = DiagnosticsStorage(None)
 
         test_file_path = "test.py"
         diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict())

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -1,5 +1,5 @@
 from . import test_sublime as test_sublime
-from .diagnostics import WindowDiagnostics
+from .diagnostics import DiagnosticsStorage
 from .events import global_events
 from .sessions import create_session
 from .sessions import Session
@@ -79,7 +79,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_start_active_views(self):
         docs = MockDocuments()
         wm = WindowManager(MockWindow([[MockView(__file__)]]), MockConfigs(), docs,
-                           WindowDiagnostics(), mock_start_session, test_sublime, MockHandlerDispatcher())
+                           DiagnosticsStorage(None), mock_start_session, test_sublime, MockHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -89,7 +89,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_open_supported_view(self):
         docs = MockDocuments()
         window = MockWindow([[]])
-        wm = WindowManager(window, MockConfigs(), docs, WindowDiagnostics(), mock_start_session, test_sublime,
+        wm = WindowManager(window, MockConfigs(), docs, DiagnosticsStorage(None), mock_start_session, test_sublime,
                            MockHandlerDispatcher())
 
         wm.start_active_views()
@@ -106,7 +106,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_can_restart_sessions(self):
         docs = MockDocuments()
         wm = WindowManager(MockWindow([[MockView(__file__)]]), MockConfigs(), docs,
-                           WindowDiagnostics(), mock_start_session, test_sublime, MockHandlerDispatcher())
+                           DiagnosticsStorage(None), mock_start_session, test_sublime, MockHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -128,7 +128,7 @@ class WindowManagerTests(unittest.TestCase):
         docs = MockDocuments()
         test_window = MockWindow([[MockView(__file__)]])
         wm = WindowManager(test_window, MockConfigs(), docs,
-                           WindowDiagnostics(), mock_start_session, test_sublime, MockHandlerDispatcher())
+                           DiagnosticsStorage(None), mock_start_session, test_sublime, MockHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -149,7 +149,7 @@ class WindowManagerTests(unittest.TestCase):
         docs = MockDocuments()
         test_window = MockWindow([[MockView(__file__)]])
         wm = WindowManager(test_window, MockConfigs(), docs,
-                           WindowDiagnostics(), mock_start_session, test_sublime, MockHandlerDispatcher())
+                           DiagnosticsStorage(None), mock_start_session, test_sublime, MockHandlerDispatcher())
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
@@ -175,7 +175,7 @@ class WindowManagerTests(unittest.TestCase):
     def test_offers_restart_on_crash(self):
         docs = MockDocuments()
         wm = WindowManager(MockWindow([[MockView(__file__)]]), MockConfigs(), docs,
-                           WindowDiagnostics(), mock_start_session, test_sublime,
+                           DiagnosticsStorage(None), mock_start_session, test_sublime,
                            MockHandlerDispatcher())
         wm.start_active_views()
 
@@ -197,7 +197,7 @@ class WindowManagerTests(unittest.TestCase):
         docs = MockDocuments()
         dispatcher = MockHandlerDispatcher()
         wm = WindowManager(MockWindow([[MockView(__file__)]]), MockConfigs(), docs,
-                           WindowDiagnostics(), mock_start_session, test_sublime,
+                           DiagnosticsStorage(None), mock_start_session, test_sublime,
                            dispatcher)
         wm.start_active_views()
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -14,7 +14,6 @@ class Settings(object):
         self.show_view_status = True
         self.auto_show_diagnostics_panel = True
         self.auto_show_diagnostics_panel_level = 3
-        self.show_diagnostics_phantoms = False
         self.show_diagnostics_count_in_view_status = False
         self.show_diagnostics_in_view_status = True
         self.show_diagnostics_severity_level = 3

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -12,7 +12,7 @@ class Settings(object):
     def __init__(self) -> None:
         self.show_status_messages = True
         self.show_view_status = True
-        self.auto_show_diagnostics_panel = True
+        self.auto_show_diagnostics_panel = 'always'
         self.auto_show_diagnostics_panel_level = 3
         self.show_diagnostics_count_in_view_status = False
         self.show_diagnostics_in_view_status = True

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -317,7 +317,7 @@ class WindowManager(object):
         # configurations.py: window_client_configs and all references
         self._window = window
         self._configs = configs
-        self._diagnostics = diagnostics
+        self.diagnostics = diagnostics
         self._documents = documents
         self._sessions = dict()  # type: Dict[str, Session]
         self._start_session = session_starter
@@ -508,7 +508,7 @@ class WindowManager(object):
 
         client.on_notification(
             "textDocument/publishDiagnostics",
-            lambda params: self._diagnostics.receive(session.config.name, params))
+            lambda params: self.diagnostics.receive(session.config.name, params))
 
         self._handlers.on_initialized(session.config.name, self._window, client)
 
@@ -566,7 +566,7 @@ class WindowManager(object):
         for view in self._window.views():
             file_name = view.file_name()
             if file_name:
-                self._diagnostics.remove(file_name, config_name)
+                self.diagnostics.remove(file_name, config_name)
 
         debug("session", config_name, "ended")
         if not self._sessions:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -1,4 +1,4 @@
-from .diagnostics import WindowDiagnostics
+from .diagnostics import DiagnosticsStorage
 from .events import global_events
 from .logging import debug, server_log
 from .types import (ClientStates, ClientConfig, WindowLike, ViewLike,
@@ -302,7 +302,7 @@ class WindowDocumentHandler(object):
 
 class WindowManager(object):
     def __init__(self, window: WindowLike, configs: ConfigRegistry, documents: DocumentHandler,
-                 diagnostics: WindowDiagnostics, session_starter: 'Callable', sublime: 'Any',
+                 diagnostics: DiagnosticsStorage, session_starter: 'Callable', sublime: 'Any',
                  handler_dispatcher: LanguageHandlerListener, on_closed: 'Optional[Callable]' = None) -> None:
 
         # to move here:
@@ -500,7 +500,7 @@ class WindowManager(object):
 
         client.on_notification(
             "textDocument/publishDiagnostics",
-            lambda params: self._diagnostics.handle_client_diagnostics(session.config.name, params))
+            lambda params: self._diagnostics.receive(session.config.name, params))
 
         self._handlers.on_initialized(session.config.name, self._window, client)
 
@@ -592,7 +592,7 @@ class WindowRegistry(object):
             window_documents = self._documents.for_window(window, window_configs)
             diagnostics_ui = self._diagnostics_ui_class(window, None) if self._diagnostics_ui_class else None
             state = WindowManager(window, window_configs, window_documents,
-                                  WindowDiagnostics(diagnostics_ui), self._session_starter,
+                                  DiagnosticsStorage(diagnostics_ui), self._session_starter,
                                   self._sublime, self._handler_dispatcher, lambda: self._on_closed(window))
             self._windows[window.id()] = state
         return state

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -329,12 +329,13 @@ class DiagnosticsPresenter(object):
         self._window = window
         self._dirty = False
         self._received_diagnostics_after_change = False
-        self._show_panel_on_diagnostics = True
+        self._show_panel_on_diagnostics = False if settings.auto_show_diagnostics_panel == 'never' else True
         self._panel_update = DiagnosticOutputPanel(self._window)
         self._bar_summary_update = StatusBarSummary(self._window)
         self._relevance_check = HasRelevantDiagnostics()
-        setattr(documents_state, 'changed', self.on_document_changed)
-        setattr(documents_state, 'saved', self.on_document_saved)
+        if settings.auto_show_diagnostics_panel == 'saved':
+            setattr(documents_state, 'changed', self.on_document_changed)
+            setattr(documents_state, 'saved', self.on_document_saved)
 
     def on_document_changed(self) -> None:
         self._received_diagnostics_after_change = False
@@ -347,10 +348,6 @@ class DiagnosticsPresenter(object):
 
     def show_panel_if_relevant(self) -> None:
         self._show_panel_on_diagnostics = False
-
-        # todo: worth checking before showing/hiding?
-        # active_panel = window.active_panel()
-        # is_active_panel = (active_panel == "output.diagnostics")
 
         if self._relevance_check.result:
             self._window.run_command("show_panel", {"panel": "output.diagnostics"})
@@ -378,5 +375,5 @@ class DiagnosticsPresenter(object):
         walker = DiagnosticsWalker(updatables)
         walker.walk(diagnostics)
 
-        if self._show_panel_on_diagnostics:
+        if settings.auto_show_diagnostics_panel == 'always' or self._show_panel_on_diagnostics:
             self.show_panel_if_relevant()

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -319,7 +319,7 @@ class DocumentsState(Protocol):
         ...
 
 
-class DiagnosticsUI(object):
+class DiagnosticsPresenter(object):
 
     def __init__(self, window: sublime.Window, documents_state: DocumentsState) -> None:
         self._window = window

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -111,14 +111,6 @@ def format_severity(severity: int) -> str:
     return diagnostic_severity_names.get(severity, "???")
 
 
-def get_point_diagnostics(view: sublime.View, point: int) -> 'List[Diagnostic]':
-    diagnostics = get_view_diagnostics(view)
-    return [
-        diagnostic for diagnostic in diagnostics
-        if range_to_region(diagnostic.range, view).contains(point)
-    ]
-
-
 def point_diagnostics_by_config(view: sublime.View, point: int) -> 'Dict[str, List[Diagnostic]]':
     diagnostics_by_config = {}
     if view.window():
@@ -287,17 +279,16 @@ class DiagnosticsWalker(object):
     def walk(self, diagnostics_by_file: 'Dict[str, Dict[str, List[Diagnostic]]]') -> None:
         self.invoke_each(lambda w: w.begin())
 
-        if diagnostics_by_file is not None:
-            if diagnostics_by_file:
-                for file_path, source_diagnostics in diagnostics_by_file.items():
+        if diagnostics_by_file:
+            for file_path, source_diagnostics in diagnostics_by_file.items():
 
-                    self.invoke_each(lambda w: w.begin_file(file_path))
+                self.invoke_each(lambda w: w.begin_file(file_path))
 
-                    for origin, diagnostics in source_diagnostics.items():
-                        for diagnostic in diagnostics:
-                            self.invoke_each(lambda w: w.diagnostic(diagnostic))
+                for origin, diagnostics in source_diagnostics.items():
+                    for diagnostic in diagnostics:
+                        self.invoke_each(lambda w: w.diagnostic(diagnostic))
 
-                    self.invoke_each(lambda w: w.end_file(file_path))
+                self.invoke_each(lambda w: w.end_file(file_path))
 
         self.invoke_each(lambda w: w.end())
 

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -99,8 +99,8 @@ class LSPViewEventListener(sublime_plugin.ViewEventListener):
 
 class DiagnosticsCursorListener(LSPViewEventListener):
     def __init__(self, view: sublime.View) -> None:
-        self.view = view
         self.has_status = False
+        super().__init__(view)
 
     @classmethod
     def is_applicable(cls, view_settings: dict) -> bool:

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -246,6 +246,8 @@ class DiagnosticsWalker(object):
 
 
 class HasRelevantDiagnostics(DiagnosticsUpdateWalk):
+    def __init__(self) -> None:
+        self.result = False
 
     def begin(self) -> None:
         self.result = False

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -1,4 +1,3 @@
-import html
 import os
 import sublime
 import sublime_plugin
@@ -35,77 +34,11 @@ diagnostic_severity_scopes = {
     DiagnosticSeverity.Hint: 'markup.inserted.lsp sublimelinter.gutter-mark markup.info.suggestion.lsp'
 }
 
-stylesheet = '''
-            <style>
-                div.error-arrow {
-                    border-top: 0.4rem solid transparent;
-                    border-left: 0.5rem solid color(var(--redish) blend(var(--background) 30%));
-                    width: 0;
-                    height: 0;
-                }
-                div.error {
-                    padding: 0.4rem 0 0.4rem 0.7rem;
-                    margin: 0 0 0.2rem;
-                    border-radius: 0 0.2rem 0.2rem 0.2rem;
-                }
-
-                div.error span.message {
-                    padding-right: 0.7rem;
-                }
-
-                div.error a {
-                    text-decoration: inherit;
-                    padding: 0.35rem 0.7rem 0.45rem 0.8rem;
-                    position: relative;
-                    bottom: 0.05rem;
-                    border-radius: 0 0.2rem 0.2rem 0;
-                    font-weight: bold;
-                }
-                html.dark div.error a {
-                    background-color: #00000018;
-                }
-                html.light div.error a {
-                    background-color: #ffffff18;
-                }
-            </style>
-        '''
 
 UNDERLINE_FLAGS = (sublime.DRAW_SQUIGGLY_UNDERLINE | sublime.DRAW_NO_OUTLINE | sublime.DRAW_NO_FILL |
                    sublime.DRAW_EMPTY_AS_OVERWRITE)
 
 BOX_FLAGS = sublime.DRAW_NO_FILL | sublime.DRAW_EMPTY_AS_OVERWRITE
-
-
-def create_phantom_html(text: str) -> str:
-    global stylesheet
-    formatted = "<br>".join(html.escape(line, quote=False) for line in text.splitlines())
-    return """<body id=inline-error>{}
-                <div class="error-arrow"></div>
-                <div class="error">
-                    <span class="message">{}</span>
-                    <a href="code-actions">Code Actions</a>
-                </div>
-                </body>""".format(stylesheet, formatted)
-
-
-def on_phantom_navigate(view: sublime.View, href: str, point: int) -> None:
-    # TODO: don't mess with the user's cursor.
-    sel = view.sel()
-    sel.clear()
-    sel.add(sublime.Region(point))
-    view.run_command("lsp_code_actions")
-
-
-def create_phantom(view: sublime.View, diagnostic: Diagnostic) -> sublime.Phantom:
-    region = range_to_region(diagnostic.range, view)
-    # TODO: hook up hide phantom (if keeping them)
-    content = create_phantom_html(diagnostic.message)
-    return sublime.Phantom(
-        region,
-        '<p>' + content + '</p>',
-        sublime.LAYOUT_BELOW,
-        lambda href: on_phantom_navigate(view, href, region.begin())
-    )
 
 
 def format_severity(severity: int) -> str:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -4,9 +4,9 @@ import sublime_plugin
 import webbrowser
 from html import escape
 from .core.configurations import is_supported_syntax
-from .diagnostics import point_diagnostics_by_config
+from .diagnostics import filter_by_point, view_diagnostics
 from .core.registry import session_for_view, LspTextCommand
-from .core.protocol import Request, DiagnosticSeverity, Diagnostic
+from .core.protocol import Request, DiagnosticSeverity, Diagnostic, Point
 from .core.documents import get_document_position
 from .core.popups import popup_css, popup_class
 from .code_actions import actions_manager, run_code_action_or_command
@@ -89,7 +89,8 @@ class LspHoverCommand(LspTextCommand):
         if self.is_likely_at_symbol(hover_point):
             self.request_symbol_hover(hover_point)
 
-        self._diagnostics_by_config = point_diagnostics_by_config(self.view, hover_point)
+        self._diagnostics_by_config = filter_by_point(view_diagnostics(self.view),
+                                                      Point(*self.view.rowcol(hover_point)))
         if self._diagnostics_by_config:
             self.request_code_actions(hover_point)
             self.request_show_hover(hover_point)


### PR DESCRIPTION
The "Show diagnostics panel after saving" investigation (#748) showed the functionality could be "tacked" on, but would work better if components were set up in proper relations instead of querying global state.

In this PR, a DiagnosticsPresenter is introduced which gets access to DocumentHandler's events.

Clean ups:
- [x] Deprecate the `show_diagnostics_phantoms` feature (as discussed in #722)

Desired fixes:
- [x] Stop using global_events for pushing diagnostics updates to ui
- [x] Remove duplication of looping logic over diagnostics after an update: `update_diagnostics_in_status_bar `, `update_diagnostics_panel`, `window_has_relevant_diagnostics`, `update_view_diagnostics` (trying a strategy to update many things in a single walk through)
- [x] Remove duplication querying diagnostics at a point: `point_diagnostics_by_config` vs `get_line_diagnostics` (perhaps share a cache if cursor listener and bulb listener both want diagnostics?)

- [x] Try to remove the need for `get_window_diagnostics` / `get_view_diagnostics` - it should be easy to access the DiagnosticsStorage, and it should expose useful functions for accessing/filtering data.