### PR TITLE
Add GoSublime-Recommended syntax to gopls config

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -422,7 +422,10 @@
     {
       "command": ["gopls"],
       "scopes": ["source.go"],
-      "syntaxes": ["Packages/Go/Go.sublime-syntax"],
+      "syntaxes": [
+        "Packages/Go/Go.sublime-syntax",
+        "Packages/GoSublime/syntax/GoSublime-Go-Recommended.sublime-syntax",
+      ],
       "languageId": "go"
     },
     "jdtls":


### PR DESCRIPTION
It is very common to use GoSublime when working on a go project in
sublimetext which comes with it's own syntax for Go files.

This adds the default recommended GoSublime syntax to the gopls client
config