### PR TITLE
Add an extra comma so as to not have an invalid.illegal scope

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -162,7 +162,7 @@
       "command": ["pyls"],
       "scopes": ["source.python"],
       "syntaxes": ["Packages/Python/Python.sublime-syntax", "Packages/MagicPython/grammars/MagicPython.tmLanguage", "Packages/Djaneiro/Syntaxes/Python Django.tmLanguage"],
-      "languageId": "python"
+      "languageId": "python",
       // "settings": {
       //   "pyls": {
       //       "configurationSources": ["flake8"],


### PR DESCRIPTION
Although the JSON (with comments) is valid, basically because ST3 parses it and doesn't complain, the sublime syntax definition for JSON incorrectly scopes the whitespace just before `// "settings"` as `invalid.illegal`. Adding a comma works around this issue.