### PR TITLE
Put the context menu into a separate child menu

### DIFF
--- a/Menus/Context.sublime-menu
+++ b/Menus/Context.sublime-menu
@@ -1,40 +1,44 @@
 [
-    { "caption": "-", "id": "lsp" },
     {
-        "command": "lsp_symbol_references",
-        "caption": "Find Symbol References"
-    },
-    {
-        "command": "lsp_symbol_definition",
-        "caption": "Go To Symbol Definition"
-    },
-    {
-        "command": "lsp_symbol_type_definition",
-        "caption": "Go To Symbol Type Definition"
-    },
-    {
-        "command": "lsp_symbol_declaration",
-        "caption": "Go To Symbol Declaration"
-    },
-    {
-        "command": "lsp_symbol_implementation",
-        "caption": "Go To Symbol Implementation"
-    },
-    {
-        "command": "lsp_symbol_rename",
-        "caption": "Rename Symbol"
-    },
-    {
-        "command": "lsp_code_actions",
-        "caption": "Code Actions"
-    },
-    {
-        "command": "lsp_format_document",
-        "caption": "Format Document"
-    },
-    {
-        "command": "lsp_format_document_range",
-        "caption": "Format Selection"
-    },
-    { "caption": "-", "id": "lsp_end"}
+        "caption": "LSP",
+        "children":
+        [
+            {
+                "command": "lsp_symbol_references",
+                "caption": "Find Symbol References"
+            },
+            {
+                "command": "lsp_symbol_definition",
+                "caption": "Go To Symbol Definition"
+            },
+            {
+                "command": "lsp_symbol_type_definition",
+                "caption": "Go To Symbol Type Definition"
+            },
+            {
+                "command": "lsp_symbol_declaration",
+                "caption": "Go To Symbol Declaration"
+            },
+            {
+                "command": "lsp_symbol_implementation",
+                "caption": "Go To Symbol Implementation"
+            },
+            {
+                "command": "lsp_symbol_rename",
+                "caption": "Rename Symbol"
+            },
+            {
+                "command": "lsp_code_actions",
+                "caption": "Code Actions"
+            },
+            {
+                "command": "lsp_format_document",
+                "caption": "Format Document"
+            },
+            {
+                "command": "lsp_format_document_range",
+                "caption": "Format Selection"
+            }
+        ]
+    }
 ]


### PR DESCRIPTION
The number of LSP capabilities grows larger and larger :) I think it makes sense to put the items of the context menu into a child menu.

![Screenshot from 2019-11-10 10-41-15](https://user-images.githubusercontent.com/2431823/68541982-f2222580-03a6-11ea-9be4-641294eb5480.png)
