### PR TITLE
Remove the project_path property of the Session object

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -151,7 +151,6 @@ class Session(object):
                  on_post_initialize: 'Optional[Callable[[Session], None]]' = None,
                  on_post_exit: 'Optional[Callable[[str], None]]' = None) -> None:
         self.config = config
-        self.project_path = project_path
         self.state = ClientStates.STARTING
         self._on_post_initialize = on_post_initialize
         self._on_post_exit = on_post_exit
@@ -159,7 +158,7 @@ class Session(object):
         self.client = client
         if on_pre_initialize:
             on_pre_initialize(self)
-        self.initialize()
+        self._initialize(project_path)
 
     def has_capability(self, capability: str) -> bool:
         return capability in self.capabilities and self.capabilities[capability] is not False
@@ -167,8 +166,8 @@ class Session(object):
     def get_capability(self, capability: str) -> 'Optional[Any]':
         return self.capabilities.get(capability)
 
-    def initialize(self) -> None:
-        params = get_initialize_params(self.project_path, self.config)
+    def _initialize(self, project_path: str) -> None:
+        params = get_initialize_params(project_path, self.config)
         self.client.send_request(
             Request.initialize(params),
             lambda result: self._handle_initialize_result(result))

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -83,7 +83,6 @@ class SessionTest(unittest.TestCase):
             create_session(config, project_path, dict(), Settings()))
 
         self.assertEqual(session.state, ClientStates.STARTING)
-        self.assertEqual(session.project_path, project_path)
         session.end()
         # self.assertIsNone(session.capabilities) -- empty dict
 
@@ -99,7 +98,6 @@ class SessionTest(unittest.TestCase):
                            on_post_initialize=post_initialize_callback))
         self.assertEqual(session.state, ClientStates.READY)
         self.assertIsNotNone(session.client)
-        self.assertEqual(session.project_path, project_path)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
         post_initialize_callback.assert_called_once()
@@ -118,7 +116,6 @@ class SessionTest(unittest.TestCase):
                            on_post_initialize=post_initialize_callback))
         self.assertEqual(session.state, ClientStates.READY)
         self.assertIsNotNone(session.client)
-        self.assertEqual(session.project_path, project_path)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
         pre_initialize_callback.assert_called_once()
@@ -138,12 +135,10 @@ class SessionTest(unittest.TestCase):
                            on_post_exit=post_exit_callback))
         self.assertEqual(session.state, ClientStates.READY)
         self.assertIsNotNone(session.client)
-        self.assertEqual(session.project_path, project_path)
         self.assertTrue(session.has_capability("testing"))
         post_initialize_callback.assert_called_once()
         session.end()
         self.assertEqual(session.state, ClientStates.STOPPING)
-        self.assertEqual(session.project_path, project_path)
         self.assertIsNone(session.client)
         self.assertFalse(session.has_capability("testing"))
         self.assertIsNone(session.get_capability("testing"))


### PR DESCRIPTION
There's no need to keep this information around. The authority on that
information is the WindowManager class.

One of the building blocks for #697.