### PR TITLE
Parse and show related information in diagnostics hover content

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -122,7 +122,10 @@ def get_initialize_params(project_path: str, config: ClientConfig) -> dict:
                     }
                 },
                 "rename": {},
-                "colorProvider": {}
+                "colorProvider": {},
+                "publishDiagnostics": {
+                    "relatedInformation": True
+                }
             },
             "workspace": {
                 "applyEdit": True,

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -18,7 +18,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
         wd = DiagnosticsStorage(None)
 
         test_file_path = "test.py"
-        diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict())
+        diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict(), [])
 
         wd.update(test_file_path, "test_server", [diag])
         view_diags = wd.get_by_file(test_file_path)
@@ -47,7 +47,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
         wd = DiagnosticsStorage(None)
 
         test_file_path = "test.py"
-        diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict())
+        diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict(), [])
 
         wd.update(test_file_path, "test_server", [diag])
         view_diags = wd.get_by_file(test_file_path)

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -2,11 +2,12 @@ import mdpopups
 import sublime
 import sublime_plugin
 import webbrowser
+import os
 from html import escape
 from .core.configurations import is_supported_syntax
 from .diagnostics import filter_by_point, view_diagnostics
-from .core.registry import session_for_view, LspTextCommand
-from .core.protocol import Request, DiagnosticSeverity, Diagnostic, Point
+from .core.registry import session_for_view, LspTextCommand, windows
+from .core.protocol import Request, DiagnosticSeverity, Diagnostic, DiagnosticRelatedInformation, Point
 from .core.documents import get_document_position
 from .core.popups import popups
 from .code_actions import actions_manager, run_code_action_or_command
@@ -75,6 +76,7 @@ goto_kinds = [
 class LspHoverCommand(LspTextCommand):
     def __init__(self, view: sublime.View) -> None:
         super().__init__(view)
+        self._base_dir = None   # type: Optional[str]
 
     def is_likely_at_symbol(self, point: int) -> bool:
         word_at_sel = self.view.classify(point)
@@ -82,6 +84,8 @@ class LspHoverCommand(LspTextCommand):
 
     def run(self, edit: sublime.Edit, point: 'Optional[int]' = None) -> None:
         hover_point = point or self.view.sel()[0].begin()
+        self._base_dir = windows.lookup(self.view.window()).get_project_path()
+
         self._hover = None  # type: Optional[Any]
         self._actions_by_config = {}  # type: Dict[str, List[CodeActionOrCommand]]
         self._diagnostics_by_config = {}  # type: Dict[str, List[Diagnostic]]
@@ -130,13 +134,22 @@ class LspHoverCommand(LspTextCommand):
             actions.append("<a href='{}'>{}</a>".format('rename', 'Rename'))
         return "<p>" + " | ".join(actions) + "</p>"
 
+    def format_diagnostic_related_info(self, info: DiagnosticRelatedInformation) -> str:
+        file_path = os.path.relpath(info.location.file_path,
+                                    self._base_dir) if self._base_dir else info.location.file_path
+        location = "{}:{}:{}".format(file_path, info.location.range.start.row, info.location.range.start.col)
+        return "<a href='location:{}'>{}</a><br>{}".format(location, location, escape(info.message))
+
     def format_diagnostic(self, diagnostic: 'Diagnostic') -> str:
         diagnostic_message = escape(diagnostic.message, False).replace('\n', '<br>')
+        related_infos = [self.format_diagnostic_related_info(info) for info in diagnostic.related_info]
+        related_content = "<br><br>" + "<br>".join(related_infos) if related_infos else ""
         if diagnostic.source:
-            return "<pre class=\"{}\">[{}] {}</pre>".format(class_for_severity[diagnostic.severity], diagnostic.source,
-                                                            diagnostic_message)
+            return "<pre class=\"{}\">[{}] {}{}</pre>".format(class_for_severity[diagnostic.severity],
+                                                              diagnostic.source, diagnostic_message, related_content)
         else:
-            return "<pre class=\"{}\">{}</pre>".format(class_for_severity[diagnostic.severity], diagnostic_message)
+            return "<pre class=\"{}\">{}{}</pre>".format(class_for_severity[diagnostic.severity], diagnostic_message,
+                                                         related_content)
 
     def diagnostics_content(self) -> str:
         formatted = []
@@ -230,6 +243,12 @@ class LspHoverCommand(LspTextCommand):
             sel.add(sublime.Region(point, point))
 
             self.view.show_popup_menu(titles, lambda i: self.handle_code_action_select(config_name, i))
+        elif href.startswith('location'):
+            _, file_path, location = href.split(":", 2)
+            file_path = os.path.join(self._base_dir, file_path) if self._base_dir else file_path
+            window = self.view.window()
+            if window:
+                window.open_file(file_path + ":" + location, sublime.ENCODED_POSITION | sublime.TRANSIENT)
         else:
             webbrowser.open_new_tab(href)
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -138,7 +138,7 @@ class LspHoverCommand(LspTextCommand):
         file_path = os.path.relpath(info.location.file_path,
                                     self._base_dir) if self._base_dir else info.location.file_path
         location = "{}:{}:{}".format(file_path, info.location.range.start.row, info.location.range.start.col)
-        return "<a href='location:{}'>{}</a><br>{}".format(location, location, escape(info.message))
+        return "<a href='location:{}'>{}</a>: {}".format(location, location, escape(info.message))
 
     def format_diagnostic(self, diagnostic: 'Diagnostic') -> str:
         diagnostic_message = escape(diagnostic.message, False).replace('\n', '<br>')

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -135,20 +135,22 @@ class LspHoverCommand(LspTextCommand):
         return "<p>" + " | ".join(actions) + "</p>"
 
     def format_diagnostic_related_info(self, info: DiagnosticRelatedInformation) -> str:
-        file_path = os.path.relpath(info.location.file_path,
-                                    self._base_dir) if self._base_dir else info.location.file_path
+        file_path = info.location.file_path
+        if self._base_dir and file_path.startswith(self._base_dir):
+            file_path = os.path.relpath(file_path, self._base_dir)
         location = "{}:{}:{}".format(file_path, info.location.range.start.row, info.location.range.start.col)
         return "<a href='location:{}'>{}</a>: {}".format(location, location, escape(info.message))
 
     def format_diagnostic(self, diagnostic: 'Diagnostic') -> str:
         diagnostic_message = escape(diagnostic.message, False).replace('\n', '<br>')
         related_infos = [self.format_diagnostic_related_info(info) for info in diagnostic.related_info]
-        related_content = "<br><br>" + "<br>".join(related_infos) if related_infos else ""
+        related_content = "<pre class='related_info'>" + "<br>".join(related_infos) + "</pre>" if related_infos else ""
+
         if diagnostic.source:
-            return "<pre class=\"{}\">[{}] {}{}</pre>".format(class_for_severity[diagnostic.severity],
+            return "<pre class=\"{}\">[{}] {}</pre>{}".format(class_for_severity[diagnostic.severity],
                                                               diagnostic.source, diagnostic_message, related_content)
         else:
-            return "<pre class=\"{}\">{}{}</pre>".format(class_for_severity[diagnostic.severity], diagnostic_message,
+            return "<pre class=\"{}\">{}</pre>{}".format(class_for_severity[diagnostic.severity], diagnostic_message,
                                                          related_content)
 
     def diagnostics_content(self) -> str:

--- a/popups.css
+++ b/popups.css
@@ -51,3 +51,9 @@
     text-decoration: none;
     color: var(--foreground);
 }
+.lsp_popup .related_info {
+    border-width: 0;
+    background-color: color(var(--foreground) alpha(0.25));
+    color: var(--whitish);
+    padding: 0.5rem;
+}


### PR DESCRIPTION
Closes #492 

It's pretty ugly, though RLS's duplicate content in the diagnostics doesn't help:

<img width="404" alt="Screenshot 2019-11-13 at 17 59 41" src="https://user-images.githubusercontent.com/4395832/68786080-78589900-063f-11ea-8eb4-69d33f360384.png">

Discussion of how VS Code implemented the UI: https://github.com/microsoft/vscode/issues/10271

