### PR TITLE
Break long spans in popups

### DIFF
--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -234,6 +234,25 @@ class RenderSignatureLabelTests(unittest.TestCase):
  \n<variable.parameter>foo</variable.parameter>\
  \n<variable.parameter emphasize>foo</variable.parameter></entity.name.function>""")
 
+    def test_long_signature(self):
+        # self.maxDiff = None
+        sig = create_signature(
+            "do_the_foo_bar_if_correct_with_optional_bar_and_uppercase_option(takes_a_mandatory_foo: int, bar_if_needed: Optional[str], in_uppercase: Optional[bool]) -> Optional[str]",
+            "takes_a_mandatory_foo",
+            "bar_if_needed",
+            "in_uppercase",
+            activeParameter=1)
+        help = create_signature_help(dict(signatures=[sig]))
+        if help:
+            label = render_signature_label(renderer, help.active_signature(), 1)
+            self.assertEqual(label, """
+<entity.name.function>do_the_foo_bar_if_correct_with_optional_bar_and_uppercase_option
+<punctuation>(</punctuation>
+<variable.parameter>takes_a_mandatory_foo</variable.parameter>: int,\
+ <br>&nbsp;&nbsp;&nbsp;&nbsp;\n<variable.parameter emphasize>bar_if_needed</variable.parameter>: Optional[str],\
+ <br>&nbsp;&nbsp;&nbsp;&nbsp;\n<variable.parameter>in_uppercase</variable.parameter>: Optional[bool]
+<punctuation>)</punctuation> -&gt; Optional[str]</entity.name.function>""")
+
 
 class SignatureHelpTests(unittest.TestCase):
 

--- a/plugin/core/test_signature_help.py
+++ b/plugin/core/test_signature_help.py
@@ -237,7 +237,8 @@ class RenderSignatureLabelTests(unittest.TestCase):
     def test_long_signature(self):
         # self.maxDiff = None
         sig = create_signature(
-            "do_the_foo_bar_if_correct_with_optional_bar_and_uppercase_option(takes_a_mandatory_foo: int, bar_if_needed: Optional[str], in_uppercase: Optional[bool]) -> Optional[str]",
+            """do_the_foo_bar_if_correct_with_optional_bar_and_uppercase_option(takes_a_mandatory_foo: int, \
+bar_if_needed: Optional[str], in_uppercase: Optional[bool]) -> Optional[str]""",
             "takes_a_mandatory_foo",
             "bar_if_needed",
             "in_uppercase",

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -13,7 +13,6 @@ from .core.documents import get_document_position
 from .core.popups import popups
 from .code_actions import actions_manager, run_code_action_or_command
 from .core.settings import client_configs, settings
-from .core.logging import debug
 
 try:
     from typing import List, Optional, Any, Dict
@@ -205,9 +204,7 @@ class LspHoverCommand(LspTextCommand):
                 formatted.append(value)
 
         if formatted:
-            output = mdpopups.md2html(self.view, "\n".join(formatted))
-            debug(output)
-            return output
+            return mdpopups.md2html(self.view, "\n".join(formatted))
 
         return ""
 

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -3,6 +3,7 @@ import sublime
 import sublime_plugin
 import webbrowser
 import os
+import textwrap
 from html import escape
 from .core.configurations import is_supported_syntax
 from .diagnostics import filter_by_point, view_diagnostics
@@ -12,6 +13,7 @@ from .core.documents import get_document_position
 from .core.popups import popups
 from .code_actions import actions_manager, run_code_action_or_command
 from .core.settings import client_configs, settings
+from .core.logging import debug
 
 try:
     from typing import List, Optional, Any, Dict
@@ -198,10 +200,14 @@ class LspHoverCommand(LspTextCommand):
             if language:
                 formatted.append("```{}\n{}\n```\n".format(language, value))
             else:
+                if '\n' not in value:
+                    value = "\n".join(textwrap.wrap(value, 80))
                 formatted.append(value)
 
         if formatted:
-            return mdpopups.md2html(self.view, "\n".join(formatted))
+            output = mdpopups.md2html(self.view, "\n".join(formatted))
+            debug(output)
+            return output
 
         return ""
 


### PR DESCRIPTION
Closes #486

Specific fixes for the related issues #604 and #646 

Long hover before:
<img width="801" alt="Screenshot 2019-11-16 at 18 19 48" src="https://user-images.githubusercontent.com/4395832/68996714-16e23580-089e-11ea-801c-de213d9b1d1c.png">
after:
<img width="529" alt="Screenshot 2019-11-16 at 18 22 02" src="https://user-images.githubusercontent.com/4395832/68996719-2792ab80-089e-11ea-92b1-13ccfbcf1d39.png">

Long signature before:
<img width="1043" alt="Screenshot 2019-11-16 at 18 20 54" src="https://user-images.githubusercontent.com/4395832/68996726-38dbb800-089e-11ea-94ae-562dbac3b05e.png">

after:
<img width="767" alt="Screenshot 2019-11-16 at 18 22 17" src="https://user-images.githubusercontent.com/4395832/68996729-3ed19900-089e-11ea-9254-d7a81db53bb9.png">

Worth noting:
* Line breaks added at 80 characters, I'm aware there's logic in SublimeLinter that sets a viewport-relative limit but perhaps this is enough?
* Splitting does not work in signature labels that don't use commas.  

To do:
- [x] update tests
- [x] clean code
- [x] add screenshots.


