### PR TITLE
Docs: Add TypeScript disable auto-import feature

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,7 @@ Have you added multiple folders to your Sublime workspace? LSP may not handle yo
 
 ### 4. [TypeScript] Disable auto-import out of scope autocompletions
 
-![typescript-auto-import](https://user-images.githubusercontent.com/1457327/68996892-42e5c280-086e-11ea-98e5-fffb003a1261.gif "TypeScript Auto Import")
+<img src="https://user-images.githubusercontent.com/1457327/68996892-42e5c280-086e-11ea-98e5-fffb003a1261.gif" alt="TypeScript Auto Import" width="256 />
 
 Find and comment out the following line in your prefered typescript language server:
 ```ts

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,23 @@ This issue can be solved in a few ways:
 
 Have you added multiple folders to your Sublime workspace? LSP may not handle your second folder as expected, see [this issue](https://github.com/tomv564/LSP/issues/81) for more details.
 
+### 4. [TypeScript] Disable auto-import out of scope autocompletions
+
+![typescript-auto-import](docs/images/typescript-auto-import.gif "TypeScript Auto Import")
+
+Find and comment out the following line in your prefered typescript language server:
+```ts
+includeExternalModuleExports: true,
+```
+
+#### Example for `typescript-language-server`
+```sh
+$ cd $(npm root -g)
+$ grep -Rn includeExternalModuleExports typescript-language-server
+typescript-language-server/lib/lsp-server.js:392:                    includeExternalModuleExports: true,
+```
+Comment out the line identified, restart sublime text, proceed with life. 👍
+
 ## Known Issues
 
 ### Completions not shown after certain keywords

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,7 +37,7 @@ Have you added multiple folders to your Sublime workspace? LSP may not handle yo
 
 > As you type `pos` in hopes to get the `position` variable autocomplete, `posix` appears and added auto import statment.
 
-Find and comment out the following line in your prefered typescript language server:
+Find and comment out the following line in your prefered typescript language server module:
 ```ts
 includeExternalModuleExports: true,
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,7 @@ Have you added multiple folders to your Sublime workspace? LSP may not handle yo
 
 ### 4. [TypeScript] Disable auto-import out of scope autocompletions
 
-![typescript-auto-import](docs/images/typescript-auto-import.gif "TypeScript Auto Import")
+![typescript-auto-import](https://user-images.githubusercontent.com/1457327/68996892-42e5c280-086e-11ea-98e5-fffb003a1261.gif "TypeScript Auto Import")
 
 Find and comment out the following line in your prefered typescript language server:
 ```ts

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,6 +35,8 @@ Have you added multiple folders to your Sublime workspace? LSP may not handle yo
 
 <img src="https://user-images.githubusercontent.com/1457327/68996892-42e5c280-086e-11ea-98e5-fffb003a1261.gif" alt="TypeScript Auto Import" width="512" />
 
+> As you type `pos` in hopes to get the `position` variable autocomplete, `posix` appears and added auto import statment.
+
 Find and comment out the following line in your prefered typescript language server:
 ```ts
 includeExternalModuleExports: true,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,7 +31,7 @@ This issue can be solved in a few ways:
 
 Have you added multiple folders to your Sublime workspace? LSP may not handle your second folder as expected, see [this issue](https://github.com/tomv564/LSP/issues/81) for more details.
 
-### 4. [TypeScript] Disable auto-import out of scope autocompletions
+### 4. TypeScript - Disable auto-import out of scope autocompletions
 
 <img src="https://user-images.githubusercontent.com/1457327/68996892-42e5c280-086e-11ea-98e5-fffb003a1261.gif" alt="TypeScript Auto Import" width="512" />
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,7 @@ Have you added multiple folders to your Sublime workspace? LSP may not handle yo
 
 ### 4. [TypeScript] Disable auto-import out of scope autocompletions
 
-<img src="https://user-images.githubusercontent.com/1457327/68996892-42e5c280-086e-11ea-98e5-fffb003a1261.gif" alt="TypeScript Auto Import" width="256 />
+<img src="https://user-images.githubusercontent.com/1457327/68996892-42e5c280-086e-11ea-98e5-fffb003a1261.gif" alt="TypeScript Auto Import" width="512" />
 
 Find and comment out the following line in your prefered typescript language server:
 ```ts

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,7 +48,7 @@ $ cd $(npm root -g)
 $ grep -Rn includeExternalModuleExports typescript-language-server
 typescript-language-server/lib/lsp-server.js:392:                    includeExternalModuleExports: true,
 ```
-Comment out the line identified, restart sublime text, proceed with life. 👍
+Comment out the line identified, `lsp-server.js:392`, restart sublime text, proceed with life. 👍
 
 ## Known Issues
 


### PR DESCRIPTION
This `tsserver` default configuration frustrated me, thought I'd document a quick way to disable this feature until additional LSP option's are made available. 🙂