### PR TITLE
Fix bulb not showing up in selections even if code action exist

### DIFF
--- a/plugin/code_actions.py
+++ b/plugin/code_actions.py
@@ -63,9 +63,8 @@ class CodeActionsManager(object):
         else:
             self._requests.clear()
             if diagnostics_by_config is None:
-                diagnostics_by_config = point_diagnostics_by_config(view, view.sel()[0])
-                print('here are diagnostics', diagnostics_by_config)
-            self._requests[current_location] = request_code_actions(view, diagnostics_by_config, point, actions_handler)
+                diagnostics_by_config = point_diagnostics_by_config(view, point)
+            self._requests[current_location] = request_code_actions(view, point, actions_handler)
 
     def get_location_key(self, view: sublime.View, point: int) -> str:
         return "{}#{}:{}".format(view.file_name(), view.change_count(), point)
@@ -74,7 +73,13 @@ class CodeActionsManager(object):
 actions_manager = CodeActionsManager()
 
 
-def request_code_actions(view: sublime.View, diagnostics_by_config: 'Dict[str, List[Diagnostic]]',
+def request_code_actions(view: sublime.View, point: int,
+                         actions_handler: 'Callable[[CodeActionsByConfigName], None]') -> 'CodeActionsAtLocation':
+    diagnostics_by_config = point_diagnostics_by_config(view, point)
+    return request_code_actions_with_diagnostics(view, diagnostics_by_config, point, actions_handler)
+
+
+def request_code_actions_with_diagnostics(view: sublime.View, diagnostics_by_config: 'Dict[str, List[Diagnostic]]',
                                           point: int, actions_handler: 'Callable[[CodeActionsByConfigName], None]'
                                           ) -> 'CodeActionsAtLocation':
 
@@ -83,37 +88,26 @@ def request_code_actions(view: sublime.View, diagnostics_by_config: 'Dict[str, L
     for session in sessions_for_view(view, point):
 
         if session.has_capability('codeActionProvider'):
-            point_diagnostics = None
             if session.config.name in diagnostics_by_config:
                 point_diagnostics = diagnostics_by_config[session.config.name]
-                print('point diagnostics for', session.config.name, point_diagnostics)
-
-            file_name = view.file_name()
-
-            range = region_to_range(
-                view,
-                view.sel()[0]
-            )
-
-            diagnostics = []  # type: 'List[Dict[str, Any]]'
-            if point_diagnostics:
-                diagnostics = list(diagnostic.to_lsp() for diagnostic in point_diagnostics)
-
-            print('send len diagnostics', len(diagnostics))
-            if file_name:
-                params = {
-                    "textDocument": {
-                        "uri": filename_to_uri(file_name)
-                    },
-                    "range": range.to_lsp(),
-                    "context": {
-                        "diagnostics": diagnostics
+                file_name = view.file_name()
+                relevant_range = point_diagnostics[0].range if point_diagnostics else region_to_range(
+                    view,
+                    view.sel()[0])
+                if file_name:
+                    params = {
+                        "textDocument": {
+                            "uri": filename_to_uri(file_name)
+                        },
+                        "range": relevant_range.to_lsp(),
+                        "context": {
+                            "diagnostics": list(diagnostic.to_lsp() for diagnostic in point_diagnostics)
+                        }
                     }
-                }
-                if session.client:
-                    session.client.send_request(
-                        Request.codeAction(params),
-                        actions_at_location.collect(session.config.name))
+                    if session.client:
+                        session.client.send_request(
+                            Request.codeAction(params),
+                            actions_at_location.collect(session.config.name))
     return actions_at_location
 
 

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -4,8 +4,8 @@ import sublime
 import sublime_plugin
 
 try:
-    from typing import Any, List, Dict, Callable, Optional, Union
-    assert Any and List and Dict and Callable and Optional and Union
+    from typing import Any, List, Dict, Callable, Optional
+    assert Any and List and Dict and Callable and Optional
 except ImportError:
     pass
 
@@ -154,7 +154,7 @@ def get_point_diagnostics(view: sublime.View, point: int) -> 'List[Diagnostic]':
     ]
 
 
-def point_diagnostics_by_config(view: sublime.View, x: 'Union[int, sublime.Region]') -> 'Dict[str, List[Diagnostic]]':
+def point_diagnostics_by_config(view: sublime.View, point: int) -> 'Dict[str, List[Diagnostic]]':
     diagnostics_by_config = {}
     if view.window():
         file_name = view.file_name()
@@ -162,21 +162,12 @@ def point_diagnostics_by_config(view: sublime.View, x: 'Union[int, sublime.Regio
             window_diagnostics = windows.lookup(view.window())._diagnostics.get()
             file_diagnostics = window_diagnostics.get(file_name, {})
             for config_name, diagnostics in file_diagnostics.items():
-                point_diagnostics = []  # type: List[Diagnostic]
-                if isinstance(x, sublime.Region) and x.begin() != x.end():
-                    point_diagnostics = [
-                        diagnostic for diagnostic in diagnostics
-                        if x.intersects(range_to_region(diagnostic.range, view))
-                    ]
-                else:
-                    point_diagnostics = [
-                        diagnostic for diagnostic in diagnostics
-                        if range_to_region(diagnostic.range, view).contains(x)
-                    ]
-
+                point_diagnostics = [
+                    diagnostic for diagnostic in diagnostics
+                    if range_to_region(diagnostic.range, view).contains(point)
+                ]
                 if point_diagnostics:
                     diagnostics_by_config[config_name] = point_diagnostics
-                    print('diagnostics count is', len(point_diagnostics), 'for', config_name)
 
     return diagnostics_by_config
 

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -4,8 +4,8 @@ import sublime
 import sublime_plugin
 
 try:
-    from typing import Any, List, Dict, Callable, Optional
-    assert Any and List and Dict and Callable and Optional
+    from typing import Any, List, Dict, Callable, Optional, Union
+    assert Any and List and Dict and Callable and Optional and Union
 except ImportError:
     pass
 
@@ -154,7 +154,7 @@ def get_point_diagnostics(view: sublime.View, point: int) -> 'List[Diagnostic]':
     ]
 
 
-def point_diagnostics_by_config(view: sublime.View, point: int) -> 'Dict[str, List[Diagnostic]]':
+def point_diagnostics_by_config(view: sublime.View, x: 'Union[int, sublime.Region]') -> 'Dict[str, List[Diagnostic]]':
     diagnostics_by_config = {}
     if view.window():
         file_name = view.file_name()
@@ -162,12 +162,21 @@ def point_diagnostics_by_config(view: sublime.View, point: int) -> 'Dict[str, Li
             window_diagnostics = windows.lookup(view.window())._diagnostics.get()
             file_diagnostics = window_diagnostics.get(file_name, {})
             for config_name, diagnostics in file_diagnostics.items():
-                point_diagnostics = [
-                    diagnostic for diagnostic in diagnostics
-                    if range_to_region(diagnostic.range, view).contains(point)
-                ]
+                point_diagnostics = []  # type: List[Diagnostic]
+                if isinstance(x, sublime.Region) and x.begin() != x.end():
+                    point_diagnostics = [
+                        diagnostic for diagnostic in diagnostics
+                        if x.intersects(range_to_region(diagnostic.range, view))
+                    ]
+                else:
+                    point_diagnostics = [
+                        diagnostic for diagnostic in diagnostics
+                        if range_to_region(diagnostic.range, view).contains(x)
+                    ]
+
                 if point_diagnostics:
                     diagnostics_by_config[config_name] = point_diagnostics
+                    print('diagnostics count is', len(point_diagnostics), 'for', config_name)
 
     return diagnostics_by_config
 

--- a/stubs/sublime.pyi
+++ b/stubs/sublime.pyi
@@ -456,7 +456,7 @@ class Region:
     def size(self) -> int:
         ...
 
-    def contains(self, x: int) -> bool:
+    def contains(self, x: 'Union[Region, int]') -> bool:
         ...
 
     def cover(self, rhs: 'Region') -> 'Region':


### PR DESCRIPTION
Send Code Action request only if the Region didn't changed for 800ms.

Previously we only checked if the .begin() of the region didn't changed for 800ms.

But in that case we might end up in situation when making a selection,
where we had code actions but didn't show a bulb, because the begin in selections didn't change.

https://github.com/tomv564/LSP/blob/f9c68aa98266e23f61b1254c3f41ee0af8c00f64/plugin/code_actions.py#L136

The bug:

![bug](https://user-images.githubusercontent.com/22029477/69000048-ff20a680-08c9-11ea-849c-bd6662a225c6.gif)

After this PR gets merged:
![good](https://user-images.githubusercontent.com/22029477/69000059-20819280-08ca-11ea-98b6-08d3a34cf100.gif)

