### PR TITLE
Show previous/next diagnostic with phantom

### DIFF
--- a/Commands/Default.sublime-commands
+++ b/Commands/Default.sublime-commands
@@ -62,6 +62,16 @@
         "args": {}
     },
     {
+        "caption": "LSP: Next Diagnostic",
+        "command": "lsp_next_diagnostic",
+        "args": {}
+    },
+    {
+        "caption": "LSP: Previous Diagnostic",
+        "command": "lsp_previous_diagnostic",
+        "args": {}
+    },
+    {
         "caption": "LSP: Workspace Symbol",
         "command": "lsp_workspace_symbols"
     },

--- a/phantoms.css
+++ b/phantoms.css
@@ -12,9 +12,16 @@ div.warning-arrow {
 }
 div.container {
     margin: 0;
+    border-radius: 0 0.2rem 0.2rem 0.2rem;
 }
 div.content {
     padding: 0.4rem 0.4rem 0.4rem 0.7rem;
+}
+div.content p {
+    margin: 0.2rem;
+}
+div.content p.additional {
+    margin-top: 0.7rem;
 }
 div.toolbar {
     padding: 0.2rem 0.7rem 0.2rem 0.7rem;

--- a/phantoms.css
+++ b/phantoms.css
@@ -1,3 +1,15 @@
+div.error-arrow {
+    border-top: 0.4rem solid transparent;
+    border-left: 0.5rem solid color(var(--redish) blend(var(--background) 30%));
+    width: 0;
+    height: 0;
+}
+div.warning-arrow {
+    border-top: 0.4rem solid transparent;
+    border-left: 0.5rem solid color(var(--yellowish) blend(var(--background) 30%));
+    width: 0;
+    height: 0;
+}
 div.container {
     margin: 0;
 }

--- a/phantoms.css
+++ b/phantoms.css
@@ -21,7 +21,9 @@ div.content p {
     margin: 0.2rem;
 }
 div.content p.additional {
+    border-top: 1px solid color(var(--background) alpha(0.25));
     margin-top: 0.7rem;
+    padding-top: 0.7rem;
 }
 div.toolbar {
     padding: 0.2rem 0.7rem 0.2rem 0.7rem;

--- a/phantoms.css
+++ b/phantoms.css
@@ -20,17 +20,8 @@ div.content {
 div.content p {
     margin: 0.2rem;
 }
-div.content-additional {
-    background-color: var(--background);
-    color: var(--whitish);
-    margin-bottom: 0.4rem;
-}
-div.content-additional-inner {
-    padding: 0.4rem 0.4rem 0.4rem 0.7rem;
-    background-color: color(var(--foreground) alpha(0.25));
-}
-div.content-additional p {
-    margin: 0.2rem 0.2rem 0.2rem 0.2rem;
+div.content p.additional {
+    margin-top: 0.7rem;
 }
 div.toolbar {
     padding: 0.2rem 0.7rem 0.2rem 0.7rem;

--- a/phantoms.css
+++ b/phantoms.css
@@ -20,8 +20,17 @@ div.content {
 div.content p {
     margin: 0.2rem;
 }
-div.content p.additional {
-    margin-top: 0.7rem;
+div.content-additional {
+    background-color: var(--background);
+    color: var(--whitish);
+    margin-bottom: 0.4rem;
+}
+div.content-additional-inner {
+    padding: 0.4rem 0.4rem 0.4rem 0.7rem;
+    background-color: color(var(--foreground) alpha(0.25));
+}
+div.content-additional p {
+    margin: 0.2rem 0.2rem 0.2rem 0.2rem;
 }
 div.toolbar {
     padding: 0.2rem 0.7rem 0.2rem 0.7rem;

--- a/phantoms.css
+++ b/phantoms.css
@@ -1,0 +1,18 @@
+div.container {
+    margin: 0;
+}
+div.content {
+    padding: 0.4rem 0.4rem 0.4rem 0.7rem;
+}
+div.toolbar {
+    padding: 0.2rem 0.7rem 0.2rem 0.7rem;
+}
+div.toolbar a {
+    text-decoration: none
+}
+html.dark div.toolbar {
+    background-color: #00000018;
+}
+html.light div.toolbar {
+    background-color: #ffffff18;
+}

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -221,7 +221,11 @@ class FromDiagnosticWalk(DiagnosticCursorWalk):
 
     def diagnostic(self, diagnostic: 'Diagnostic') -> None:
         if diagnostic.severity <= DiagnosticSeverity.Warning:
+
             if self._direction == CURSOR_FORWARD:
+                if not self._first:
+                    self._first = self._current_file_path, diagnostic
+
                 if self._take_next:
                     self._take_candidate(diagnostic)
                     self._take_next = False
@@ -237,10 +241,10 @@ class FromDiagnosticWalk(DiagnosticCursorWalk):
         if self._candidate:
             self._cursor.set_value(self._candidate)
         else:
-            if self._direction == CURSOR_BACKWARD:
-                self._cursor.set_value(self._previous)
+            if self._direction == CURSOR_FORWARD:
+                self._cursor.set_value(self._first)
             else:
-                self._cursor.set_value((self._file_path, self._diagnostic))
+                self._cursor.set_value(self._previous)
 
 
 class TakeFirstDiagnosticWalk(DiagnosticCursorWalk):

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -1,6 +1,6 @@
 from .logging import debug
 from .url import uri_to_filename
-from .protocol import Diagnostic
+from .protocol import Diagnostic, DiagnosticSeverity, Point
 assert Diagnostic
 
 try:
@@ -90,3 +90,132 @@ class DiagnosticsStorage(object):
     def select_none(self) -> None:
         if self._updatable:
             self._updatable.deselect()
+
+
+class DocumentsState(Protocol):
+
+    def changed(self) -> None:
+        ...
+
+    def saved(self) -> None:
+        ...
+
+
+class DiagnosticsUpdateWalk(object):
+
+    def begin(self) -> None:
+        pass
+
+    def begin_file(self, file_path: str) -> None:
+        pass
+
+    def diagnostic(self, diagnostic: 'Diagnostic') -> None:
+        pass
+
+    def end_file(self, file_path: str) -> None:
+        pass
+
+    def end(self) -> None:
+        pass
+
+
+class DiagnosticsCursor(DiagnosticsUpdateWalk):
+    def __init__(self) -> None:
+        self.file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
+        self._first_file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
+        self._last_file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
+        self._previous_file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
+        self._select_offset = 0
+        self._debug_index = -1
+
+    def select_offset(self, offset: int, file_path: 'Optional[str]' = None, point: 'Optional[Point]' = None) -> None:
+        self._select_offset = offset
+        self._select_file_path = file_path
+        self._select_point = point
+
+    def begin(self) -> None:
+        self._found = False
+        self._debug_index = -1
+        self._first_file_diagnostic = None
+        self._last_file_diagnostic = None
+        self._nearest_file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
+        self._previous_file_diagnostic = self.file_diagnostic
+        self.file_diagnostic = None
+
+    def begin_file(self, file_path: str) -> None:
+        self._current_file_path = file_path
+
+    def diagnostic(self, diagnostic: 'Diagnostic') -> None:
+        if diagnostic.severity <= DiagnosticSeverity.Warning:
+            if not self._found:
+                if not self._first_file_diagnostic:
+                    self._first_file_diagnostic = self._current_file_path, diagnostic
+
+                if self._select_offset == -1:
+                    if self._previous_file_diagnostic and diagnostic == self._previous_file_diagnostic[1]:
+                        if self._last_file_diagnostic:
+                            self.file_diagnostic = self._last_file_diagnostic
+                            self._found = True
+
+                elif self._select_offset == 1:
+                    if self._last_file_diagnostic and self._previous_file_diagnostic and self._previous_file_diagnostic[
+                            1] == self._last_file_diagnostic[1]:
+                        self.file_diagnostic = self._current_file_path, diagnostic
+                        self._found = True
+
+                # update nearest candidate
+                if not self._found and self._select_file_path and self._select_point and\
+                        self._current_file_path == self._select_file_path:
+                    self._update_nearest_candidate(diagnostic, self._select_point)
+
+                self._last_file_diagnostic = self._current_file_path, diagnostic
+
+    def _update_nearest_candidate(self, diagnostic: Diagnostic, point: Point) -> None:
+        if self._select_offset == -1:
+            if diagnostic.range.start.row < point.row:
+                if not self._nearest_file_diagnostic or diagnostic.range.start.row > self._nearest_file_diagnostic[
+                        1].range.start.row:
+                    self._nearest_file_diagnostic = self._current_file_path, diagnostic
+        elif self._select_offset == 1:
+            if diagnostic.range.start.row > point.row:
+                if not self._nearest_file_diagnostic or diagnostic.range.start.row < self._nearest_file_diagnostic[
+                        1].range.start.row:
+                    self._nearest_file_diagnostic = self._current_file_path, diagnostic
+
+    def end(self) -> None:
+        if not self.file_diagnostic:
+            if self._select_offset == -1 and self._previous_file_diagnostic == self._first_file_diagnostic:
+                self.file_diagnostic = self._last_file_diagnostic
+            elif self._select_offset == 1 and self._previous_file_diagnostic == self._last_file_diagnostic:
+                self.file_diagnostic = self._first_file_diagnostic
+            elif self._nearest_file_diagnostic:  # a match before/after in the current file
+                self.file_diagnostic = self._nearest_file_diagnostic
+
+        self._select_offset = 0
+
+
+class DiagnosticsWalker(object):
+    """ Iterate over diagnostics structure"""
+
+    def __init__(self, subs: 'List[DiagnosticsUpdateWalk]') -> None:
+        self._subscribers = subs
+
+    def walk(self, diagnostics_by_file: 'Dict[str, Dict[str, List[Diagnostic]]]') -> None:
+        self.invoke_each(lambda w: w.begin())
+
+        if diagnostics_by_file:
+            for file_path, source_diagnostics in diagnostics_by_file.items():
+
+                self.invoke_each(lambda w: w.begin_file(file_path))
+
+                for origin, diagnostics in source_diagnostics.items():
+                    for diagnostic in diagnostics:
+                        self.invoke_each(lambda w: w.diagnostic(diagnostic))
+
+                self.invoke_each(lambda w: w.end_file(file_path))
+
+        self.invoke_each(lambda w: w.end())
+
+    def invoke_each(self, func: 'Callable[[DiagnosticsUpdateWalk], None]') -> None:
+        for sub in self._subscribers:
+            func(sub)

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -14,15 +14,18 @@ except ImportError:
     Protocol = object  # type: ignore
 
 
-class DiagnosticsUpdateable(Protocol):
+class DiagnosticsUI(Protocol):
 
     def update(self, file_name: str, config_name: str, diagnostics: 'Dict[str, Dict[str, List[Diagnostic]]]') -> None:
+        ...
+
+    def select(self, index: int) -> None:
         ...
 
 
 class DiagnosticsStorage(object):
 
-    def __init__(self, updateable: 'Optional[DiagnosticsUpdateable]') -> None:
+    def __init__(self, updateable: 'Optional[DiagnosticsUI]') -> None:
         self._diagnostics = {}  # type: Dict[str, Dict[str, List[Diagnostic]]]
         self._updatable = updateable
 
@@ -72,3 +75,11 @@ class DiagnosticsStorage(object):
 
     def remove(self, file_path: str, client_name: str) -> None:
         self.update(file_path, client_name, [])
+
+    def select_next(self) -> None:
+        if self._updatable:
+            self._updatable.select(1)
+
+    def select_previous(self) -> None:
+        if self._updatable:
+            self._updatable.select(-1)

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -123,137 +123,147 @@ CURSOR_FORWARD = 1
 CURSOR_BACKWARD = -1
 
 
-class FromPositionWalk(DiagnosticsUpdateWalk):
-    def __init__(self, cursor: 'DiagnosticsCursor', file_path: str, point: Point, direction: int) -> None:
-        self.file_path = file_path
-        self.point = point
+class DiagnosticCursorWalk(DiagnosticsUpdateWalk):
+
+    def __init__(self, cursor: 'DiagnosticsCursor', direction: int=0) -> None:
         self._cursor = cursor
         self._direction = direction
-        self.file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
-        self._first_file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
-        self._nearest_file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
-        self._previous_file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
+        self._current_file_path = ""
+        self._candidate = None  # type: 'Optional[Tuple[str, Diagnostic]]'
 
     def begin_file(self, file_path: str) -> None:
         self._current_file_path = file_path
+
+    def _take_candidate(self, diagnostic: 'Diagnostic') -> None:
+        self._candidate = self._current_file_path, diagnostic
+
+    def end(self) -> None:
+        self._cursor.set_value(self._candidate)
+
+
+class FromPositionWalk(DiagnosticCursorWalk):
+    def __init__(self, cursor: 'DiagnosticsCursor', file_path: str, point: Point, direction: int) -> None:
+        super().__init__(cursor, direction)
+        self._first = None  # type: Optional[Tuple[str, Diagnostic]]
+        self._previous = None  # type: Optional[Tuple[str, Diagnostic]]
+
+        # position-specific
+        self._file_path = file_path
+        self._point = point
+        self._first_after_file = None  # type: Optional[Tuple[str, Diagnostic]]
+        self._last_before_file = None  # type: Optional[Tuple[str, Diagnostic]]
 
     def diagnostic(self, diagnostic: 'Diagnostic') -> None:
         if diagnostic.severity <= DiagnosticSeverity.Warning:
-            if not self._first_file_diagnostic:
-                self._first_file_diagnostic = self._current_file_path, diagnostic
+            if not self._first:
+                self._first = self._current_file_path, diagnostic
 
-            if self._direction == CURSOR_FORWARD:
-                if self._current_file_path == self.file_path:
+            if self._current_file_path == self._file_path:
+                if self._direction == CURSOR_FORWARD:
                     self._take_if_nearer_forward(diagnostic)
-            else:
-                if self._current_file_path == self.file_path:
+                else:
                     self._take_if_nearer_backward(diagnostic)
-                    self._last_before_file_diagnostic = self._previous_file_diagnostic
-                self._previous_file_diagnostic = self._current_file_path, diagnostic
+                    self._set_last_before_file(diagnostic)
+            else:
+                if self._direction == CURSOR_FORWARD:
+                    self._set_first_after_file(diagnostic)
+
+            self._previous = self._current_file_path, diagnostic
 
     def _take_if_nearer_forward(self, diagnostic: Diagnostic) -> None:
-        if diagnostic.range.start.row > self.point.row:
-            if not self._nearest_file_diagnostic or diagnostic.range.start.row < self._nearest_file_diagnostic[
-                    1].range.start.row:
-                self._nearest_file_diagnostic = self._current_file_path, diagnostic
+        if diagnostic.range.start.row > self._point.row:
+            if not self._candidate:
+                self._take_candidate(diagnostic)
+            else:
+                candidate_start_row = self._candidate[1].range.start.row
+                if diagnostic.range.start.row < candidate_start_row:
+                    self._take_candidate(diagnostic)
 
     def _take_if_nearer_backward(self, diagnostic: Diagnostic) -> None:
-        if diagnostic.range.start.row < self.point.row:
-            if not self._nearest_file_diagnostic or diagnostic.range.start.row > self._nearest_file_diagnostic[
-                    1].range.start.row:
-                self._nearest_file_diagnostic = self._current_file_path, diagnostic
+        if diagnostic.range.start.row < self._point.row:
+            if not self._candidate:
+                self._take_candidate(diagnostic)
+            else:
+                candidate_start_row = self._candidate[1].range.start.row
+                if diagnostic.range.start.row > candidate_start_row:
+                    self._take_candidate(diagnostic)
+
+    def _set_last_before_file(self, diagnostic: Diagnostic) -> None:
+        if not self._last_before_file and self._previous:
+            if self._previous[0] != self._current_file_path:
+                self._last_before_file = self._previous
+
+    def _set_first_after_file(self, diagnostic: Diagnostic) -> None:
+        if not self._first_after_file:
+            if self._previous and self._previous[0] == self._file_path:
+                self._first_after_file = self._current_file_path, diagnostic
 
     def end(self) -> None:
-        if self._nearest_file_diagnostic:
-            self._cursor.set_value(self._nearest_file_diagnostic)
+        if self._candidate:
+            self._cursor.set_value(self._candidate)
         else:
             if self._direction == CURSOR_FORWARD:
-                self._cursor.set_value(self._first_file_diagnostic)
+                self._cursor.set_value(self._first_after_file or self._first)
             else:
-                self._cursor.set_value(self._last_before_file_diagnostic)
+                self._cursor.set_value(self._last_before_file or self._previous)
 
 
-class DiagnosticsUpdatedWalk(DiagnosticsUpdateWalk):
+class FromDiagnosticWalk(DiagnosticCursorWalk):
+    def __init__(self, cursor: 'DiagnosticsCursor', direction: int) -> None:
+        super().__init__(cursor, direction)
 
-    def __init__(self, cursor: 'DiagnosticsCursor', file_path: str, diagnostic: Diagnostic) -> None:
-        self._file_path = file_path
-        self._diagnostic = diagnostic
-        self._cursor = cursor
-        self.file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
+        self._first = None  # type: Optional[Tuple[str, Diagnostic]]
+        self._previous = None  # type: Optional[Tuple[str, Diagnostic]]
 
-    def begin_file(self, file_path: str) -> None:
-        self._is_same_file = self._file_path == file_path
-
-    def diagnostic(self, diagnostic: 'Diagnostic') -> None:
-        if self._is_same_file:
-            if diagnostic == self._diagnostic:
-                self.file_diagnostic = self._file_path, diagnostic
-
-    def end(self) -> None:
-        self._cursor.set_value(self.file_diagnostic)
-
-
-class FromDiagnosticWalk(DiagnosticsUpdateWalk):
-    def __init__(self, cursor: 'DiagnosticsCursor', direction: int, file_path: str, diagnostic: Diagnostic) -> None:
-        self._file_path = file_path
-        self._diagnostic = diagnostic
-        self._direction = direction
-        self.file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
-        self._cursor = cursor
-        self._first_file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
-        self._previous_file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
+        assert cursor.value
+        self._file_path, self._diagnostic = cursor.value
         self._take_next = False
-
-    def begin_file(self, file_path: str) -> None:
-        self._current_file_path = file_path
 
     def diagnostic(self, diagnostic: 'Diagnostic') -> None:
         if diagnostic.severity <= DiagnosticSeverity.Warning:
             if self._direction == CURSOR_FORWARD:
                 if self._take_next:
-                    self.file_diagnostic = self._current_file_path, diagnostic
+                    self._take_candidate(diagnostic)
                     self._take_next = False
                 elif diagnostic == self._diagnostic and self._current_file_path == self._file_path:
                     self._take_next = True
             else:
                 if self._current_file_path == self._file_path and self._diagnostic == diagnostic:
-                    if self._previous_file_diagnostic:
-                        self.file_diagnostic = self._previous_file_diagnostic
-                self._previous_file_diagnostic = self._current_file_path, diagnostic
+                    if self._previous:
+                        self._candidate = self._previous
+                self._previous = self._current_file_path, diagnostic
 
     def end(self) -> None:
-        if self.file_diagnostic:
-            self._cursor.set_value(self.file_diagnostic)
+        if self._candidate:
+            self._cursor.set_value(self._candidate)
         else:
             if self._direction == CURSOR_BACKWARD:
-                self._cursor.set_value(self._previous_file_diagnostic)
+                self._cursor.set_value(self._previous)
             else:
                 self._cursor.set_value((self._file_path, self._diagnostic))
 
 
-class TakeFirstDiagnosticWalk(DiagnosticsUpdateWalk):
-
-    def __init__(self, cursor: 'DiagnosticsCursor', direction: int) -> None:
-        self._cursor = cursor
-        self._file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
-        self._direction = direction
-
-    def begin_file(self, file_path: str) -> None:
-        self._current_file_path = file_path
+class TakeFirstDiagnosticWalk(DiagnosticCursorWalk):
 
     def diagnostic(self, diagnostic: Diagnostic) -> None:
         if diagnostic.severity <= DiagnosticSeverity.Warning:
             if self._direction == CURSOR_FORWARD:
-                if self._file_diagnostic is None:
-                    self._file_diagnostic = self._current_file_path, diagnostic
+                if self._candidate is None:
+                    self._take_candidate(diagnostic)
             else:
-                self._file_diagnostic = self._current_file_path, diagnostic
-
-    def end(self) -> None:
-        self._cursor.set_value(self._file_diagnostic)
+                self._take_candidate(diagnostic)
 
 
-class DiagnosticsCursor(DiagnosticsUpdateWalk):
+class DiagnosticsUpdatedWalk(DiagnosticCursorWalk):
+
+    def diagnostic(self, diagnostic: 'Diagnostic') -> None:
+        if self._cursor.value:
+            if self._current_file_path == self._cursor.value[0]:
+                if diagnostic == self._cursor.value[1]:
+                    self._take_candidate(diagnostic)
+
+
+class DiagnosticsCursor(object):
 
     def __init__(self) -> None:
         self._file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
@@ -278,11 +288,11 @@ class DiagnosticsCursor(DiagnosticsUpdateWalk):
 
     def from_diagnostic(self, direction: int) -> DiagnosticsUpdateWalk:
         assert self._file_diagnostic
-        return FromDiagnosticWalk(self, direction, *self._file_diagnostic)
+        return FromDiagnosticWalk(self, direction)
 
     def update(self) -> DiagnosticsUpdateWalk:
         assert self._file_diagnostic
-        return DiagnosticsUpdatedWalk(self, *self._file_diagnostic)
+        return DiagnosticsUpdatedWalk(self)
 
 
 class DiagnosticsWalker(object):

--- a/plugin/core/diagnostics.py
+++ b/plugin/core/diagnostics.py
@@ -22,6 +22,9 @@ class DiagnosticsUI(Protocol):
     def select(self, index: int) -> None:
         ...
 
+    def deselect(self) -> None:
+        ...
+
 
 class DiagnosticsStorage(object):
 
@@ -83,3 +86,7 @@ class DiagnosticsStorage(object):
     def select_previous(self) -> None:
         if self._updatable:
             self._updatable.select(-1)
+
+    def select_none(self) -> None:
+        if self._updatable:
+            self._updatable.deselect()

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -267,6 +267,11 @@ class Point(object):
     def __repr__(self) -> str:
         return "{}:{}".format(self.row, self.col)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Point):
+            raise NotImplementedError()
+        return self.row == other.row and self.col == other.col
+
     @classmethod
     def from_lsp(cls, point: dict) -> 'Point':
         return Point(point['line'], point['character'])
@@ -285,6 +290,12 @@ class Range(object):
 
     def __repr__(self) -> str:
         return "({} {})".format(self.start, self.end)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Range):
+            raise NotImplementedError()
+
+        return self.start == other.start and self.end == other.end
 
     @classmethod
     def from_lsp(cls, range: dict) -> 'Range':
@@ -387,6 +398,15 @@ class Diagnostic(object):
 
     def to_lsp(self) -> 'Dict[str, Any]':
         return self._lsp_diagnostic
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Diagnostic):
+            raise NotImplementedError()
+
+        return self.message == other.message and self.range == other.range
+
+    def __repr__(self) -> str:
+        return str(self.range) + ":" + self.message
 
 
 class WorkspaceFolder:

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -1,4 +1,5 @@
 import unittest
+from collections import OrderedDict
 from unittest import mock
 from .diagnostics import DiagnosticsStorage, DiagnosticsWalker, DiagnosticsCursor, CURSOR_FORWARD, CURSOR_BACKWARD
 from .protocol import Diagnostic, Point, Range, DiagnosticSeverity
@@ -24,7 +25,7 @@ def at_row(row: int) -> Diagnostic:
 
 def diagnostics(test_file_diags: 'List[Diagnostic]',
                 second_file_diags: 'List[Diagnostic]' = []) -> 'Dict[str, Dict[str, List[Diagnostic]]]':
-    diags = {}
+    diags = OrderedDict()  # type: Dict[str, Dict[str, List[Diagnostic]]]
     if test_file_diags:
         source_diags = {}
         source_diags[test_server_name] = test_file_diags

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -145,6 +145,14 @@ test_diagnostics = diagnostics([row1, info, row5], [row3])
 
 class DiagnosticsCursorTest(unittest.TestCase):
 
+    def test_debug_walk_order(self) -> None:
+        for file_path, server_diagnostics in test_diagnostics.items():
+            print(file_path)
+            for server_name, diagnostics in server_diagnostics.items():
+                print(server_name)
+                for diagnostic in diagnostics:
+                    print(diagnostic)
+
     def test_empty(self) -> None:
         cursor = DiagnosticsCursor()
 

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -138,7 +138,9 @@ class DiagnosticsWalkerTests(unittest.TestCase):
 row1 = at_row(1)
 row5 = at_row(5)
 row3 = at_row(3)
-test_diagnostics = diagnostics([row1, row5], [row3])
+info = at_row(4)
+info.severity = DiagnosticSeverity.Information
+test_diagnostics = diagnostics([row1, info, row5], [row3])
 
 
 class DiagnosticsCursorTest(unittest.TestCase):

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -1,9 +1,18 @@
 import unittest
 from .diagnostics import DiagnosticsStorage
 from .protocol import Diagnostic, Range, Point
-# from .configurations import WindowConfigManager, _merge_dicts, ConfigManager, is_supported_syntax
-# from .test_session import test_config, test_language
 from .test_protocol import LSP_MINIMAL_DIAGNOSTIC
+
+
+test_file_path = "/test.py"
+test_file_uri = "file:///test.py"
+minimal_diagnostic = Diagnostic.from_lsp(LSP_MINIMAL_DIAGNOSTIC)
+
+def make_update(diagnostics: 'List[dict]') -> dict:
+    return {
+        'uri': 'file:///test.py',
+        'diagnostics': diagnostics
+    }
 
 
 class DiagnosticsStorageTest(unittest.TestCase):
@@ -11,45 +20,30 @@ class DiagnosticsStorageTest(unittest.TestCase):
     def test_empty_diagnostics(self):
         wd = DiagnosticsStorage(None)
         self.assertEqual(wd.get_by_file(__file__), {})
+        self.assertEqual(wd.get(), {})
 
-        # todo: remove
+    def test_receive_diagnostics(self):
+        ui = unittest.mock.Mock()
+        wd = DiagnosticsStorage(ui)
 
-    def test_updated_diagnostics(self):
-        wd = DiagnosticsStorage(None)
-
-        test_file_path = "test.py"
-        diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict(), [])
-
-        wd.update(test_file_path, "test_server", [diag])
+        wd.receive("test_server", make_update([LSP_MINIMAL_DIAGNOSTIC]))
         view_diags = wd.get_by_file(test_file_path)
         self.assertEqual(len(view_diags["test_server"]), 1)
-        self.assertEqual(view_diags["test_server"][0], diag)
+        self.assertEqual(view_diags["test_server"][0].message, LSP_MINIMAL_DIAGNOSTIC['message'])
+        self.assertIn(test_file_path, wd.get())
+        ui.update.assert_called_with(test_file_path, "test_server", {'/test.py': {'test_server': [minimal_diagnostic]}})
 
-        wd.update(test_file_path, "test_server", [])
+        wd.receive("test_server", make_update([]))
         view_diags = wd.get_by_file(test_file_path)
         self.assertEqual(len(view_diags), 0)
-
-    def test_handle_diagnostics_update(self):
-        wd = DiagnosticsStorage(None)
-
-        test_file_path = "/test.py"
-        update = {
-            'uri': 'file:///test.py',
-            'diagnostics': [LSP_MINIMAL_DIAGNOSTIC]
-        }
-
-        wd.receive("test_server", update)
-
-        view_diags = wd.get_by_file(test_file_path)
-        self.assertEqual(len(view_diags["test_server"]), 1)
+        self.assertEqual(wd.get(), {})
+        ui.update.assert_called_with(test_file_path, "test_server", {})
 
     def test_remove_diagnostics(self):
-        wd = DiagnosticsStorage(None)
+        ui = unittest.mock.Mock()
+        wd = DiagnosticsStorage(ui)
 
-        test_file_path = "test.py"
-        diag = Diagnostic('message', Range(Point(0, 0), Point(1, 1)), 1, None, dict(), [])
-
-        wd.update(test_file_path, "test_server", [diag])
+        wd.receive("test_server", make_update([LSP_MINIMAL_DIAGNOSTIC]))
         view_diags = wd.get_by_file(test_file_path)
         self.assertEqual(len(view_diags["test_server"]), 1)
 
@@ -57,3 +51,31 @@ class DiagnosticsStorageTest(unittest.TestCase):
 
         view_diags = wd.get_by_file(test_file_path)
         self.assertEqual(len(view_diags), 0)
+        self.assertEqual(wd.get(), {})
+        ui.update.assert_called_with(test_file_path, "test_server", {})
+
+    def test_clear_diagnostics(self):
+        ui = unittest.mock.Mock()
+        wd = DiagnosticsStorage(ui)
+
+        wd.receive("test_server", make_update([LSP_MINIMAL_DIAGNOSTIC]))
+        wd.clear()
+
+        view_diags = wd.get_by_file(test_file_path)
+        self.assertEqual(len(view_diags), 0)
+        self.assertEqual(wd.get(), {})
+        ui.update.assert_called_with(test_file_path, "test_server", {})
+
+    def test_select(self):
+        ui = unittest.mock.Mock()
+        wd = DiagnosticsStorage(ui)
+
+        wd.select_next()
+        ui.select.assert_called_with(1)
+
+        wd.select_previous()
+        ui.select.assert_called_with(-1)
+
+        wd.select_none()
+        ui.deselect.assert_called()
+

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 from .diagnostics import DiagnosticsStorage, DiagnosticsWalker
 from .protocol import Diagnostic
 from .test_protocol import LSP_MINIMAL_DIAGNOSTIC
@@ -29,7 +30,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
         self.assertEqual(wd.get(), {})
 
     def test_receive_diagnostics(self):
-        ui = unittest.mock.Mock()
+        ui = mock.Mock()
         wd = DiagnosticsStorage(ui)
 
         wd.receive("test_server", make_update([LSP_MINIMAL_DIAGNOSTIC]))
@@ -46,7 +47,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
         ui.update.assert_called_with(test_file_path, "test_server", {})
 
     def test_remove_diagnostics(self):
-        ui = unittest.mock.Mock()
+        ui = mock.Mock()
         wd = DiagnosticsStorage(ui)
 
         wd.receive("test_server", make_update([LSP_MINIMAL_DIAGNOSTIC]))
@@ -61,7 +62,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
         ui.update.assert_called_with(test_file_path, "test_server", {})
 
     def test_clear_diagnostics(self):
-        ui = unittest.mock.Mock()
+        ui = mock.Mock()
         wd = DiagnosticsStorage(ui)
 
         wd.receive("test_server", make_update([LSP_MINIMAL_DIAGNOSTIC]))
@@ -73,7 +74,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
         ui.update.assert_called_with(test_file_path, "test_server", {})
 
     def test_select(self):
-        ui = unittest.mock.Mock()
+        ui = mock.Mock()
         wd = DiagnosticsStorage(ui)
 
         wd.select_next()
@@ -89,7 +90,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
 class DiagnosticsWalkerTests(unittest.TestCase):
 
     def test_empty(self):
-        walk = unittest.mock.Mock()
+        walk = mock.Mock()
         walker = DiagnosticsWalker([walk])
         walker.walk({})
 
@@ -100,7 +101,7 @@ class DiagnosticsWalkerTests(unittest.TestCase):
 
     def test_one_diagnosic(self):
 
-        walk = unittest.mock.Mock()
+        walk = mock.Mock()
         walker = DiagnosticsWalker([walk])
         diags = {}  # type: Dict[str, Dict[str, List[Diagnostic]]]
         diags[test_file_path] = {}

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -1,5 +1,5 @@
 import unittest
-from .diagnostics import DiagnosticsStorage
+from .diagnostics import DiagnosticsStorage, DiagnosticsWalker
 from .protocol import Diagnostic, Range, Point
 from .test_protocol import LSP_MINIMAL_DIAGNOSTIC
 
@@ -78,4 +78,31 @@ class DiagnosticsStorageTest(unittest.TestCase):
 
         wd.select_none()
         ui.deselect.assert_called()
+
+
+class DiagnosticsWalkerTests(unittest.TestCase):
+
+    def test_empty(self):
+        walk = unittest.mock.Mock()
+        walker = DiagnosticsWalker([walk])
+        walker.walk({})
+
+        walk.begin.assert_called_once()
+        walk.begin_file.assert_not_called()
+        walk.diagnostic.assert_not_called()
+        walk.end.assert_called_once()
+
+    def test_one_diagnosic(self):
+
+        walk = unittest.mock.Mock()
+        walker = DiagnosticsWalker([walk])
+        diags = {}
+        diags[test_file_path] = {}
+        diags[test_file_path]["test_server"] = [minimal_diagnostic]
+        walker.walk(diags)
+
+        walk.begin.assert_called_once()
+        walk.begin_file.assert_called_with(test_file_path)
+        walk.diagnostic.assert_called_with(minimal_diagnostic)
+        walk.end.assert_called_once()
 

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -1,12 +1,18 @@
 import unittest
 from .diagnostics import DiagnosticsStorage, DiagnosticsWalker
-from .protocol import Diagnostic, Range, Point
+from .protocol import Diagnostic
 from .test_protocol import LSP_MINIMAL_DIAGNOSTIC
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import List, Dict
+    assert List and Dict
 
 
 test_file_path = "/test.py"
 test_file_uri = "file:///test.py"
 minimal_diagnostic = Diagnostic.from_lsp(LSP_MINIMAL_DIAGNOSTIC)
+
 
 def make_update(diagnostics: 'List[dict]') -> dict:
     return {
@@ -96,7 +102,7 @@ class DiagnosticsWalkerTests(unittest.TestCase):
 
         walk = unittest.mock.Mock()
         walker = DiagnosticsWalker([walk])
-        diags = {}
+        diags = {}  # type: Dict[str, Dict[str, List[Diagnostic]]]
         diags[test_file_path] = {}
         diags[test_file_path]["test_server"] = [minimal_diagnostic]
         walker.walk(diags)
@@ -105,4 +111,3 @@ class DiagnosticsWalkerTests(unittest.TestCase):
         walk.begin_file.assert_called_with(test_file_path)
         walk.diagnostic.assert_called_with(minimal_diagnostic)
         walk.end.assert_called_once()
-

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -180,12 +180,20 @@ class DiagnosticsCursorTest(unittest.TestCase):
         walker.walk(test_diagnostics)
         self.assertEqual((test_file_path, row5), cursor.value)
 
-    def test_from_other_file_position(self) -> None:
+    def test_from_other_file_position_wrap(self) -> None:
         cursor = DiagnosticsCursor()
 
         walker = DiagnosticsWalker([cursor.from_position(CURSOR_FORWARD, second_file_path, Point(5, 0))])
         walker.walk(test_diagnostics)
+
         self.assertEqual((test_file_path, row1), cursor.value)
+
+    def test_from_file_position_backward_wrap(self) -> None:
+        cursor = DiagnosticsCursor()
+
+        walker = DiagnosticsWalker([cursor.from_position(CURSOR_BACKWARD, test_file_path, Point(0, 0))])
+        walker.walk(test_diagnostics)
+        self.assertEqual((second_file_path, row3), cursor.value)
 
     def test_from_other_file_position_backwards(self) -> None:
         cursor = DiagnosticsCursor()

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -146,14 +146,6 @@ test_diagnostics = diagnostics([row1, info, row5], [row3])
 
 class DiagnosticsCursorTest(unittest.TestCase):
 
-    def test_debug_walk_order(self) -> None:
-        for file_path, server_diagnostics in test_diagnostics.items():
-            print(file_path)
-            for server_name, diagnostics in server_diagnostics.items():
-                print(server_name)
-                for diagnostic in diagnostics:
-                    print(diagnostic)
-
     def test_empty(self) -> None:
         cursor = DiagnosticsCursor()
 
@@ -269,10 +261,9 @@ class DiagnosticsCursorTest(unittest.TestCase):
         walker.walk(test_diagnostics)
         self.assertEqual((second_file_path, row3), cursor.value)
 
-        # TODO: do we need to wrap?
-        # walker = DiagnosticsWalker([cursor.from_diagnostic(CURSOR_FORWARD)])
-        # walker.walk(test_diagnostics)
-        # self.assertEqual((test_file_path, row1), cursor.value)
+        walker = DiagnosticsWalker([cursor.from_diagnostic(CURSOR_FORWARD)])
+        walker.walk(test_diagnostics)
+        self.assertEqual((test_file_path, row1), cursor.value)
 
     def test_from_diagnostic_backward(self) -> None:
 

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -174,7 +174,7 @@ class LspHideDiagnosticCommand(sublime_plugin.WindowCommand):
 
 class DiagnosticsPhantoms(object):
 
-    def __init__(self, window: sublime.Window):
+    def __init__(self, window: sublime.Window) -> None:
         self._window = window
         self._last_phantom_set = None  # type: 'Optional[sublime.PhantomSet]'
 

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -11,6 +11,7 @@ from .core.settings import settings, PLUGIN_NAME, client_configs
 from .core.views import range_to_region, region_to_range
 from .core.registry import windows
 from .core.windows import WindowManager
+from .core.diagnostics import DiagnosticsWalker, DiagnosticsUpdateWalk, DiagnosticsCursor, DocumentsState
 
 MYPY = False
 if MYPY:
@@ -222,6 +223,7 @@ class DiagnosticsPhantoms(object):
             self.navigate
         )
 
+    # TODO: share with hover?
     def format_diagnostic_related_info(self, info: DiagnosticRelatedInformation) -> str:
         file_path = info.location.file_path
         if self._base_dir and file_path.startswith(self._base_dir):
@@ -237,6 +239,7 @@ class DiagnosticsPhantoms(object):
         elif href == "previous":
             self._window.run_command("lsp_previous_diagnostic")
         elif href.startswith("location"):
+            # todo: share with hover?
             _, file_path, location = href.split(":", 2)
             file_path = os.path.join(self._base_dir, file_path) if self._base_dir else file_path
             self._window.open_file(file_path + ":" + location, sublime.ENCODED_POSITION | sublime.TRANSIENT)
@@ -259,108 +262,6 @@ class DiagnosticsPhantoms(object):
     def clear(self) -> None:
         if self._last_phantom_set:
             self._last_phantom_set.update([])
-
-
-class DocumentsState(Protocol):
-
-    def changed(self) -> None:
-        ...
-
-    def saved(self) -> None:
-        ...
-
-
-class DiagnosticsUpdateWalk(object):
-
-    def begin(self) -> None:
-        pass
-
-    def begin_file(self, file_path: str) -> None:
-        pass
-
-    def diagnostic(self, diagnostic: 'Diagnostic') -> None:
-        pass
-
-    def end_file(self, file_path: str) -> None:
-        pass
-
-    def end(self) -> None:
-        pass
-
-
-class DiagnosticsCursor(DiagnosticsUpdateWalk):
-    def __init__(self) -> None:
-        self.file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
-        self._first_file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
-        self._last_file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
-        self._previous_file_diagnostic = None  # type: 'Optional[Tuple[str, Diagnostic]]'
-        self._select_offset = 0
-        self._debug_index = -1
-
-    def select_offset(self, offset: int, file_path: 'Optional[str]' = None, point: 'Optional[Point]' = None) -> None:
-        self._select_offset = offset
-        self._select_file_path = file_path
-        self._select_point = point
-
-    def begin(self) -> None:
-        self._found = False
-        self._debug_index = -1
-        self._first_file_diagnostic = None
-        self._last_file_diagnostic = None
-        self._nearest_file_diagnostic = None  # type: Optional[Tuple[str, Diagnostic]]
-        self._previous_file_diagnostic = self.file_diagnostic
-        self.file_diagnostic = None
-
-    def begin_file(self, file_path: str) -> None:
-        self._current_file_path = file_path
-
-    def diagnostic(self, diagnostic: 'Diagnostic') -> None:
-        if diagnostic.severity <= DiagnosticSeverity.Warning:
-            if not self._found:
-                if not self._first_file_diagnostic:
-                    self._first_file_diagnostic = self._current_file_path, diagnostic
-
-                if self._select_offset == -1:
-                    if self._previous_file_diagnostic and diagnostic == self._previous_file_diagnostic[1]:
-                        if self._last_file_diagnostic:
-                            self.file_diagnostic = self._last_file_diagnostic
-                            self._found = True
-
-                elif self._select_offset == 1:
-                    if self._last_file_diagnostic and self._previous_file_diagnostic and self._previous_file_diagnostic[
-                            1] == self._last_file_diagnostic[1]:
-                        self.file_diagnostic = self._current_file_path, diagnostic
-                        self._found = True
-
-                # update nearest candidate
-                if not self._found and self._select_file_path and self._select_point and\
-                        self._current_file_path == self._select_file_path:
-                    self._update_nearest_candidate(diagnostic, self._select_point)
-
-                self._last_file_diagnostic = self._current_file_path, diagnostic
-
-    def _update_nearest_candidate(self, diagnostic: Diagnostic, point: Point) -> None:
-        if self._select_offset == -1:
-            if diagnostic.range.start.row < point.row:
-                if not self._nearest_file_diagnostic or diagnostic.range.start.row > self._nearest_file_diagnostic[
-                        1].range.start.row:
-                    self._nearest_file_diagnostic = self._current_file_path, diagnostic
-        elif self._select_offset == 1:
-            if diagnostic.range.start.row > point.row:
-                if not self._nearest_file_diagnostic or diagnostic.range.start.row < self._nearest_file_diagnostic[
-                        1].range.start.row:
-                    self._nearest_file_diagnostic = self._current_file_path, diagnostic
-
-    def end(self) -> None:
-        if not self.file_diagnostic:
-            if self._select_offset == -1 and self._previous_file_diagnostic == self._first_file_diagnostic:
-                self.file_diagnostic = self._last_file_diagnostic
-            elif self._select_offset == 1 and self._previous_file_diagnostic == self._last_file_diagnostic:
-                self.file_diagnostic = self._first_file_diagnostic
-            elif self._nearest_file_diagnostic:  # a match before/after in the current file
-                self.file_diagnostic = self._nearest_file_diagnostic
-
-        self._select_offset = 0
 
 
 class DiagnosticViewRegions(DiagnosticsUpdateWalk):
@@ -398,33 +299,6 @@ class DiagnosticViewRegions(DiagnosticsUpdateWalk):
                     UNDERLINE_FLAGS if settings.diagnostics_highlight_style == "underline" else BOX_FLAGS)
             else:
                 self._view.erase_regions(region_name)
-
-
-class DiagnosticsWalker(object):
-    """ Iterate over diagnostics structure"""
-
-    def __init__(self, subs: 'List[DiagnosticsUpdateWalk]') -> None:
-        self._subscribers = subs
-
-    def walk(self, diagnostics_by_file: 'Dict[str, Dict[str, List[Diagnostic]]]') -> None:
-        self.invoke_each(lambda w: w.begin())
-
-        if diagnostics_by_file:
-            for file_path, source_diagnostics in diagnostics_by_file.items():
-
-                self.invoke_each(lambda w: w.begin_file(file_path))
-
-                for origin, diagnostics in source_diagnostics.items():
-                    for diagnostic in diagnostics:
-                        self.invoke_each(lambda w: w.diagnostic(diagnostic))
-
-                self.invoke_each(lambda w: w.end_file(file_path))
-
-        self.invoke_each(lambda w: w.end())
-
-    def invoke_each(self, func: 'Callable[[DiagnosticsUpdateWalk], None]') -> None:
-        for sub in self._subscribers:
-            func(sub)
 
 
 class HasRelevantDiagnostics(DiagnosticsUpdateWalk):

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -214,8 +214,9 @@ class DiagnosticsPhantoms(object):
 
         additional_infos = "<br>".join([self.format_diagnostic_related_info(info) for info in diagnostic.related_info])
         severity = "error" if diagnostic.severity == DiagnosticSeverity.Error else "warning"
-        content = message + "<p class='additional'>" + additional_infos + "</p>" if additional_infos else message
-        markup = self.create_phantom_html(content, severity)
+        additional_content = "<p>" + additional_infos + "</p>" if additional_infos else ""
+
+        markup = self.create_phantom_html(message, severity, additional_content)
         return sublime.Phantom(
             region,
             markup,
@@ -244,8 +245,12 @@ class DiagnosticsPhantoms(object):
             file_path = os.path.join(self._base_dir, file_path) if self._base_dir else file_path
             self._window.open_file(file_path + ":" + location, sublime.ENCODED_POSITION | sublime.TRANSIENT)
 
-    def create_phantom_html(self, content: str, severity: str) -> str:
+    def create_phantom_html(self, content: str, severity: str, additional: str = "") -> str:
         stylesheet = sublime.load_resource("Packages/LSP/phantoms.css")
+        additional_markup = """<div class="content-additional">
+                            <div class="content-additional-inner">{}</div>
+                        </div>""".format(additional) if additional else ""
+
         return """<body id=inline-error>
                     <style>{}</style>
                     <div class="{}-arrow"></div>
@@ -256,8 +261,9 @@ class DiagnosticsPhantoms(object):
                             <a href="next">↓</a>
                         </div>
                         <div class="content">{}</div>
+                        {}
                     </div>
-                </body>""".format(stylesheet, severity, severity, content)
+                </body>""".format(stylesheet, severity, severity, content, additional_markup)
 
     def clear(self) -> None:
         if self._last_phantom_set:

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -213,7 +213,7 @@ class DiagnosticsPhantoms(object):
 
         additional_infos = "<br>".join([self.format_diagnostic_related_info(info) for info in diagnostic.related_info])
         severity = "error" if diagnostic.severity == DiagnosticSeverity.Error else "warning"
-        content = message + "<p>" + additional_infos + "</p>" if additional_infos else message
+        content = message + "<p class='additional'>" + additional_infos + "</p>" if additional_infos else message
         markup = self.create_phantom_html(content, severity)
         return sublime.Phantom(
             region,

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -308,28 +308,29 @@ class DiagnosticsCursor(DiagnosticsUpdateWalk):
         self._current_file_path = file_path
 
     def diagnostic(self, diagnostic: 'Diagnostic') -> None:
-        if not self._found:
-            if not self._first_file_diagnostic:
-                self._first_file_diagnostic = self._current_file_path, diagnostic
+        if diagnostic.severity <= DiagnosticSeverity.Warning:
+            if not self._found:
+                if not self._first_file_diagnostic:
+                    self._first_file_diagnostic = self._current_file_path, diagnostic
 
-            if self._select_offset == -1:
-                if self._previous_file_diagnostic and diagnostic == self._previous_file_diagnostic[1]:
-                    if self._last_file_diagnostic:
-                        self.file_diagnostic = self._last_file_diagnostic
+                if self._select_offset == -1:
+                    if self._previous_file_diagnostic and diagnostic == self._previous_file_diagnostic[1]:
+                        if self._last_file_diagnostic:
+                            self.file_diagnostic = self._last_file_diagnostic
+                            self._found = True
+
+                elif self._select_offset == 1:
+                    if self._last_file_diagnostic and self._previous_file_diagnostic and self._previous_file_diagnostic[
+                            1] == self._last_file_diagnostic[1]:
+                        self.file_diagnostic = self._current_file_path, diagnostic
                         self._found = True
 
-            elif self._select_offset == 1:
-                if self._last_file_diagnostic and self._previous_file_diagnostic and self._previous_file_diagnostic[
-                        1] == self._last_file_diagnostic[1]:
-                    self.file_diagnostic = self._current_file_path, diagnostic
-                    self._found = True
+                # update nearest candidate
+                if not self._found and self._select_file_path and self._select_point and\
+                        self._current_file_path == self._select_file_path:
+                    self._update_nearest_candidate(diagnostic, self._select_point)
 
-            # update nearest candidate
-            if not self._found and self._select_file_path and self._select_point and\
-                    self._current_file_path == self._select_file_path:
-                self._update_nearest_candidate(diagnostic, self._select_point)
-
-            self._last_file_diagnostic = self._current_file_path, diagnostic
+                self._last_file_diagnostic = self._current_file_path, diagnostic
 
     def _update_nearest_candidate(self, diagnostic: Diagnostic, point: Point) -> None:
         if self._select_offset == -1:

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -232,6 +232,10 @@ class DiagnosticsPhantoms(object):
     def navigate(self, href: str) -> None:
         if href == "hide":
             self.clear()
+        elif href == "next":
+            self._window.run_command("lsp_next_diagnostic")
+        elif href == "previous":
+            self._window.run_command("lsp_previous_diagnostic")
         elif href.startswith("location"):
             _, file_path, location = href.split(":", 2)
             file_path = os.path.join(self._base_dir, file_path) if self._base_dir else file_path
@@ -244,6 +248,8 @@ class DiagnosticsPhantoms(object):
                     <div class="{} container">
                         <div class="toolbar">
                             <a href="hide">×</a>
+                            <a href="previous">↑</a>
+                            <a href="next">↓</a>
                         </div>
                         <div class="content">{}</div>
                     </div>

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -191,9 +191,10 @@ class DiagnosticsPhantoms(object):
                 self.apply_phantom(view, diagnostic)
         else:
             if self._last_phantom_set:
+                view = self._last_phantom_set.view
                 has_phantom = view.settings().get('lsp_diagnostic_phantom')
                 if not has_phantom:
-                    self._last_phantom_set.view.settings().set('lsp_diagnostic_phantom', False)
+                    view.settings().set('lsp_diagnostic_phantom', False)
 
     def apply_phantom(self, view: sublime.View, diagnostic: Diagnostic) -> None:
         phantom_set = sublime.PhantomSet(view, "lsp_diagnostics")

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -214,9 +214,8 @@ class DiagnosticsPhantoms(object):
 
         additional_infos = "<br>".join([self.format_diagnostic_related_info(info) for info in diagnostic.related_info])
         severity = "error" if diagnostic.severity == DiagnosticSeverity.Error else "warning"
-        additional_content = "<p>" + additional_infos + "</p>" if additional_infos else ""
-
-        markup = self.create_phantom_html(message, severity, additional_content)
+        content = message + "<p class='additional'>" + additional_infos + "</p>" if additional_infos else message
+        markup = self.create_phantom_html(content, severity)
         return sublime.Phantom(
             region,
             markup,
@@ -245,12 +244,8 @@ class DiagnosticsPhantoms(object):
             file_path = os.path.join(self._base_dir, file_path) if self._base_dir else file_path
             self._window.open_file(file_path + ":" + location, sublime.ENCODED_POSITION | sublime.TRANSIENT)
 
-    def create_phantom_html(self, content: str, severity: str, additional: str = "") -> str:
+    def create_phantom_html(self, content: str, severity: str) -> str:
         stylesheet = sublime.load_resource("Packages/LSP/phantoms.css")
-        additional_markup = """<div class="content-additional">
-                            <div class="content-additional-inner">{}</div>
-                        </div>""".format(additional) if additional else ""
-
         return """<body id=inline-error>
                     <style>{}</style>
                     <div class="{}-arrow"></div>
@@ -261,9 +256,8 @@ class DiagnosticsPhantoms(object):
                             <a href="next">↓</a>
                         </div>
                         <div class="content">{}</div>
-                        {}
                     </div>
-                </body>""".format(stylesheet, severity, severity, content, additional_markup)
+                </body>""".format(stylesheet, severity, severity, content)
 
     def clear(self) -> None:
         if self._last_phantom_set:

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -209,11 +209,11 @@ class DiagnosticsPhantoms(object):
     def create_phantom(self, view: sublime.View, diagnostic: Diagnostic) -> sublime.Phantom:
         region = range_to_region(diagnostic.range, view)
         line = "[{}] {}".format(diagnostic.source, diagnostic.message) if diagnostic.source else diagnostic.message
-        message = "<br>".join(html.escape(line, quote=False) for line in line.splitlines())
+        message = "<p>" + "<br>".join(html.escape(line, quote=False) for line in line.splitlines()) + "</p>"
 
         additional_infos = "<br>".join([self.format_diagnostic_related_info(info) for info in diagnostic.related_info])
         severity = "error" if diagnostic.severity == DiagnosticSeverity.Error else "warning"
-        content = message + "<br>" + additional_infos if additional_infos else message
+        content = message + "<p>" + additional_infos + "</p>" if additional_infos else message
         markup = self.create_phantom_html(content, severity)
         return sublime.Phantom(
             region,
@@ -245,6 +245,7 @@ class DiagnosticsPhantoms(object):
         stylesheet = sublime.load_resource("Packages/LSP/phantoms.css")
         return """<body id=inline-error>
                     <style>{}</style>
+                    <div class="{}-arrow"></div>
                     <div class="{} container">
                         <div class="toolbar">
                             <a href="hide">×</a>
@@ -253,7 +254,7 @@ class DiagnosticsPhantoms(object):
                         </div>
                         <div class="content">{}</div>
                     </div>
-                </body>""".format(stylesheet, severity, content)
+                </body>""".format(stylesheet, severity, severity, content)
 
     def clear(self) -> None:
         if self._last_phantom_set:


### PR DESCRIPTION
Press  <kbd>F8</kbd> to open/next, <kbd>shift+F8</kbd> for previous, <kbd>esc</kbd> to close. (see suggested keybindings)

<img width="400" alt="Screenshot 2019-11-22 at 10 34 08" src="https://user-images.githubusercontent.com/4395832/69414774-add24600-0d13-11ea-86ef-314fc7d0b4a3.png">

<img width="342" alt="Screenshot 2019-11-26 at 15 19 08" src="https://user-images.githubusercontent.com/4395832/69641237-23198000-1060-11ea-98ed-fa32c2a80941.png">

Essentially like VS Code's "Next Problem" feature. 

Suggested keybindings
```json
{ "keys": ["f8"], "command": "lsp_next_diagnostic"},
{ "keys": ["shift+f8"], "command": "lsp_previous_diagnostic"},
{ "keys": ["escape"], "command": "lsp_hide_diagnostic", "context":
	[
		{ "key": "setting.lsp_diagnostic_phantom"}
	]
}
```

Closes #746:
* Allows navigation for those who don't like to use the panel for it (SublimeLinter style)
* Allows a faster and more readable way to see a diagnostic + related info than hovering.

Implementation details:
* The DiagnosticsPresenter passes user actions (forward/back) and server diagnostic updates into the DiagnosticsCursor
* The cursor selects a different walking logic based on an already-selected diagnostic or a cursor position in a file.
* The Escape key is "stolen" if the view has a `lsp_diagnostic_phantom` setting applied. There is some risk with stealing a so often-used key.
* Phantoms are not hidden if a diagnostic disappears.

To do:
- [x] Implement UI + wire up Esc for dismissing phantoms
- [x] Implement UI for related info
- <strike> Update UI for code actions (if keeping at all)</strike>
- [x] Review behaviour when diagnostics removed/moved/added.
- [x] Only include warnings and errors (See https://github.com/Microsoft/vscode/issues/45436)
- [x] UI polish (add prev/next, related info spacing and color, top arrow, rounded corners?)
- [x] Organize diagnostics code and add unit tests
