### PR TITLE
Add elixir-ls support

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -297,6 +297,19 @@
         "Packages/Dart/Dart.tmLanguage"
       ]
     },
+    "elixir-ls": {
+      "command": [
+        // Specify path to language_server.sh from https://github.com/elixir-lsp/elixir-ls here
+        // "/home/someUser/somePlace/elixir-ls/release/language_server.sh"
+      ],
+      "languageId": "elixir",
+      "scopes": ["source.elixir"],
+      "settings": {
+      },
+      "syntaxes": [
+        "Packages/Elixir/Syntaxes/Elixir.tmLanguage",
+      ]
+    },
     "flow":
     {
       "command": ["flow", "lsp"],

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Documentation is available at [LSP.readthedocs.io](https://LSP.readthedocs.io).
 * [D](https://lsp.readthedocs.io/en/latest/#d)
 * [Dart](https://lsp.readthedocs.io/en/latest/#dart)
 * [Elm](https://lsp.readthedocs.io/en/latest/#elm)
+* [Elixir](https://lsp.readthedocs.io/en/latest/#elixir)
 * [Flow (JavaScript)](https://lsp.readthedocs.io/en/latest/#flow)
 * [Go](https://lsp.readthedocs.io/en/latest/#go)
 * [HTML](https://lsp.readthedocs.io/en/latest/#html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -408,6 +408,26 @@ For more details see this [issue](https://github.com/PowerShell/PowerShellEditor
 }
 ```
 
+### Elixir
+
+1. Download the prebuilt binaries or compile [elixir-ls](https://github.com/elixir-lsp/elixir-ls). This will get you a folder containing `language_server.sh` among other things
+2. Download the official [Elixir package](https://packagecontrol.io/packages/Elixir) for syntax definitions
+3. Update the elixir-ls configuration to point to your `language_server.sh`
+
+```
+    "elixir-ls": {
+      "command": ["/home/someUser/somePlace/elixir-ls/release/language_server.sh"],
+      "enabled": true,
+      "languageId": "elixir",
+      "scopes": ["source.elixir"],
+      "settings": {
+      },
+      "syntaxes": [
+        "Packages/Elixir/Syntaxes/Elixir.tmLanguage",
+      ]
+    },
+```
+
 ### XML
 
 Discussed in [this issue](https://github.com/tomv564/LSP/issues/578)


### PR DESCRIPTION
Add configuration and instructions to make [elixir-ls](https://github.com/elixir-lsp/elixir-ls) work

Sadly still needs a bit of manual configuration since this probably won't ever be in the path