### PR TITLE
Advertise keybindings in the command palette

### DIFF
--- a/Commands/Default.sublime-commands
+++ b/Commands/Default.sublime-commands
@@ -11,6 +11,7 @@
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/LSP/Keymaps/Default (${platform}).sublime-keymap",
+            "user_file": "${packages}/User/Default ($platform).sublime-keymap",
             "default": "// Settings in here override those in \"LSP/Keymaps/Default (${platform}).sublime-keymap\",\n\n{\n\t$0\n}\n"}
     },
     {

--- a/Commands/Default.sublime-commands
+++ b/Commands/Default.sublime-commands
@@ -7,6 +7,13 @@
           "default": "// Settings in here override those in \"LSP/LSP.sublime-settings\",\n\n{\n\t$0\n}\n"}
     },
     {
+        "caption": "Preferences: LSP Keybindings",
+        "command": "edit_settings",
+        "args": {
+            "base_file": "${packages}/LSP/Keymaps/Default (${platform}).sublime-keymap",
+            "default": "// Settings in here override those in \"LSP/Keymaps/Default (${platform}).sublime-keymap\",\n\n{\n\t$0\n}\n"}
+    },
+    {
         "caption": "LSP: Setup Language Server",
         "command": "lsp_setup_language_server",
         "args": {}


### PR DESCRIPTION
In the style of GitSavvy, Terminus, etcetera.
It chooses the correct keybinding file based on the ${platform}.