### PR TITLE
Apply severity filter to diagnostics panel and navigation, not underline/hover

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -14,7 +14,7 @@
   // warning: 2
   // info: 3
   // hint: 4
-  "auto_show_diagnostics_panel_level": 3,
+  "auto_show_diagnostics_panel_level": 2,
 
   // Show errors and warnings count in the status bar
   "show_diagnostics_count_in_view_status": false,
@@ -29,7 +29,7 @@
   // warning: 2
   // info: 3
   // hint: 4
-  "show_diagnostics_severity_level": 3,
+  "show_diagnostics_severity_level": 2,
 
   // Highlighting style of code diagnostics.
   // Valid values are "underline" or "box"

--- a/plugin/core/settings.py
+++ b/plugin/core/settings.py
@@ -66,11 +66,11 @@ def update_settings(settings: Settings, settings_obj: sublime.Settings) -> None:
     settings.auto_show_diagnostics_panel = read_auto_show_diagnostics_panel_setting(settings_obj,
                                                                                     "auto_show_diagnostics_panel",
                                                                                     'always')
-    settings.auto_show_diagnostics_panel_level = read_int_setting(settings_obj, "auto_show_diagnostics_panel_level", 3)
+    settings.auto_show_diagnostics_panel_level = read_int_setting(settings_obj, "auto_show_diagnostics_panel_level", 2)
     settings.show_diagnostics_count_in_view_status = read_bool_setting(settings_obj,
                                                                        "show_diagnostics_count_in_view_status", False)
     settings.show_diagnostics_in_view_status = read_bool_setting(settings_obj, "show_diagnostics_in_view_status", True)
-    settings.show_diagnostics_severity_level = read_int_setting(settings_obj, "show_diagnostics_severity_level", 3)
+    settings.show_diagnostics_severity_level = read_int_setting(settings_obj, "show_diagnostics_severity_level", 2)
     settings.diagnostics_highlight_style = read_str_setting(settings_obj, "diagnostics_highlight_style", "underline")
     settings.document_highlight_style = read_str_setting(settings_obj, "document_highlight_style", "stippled")
     settings.document_highlight_scopes = read_dict_setting(settings_obj, "document_highlight_scopes",

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -13,10 +13,10 @@ class Settings(object):
         self.show_status_messages = True
         self.show_view_status = True
         self.auto_show_diagnostics_panel = 'always'
-        self.auto_show_diagnostics_panel_level = 3
+        self.auto_show_diagnostics_panel_level = 2
         self.show_diagnostics_count_in_view_status = False
         self.show_diagnostics_in_view_status = True
-        self.show_diagnostics_severity_level = 3
+        self.show_diagnostics_severity_level = 2
         self.only_show_lsp_completions = False
         self.diagnostics_highlight_style = "underline"
         self.document_highlight_style = "stippled"

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -368,7 +368,7 @@ class DiagnosticsPresenter(object):
         self._panel_update = DiagnosticOutputPanel(self._window)
         self._bar_summary_update = StatusBarSummary(self._window)
         self._relevance_check = HasRelevantDiagnostics()
-        self._cursor = DiagnosticsCursor()
+        self._cursor = DiagnosticsCursor(settings.show_diagnostics_severity_level)
         self._phantoms = DiagnosticsPhantoms(self._window)
         if settings.auto_show_diagnostics_panel == 'saved':
             setattr(documents_state, 'changed', self.on_document_changed)

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -259,14 +259,13 @@ class DiagnosticViewRegions(DiagnosticsUpdateWalk):
 
     def diagnostic(self, diagnostic: Diagnostic) -> None:
         if self._relevant_file:
-            if diagnostic.severity <= settings.show_diagnostics_severity_level:
-                self._regions.setdefault(diagnostic.severity, []).append(range_to_region(diagnostic.range, self._view))
+            self._regions.setdefault(diagnostic.severity, []).append(range_to_region(diagnostic.range, self._view))
 
     def end_file(self, file_name: str) -> None:
         self._relevant_file = False
 
     def end(self) -> None:
-        for severity in range(DiagnosticSeverity.Error, settings.show_diagnostics_severity_level):
+        for severity in range(DiagnosticSeverity.Error, DiagnosticSeverity.Hint):
             region_name = "lsp_" + format_severity(severity)
             if severity in self._regions:
                 regions = self._regions[severity]


### PR DESCRIPTION
Closes #795

Next/previous diagnostic was hardwired to Errors and Warnings, but as we have a setting controlling what the user thinks is relevant (`show_diagnostics_severity_level`), we should read that instead.

Also drops the severity filter for in-view diagnostic regions. This is because as a developer I want quick access to errors and warnings, but still want to see server suggestions somewhere.

- [x] Should the default for `show_diagnostics_severity_level` change from 3 (`info`) to 2 (`warning`) ?

- <strike>For those offended by `info` and `hint` squigglies in their code, should we expose `diagnostic_severity_scopes` as a setting? (We could drop some of the fallback scopes and give the user the chance to not set any scopes at all for some diagnostics)</strike> Can do this later.
