### PR TITLE
Replace undecodeable UTF-8 sequences by '?'

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -33,6 +33,10 @@ disallow_untyped_defs = False
 check_untyped_defs = True
 disallow_untyped_defs = False
 
+[mypy-plugin.core.test_process]
+check_untyped_defs = True
+disallow_untyped_defs = False
+
 [mypy-plugin.core.test_protocol]
 check_untyped_defs = True
 disallow_untyped_defs = False

--- a/plugin/core/process.py
+++ b/plugin/core/process.py
@@ -70,7 +70,7 @@ def log_stream(process: 'subprocess.Popen', stream: 'IO[Any]') -> None:
             content = stream.readline()
             if not content:
                 break
-            server_log('server', content.decode('UTF-8', 'replace'))
+            server_log('server', content.decode('UTF-8', 'replace').strip())
         except IOError as err:
             exception_log("Failure reading stream", err)
             return

--- a/plugin/core/process.py
+++ b/plugin/core/process.py
@@ -76,7 +76,7 @@ def log_stream(process: 'subprocess.Popen', stream: 'IO[Any]') -> None:
                 # There's nothing in the specification about what the encoding should be of stderr (or, in the case of a
                 # TCP transport, the encoding of stdout). Let's assume the encoding of the current locale.
                 # On Linux and macOS, this is UTF-8 (even when using a Dutch locale on macOS). On Windows, this might be
-                # cp1252.
+                # cp5212.
                 message = content.decode(preferred_encoding).strip()
             except UnicodeDecodeError:
                 message = "Unable to decode bytes! (tried decoding with {})".format(preferred_encoding)

--- a/plugin/core/process.py
+++ b/plugin/core/process.py
@@ -76,7 +76,7 @@ def log_stream(process: 'subprocess.Popen', stream: 'IO[Any]') -> None:
                 # There's nothing in the specification about what the encoding should be of stderr (or, in the case of a
                 # TCP transport, the encoding of stdout). Let's assume the encoding of the current locale.
                 # On Linux and macOS, this is UTF-8 (even when using a Dutch locale on macOS). On Windows, this might be
-                # cp5212.
+                # cp1252.
                 message = content.decode(preferred_encoding).strip()
             except UnicodeDecodeError:
                 message = "Unable to decode bytes! (tried decoding with {})".format(preferred_encoding)

--- a/plugin/core/process.py
+++ b/plugin/core/process.py
@@ -1,7 +1,8 @@
 from .logging import debug, exception_log, server_log
-import subprocess
+import locale
 import os
 import shutil
+import subprocess
 import threading
 
 try:
@@ -63,6 +64,7 @@ def log_stream(process: 'subprocess.Popen', stream: 'IO[Any]') -> None:
     Reads any errors from the LSP process.
     """
     running = True
+    preferred_encoding = locale.getpreferredencoding()
     while running:
         running = process.poll() is None
 
@@ -70,18 +72,14 @@ def log_stream(process: 'subprocess.Popen', stream: 'IO[Any]') -> None:
             content = stream.readline()
             if not content:
                 break
-            decoded = None  # type: Optional[str]
             try:
                 # There's nothing in the specification about what the encoding should be of stderr (or, in the case of a
-                # TCP transport, the encoding of stdout). Let's assume UTF-8.
-                decoded = content.decode("UTF-8")
+                # TCP transport, the encoding of stdout). Let's assume the encoding of the current locale.
+                # On Linux and macOS, this is UTF-8 (even when using a Dutch locale on macOS). On Windows, this might be
+                # cp5212.
+                message = content.decode(preferred_encoding).strip()
             except UnicodeDecodeError:
-                # Guess it wasn't UTF-8. Let's try UTF-16 as a last resort.
-                try:
-                    decoded = content.decode("UTF-16")
-                except UnicodeDecodeError:
-                    decoded = None
-            message = decoded.strip() if decoded is not None else "Unable to decode bytes! (tried UTF-8 and UTF-16)"
+                message = "Unable to decode bytes! (tried decoding with {})".format(preferred_encoding)
             server_log('server', message)
         except IOError as err:
             exception_log("Failure reading stream", err)

--- a/plugin/core/test_process.py
+++ b/plugin/core/test_process.py
@@ -1,0 +1,63 @@
+from .process import log_stream
+from contextlib import contextmanager
+from io import BytesIO, StringIO
+from subprocess import Popen
+from unittest import TestCase
+from unittest.mock import MagicMock
+import os
+import sys
+
+try:
+    from typing import Iterator
+    from typing import Tuple
+    assert Iterator and Tuple
+except ImportError:
+    pass
+
+
+@contextmanager
+def captured_output() -> 'Iterator[Tuple[StringIO, StringIO]]':
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+
+class ProcessTests(TestCase):
+
+    def do_test(self, encoded: bytes, expected: str):
+        process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
+        process.poll = MagicMock(return_value=None)  # type: ignore
+        stream = BytesIO(encoded)
+        with captured_output() as (out, err):
+            log_stream(process, stream)
+        self.assertEqual(out.getvalue().strip(), 'server: {}'.format(expected))
+        self.assertEqual(err.getvalue().strip(), '')
+
+    def test_log_stream_encoding_utf8(self):
+        # The unicode character
+        #
+        #    U+10000
+        #
+        # is encoded in UTF-8 as
+        #
+        #    0xF0 0x90 0x80 0x80
+        #
+        #  and in UTF-16 as
+        #
+        #    0xD800 0xDC00
+        #
+        # So let's use that character to do our tests. https://www.compart.com/en/unicode/U+10000
+        encoded_input = bytes((0xF0, 0x90, 0x80, 0x80))
+        expected_output = '\U00010000'
+        self.do_test(encoded_input, expected_output)
+
+    def test_log_stream_encoding_utf16(self):
+        # Here we encode U+10000 as something that can't be decoded by UTF-8, so log_stream should try to decode it as
+        # UTF-16 instead.
+        encoded_input = bytes((0x00, 0xD8, 0x00, 0xDC))
+        expected_output = '\U00010000'
+        self.do_test(encoded_input, expected_output)

--- a/plugin/core/test_process.py
+++ b/plugin/core/test_process.py
@@ -58,6 +58,11 @@ class ProcessTests(TestCase):
     def test_log_stream_encoding_utf16(self):
         # Here we encode U+10000 as something that can't be decoded by UTF-8, so log_stream should try to decode it as
         # UTF-16 instead.
-        encoded_input = bytes((0x00, 0xD8, 0x00, 0xDC))
+        encoded_input = bytes((0x00, 0xD8, 0x00, 0xDC))  # little endian...
         expected_output = '\U00010000'
+        self.do_test(encoded_input, expected_output)
+
+    def test_log_stream_encoding_failure(self):
+        encoded_input = bytes((0x00, 0xD8, 0x00))
+        expected_output = 'Unable to decode bytes! (tried UTF-8 and UTF-16)'
         self.do_test(encoded_input, expected_output)

--- a/plugin/core/test_process.py
+++ b/plugin/core/test_process.py
@@ -1,9 +1,11 @@
 from .process import log_stream
 from contextlib import contextmanager
-from io import BytesIO, StringIO
+from io import BytesIO
+from io import StringIO
 from subprocess import Popen
 from unittest import TestCase
 from unittest.mock import MagicMock
+import locale
 import os
 import sys
 
@@ -28,41 +30,37 @@ def captured_output() -> 'Iterator[Tuple[StringIO, StringIO]]':
 
 class ProcessTests(TestCase):
 
-    def do_test(self, encoded: bytes, expected: str):
+    def test_log_stream_encoding_utf8(self):
+        encoding = 'UTF-8'
         process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
         process.poll = MagicMock(return_value=None)  # type: ignore
-        stream = BytesIO(encoded)
+        text = '\U00010000'
         with captured_output() as (out, err):
-            log_stream(process, stream)
-        self.assertEqual(out.getvalue().strip(), 'server: {}'.format(expected))
+            log_stream(process, BytesIO(text.encode(encoding)))
+        self.assertEqual(out.getvalue().strip(), 'server: {}'.format(text))
         self.assertEqual(err.getvalue().strip(), '')
 
-    def test_log_stream_encoding_utf8(self):
-        # The unicode character
-        #
-        #    U+10000
-        #
-        # is encoded in UTF-8 as
-        #
-        #    0xF0 0x90 0x80 0x80
-        #
-        #  and in UTF-16 as
-        #
-        #    0xD800 0xDC00
-        #
-        # So let's use that character to do our tests. https://www.compart.com/en/unicode/U+10000
-        encoded_input = bytes((0xF0, 0x90, 0x80, 0x80))
-        expected_output = '\U00010000'
-        self.do_test(encoded_input, expected_output)
-
-    def test_log_stream_encoding_utf16(self):
-        # Here we encode U+10000 as something that can't be decoded by UTF-8, so log_stream should try to decode it as
-        # UTF-16 instead.
-        encoded_input = bytes((0x00, 0xD8, 0x00, 0xDC))  # little endian...
-        expected_output = '\U00010000'
-        self.do_test(encoded_input, expected_output)
+    def test_log_stream_encoding_preferred_locale(self):
+        encoding = locale.getpreferredencoding()
+        process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
+        process.poll = MagicMock(return_value=None)  # type: ignore
+        text = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ'
+        with captured_output() as (out, err):
+            log_stream(process, BytesIO(text.encode(encoding)))
+        self.assertEqual(out.getvalue().strip(), 'server: {}'.format(text))
+        self.assertEqual(err.getvalue().strip(), '')
 
     def test_log_stream_encoding_failure(self):
-        encoded_input = bytes((0x00, 0xD8, 0x00))
-        expected_output = 'Unable to decode bytes! (tried UTF-8 and UTF-16)'
-        self.do_test(encoded_input, expected_output)
+        encoding = locale.getpreferredencoding()
+        if encoding == "UTF-32-BE":
+            self.skipTest("this test doesn't work when the preferred encoding is UTF-32-BE")
+        process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
+        process.poll = MagicMock(return_value=None)  # type: ignore
+        with captured_output() as (out, err):
+            log_stream(process, BytesIO(bytes((0x00, 0x10, 0xFF, 0xFF))))  # U+10FFFF in UTF-32-BE
+        if encoding == "UTF-8":
+            expected = 'server: Unable to decode bytes! (tried UTF-8)'
+        else:
+            expected = 'server: Unable to decode bytes! (tried UTF-8 and {})'.format(encoding)
+        self.assertEqual(out.getvalue().strip(), expected)
+        self.assertEqual(err.getvalue().strip(), '')

--- a/plugin/core/test_process.py
+++ b/plugin/core/test_process.py
@@ -1,14 +1,11 @@
 from .process import log_stream
 from contextlib import contextmanager
-from io import BytesIO
-from io import StringIO
+from io import BytesIO, StringIO
 from subprocess import Popen
 from unittest import TestCase
 from unittest.mock import MagicMock
-import locale
 import os
 import sys
-
 
 try:
     from typing import Iterator
@@ -31,24 +28,41 @@ def captured_output() -> 'Iterator[Tuple[StringIO, StringIO]]':
 
 class ProcessTests(TestCase):
 
-    def test_log_stream_encoding(self):
-        encoding = locale.getpreferredencoding()
+    def do_test(self, encoded: bytes, expected: str):
         process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
         process.poll = MagicMock(return_value=None)  # type: ignore
-        text = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ'  # This specifically checks cp1252 compatibility for windows
-        stream = BytesIO(text.encode(encoding))
+        stream = BytesIO(encoded)
         with captured_output() as (out, err):
             log_stream(process, stream)
-        self.assertEqual(out.getvalue().strip(), 'server: {}'.format(text))
+        self.assertEqual(out.getvalue().strip(), 'server: {}'.format(expected))
         self.assertEqual(err.getvalue().strip(), '')
 
+    def test_log_stream_encoding_utf8(self):
+        # The unicode character
+        #
+        #    U+10000
+        #
+        # is encoded in UTF-8 as
+        #
+        #    0xF0 0x90 0x80 0x80
+        #
+        #  and in UTF-16 as
+        #
+        #    0xD800 0xDC00
+        #
+        # So let's use that character to do our tests. https://www.compart.com/en/unicode/U+10000
+        encoded_input = bytes((0xF0, 0x90, 0x80, 0x80))
+        expected_output = '\U00010000'
+        self.do_test(encoded_input, expected_output)
+
+    def test_log_stream_encoding_utf16(self):
+        # Here we encode U+10000 as something that can't be decoded by UTF-8, so log_stream should try to decode it as
+        # UTF-16 instead.
+        encoded_input = bytes((0x00, 0xD8, 0x00, 0xDC))  # little endian...
+        expected_output = '\U00010000'
+        self.do_test(encoded_input, expected_output)
+
     def test_log_stream_encoding_failure(self):
-        encoding = locale.getpreferredencoding()
-        process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
-        process.poll = MagicMock(return_value=None)  # type: ignore
-        stream = BytesIO(bytes((0x00, 0x10, 0xFF, 0xFF)))  # U+10FFFF in UTF-32-BE
-        with captured_output() as (out, err):
-            log_stream(process, stream)
-        expected = 'server: Unable to decode bytes! (tried decoding with {})'.format(encoding)
-        self.assertEqual(out.getvalue().strip(), expected)
-        self.assertEqual(err.getvalue().strip(), '')
+        encoded_input = bytes((0x00, 0xD8, 0x00))
+        expected_output = 'Unable to decode bytes! (tried UTF-8 and UTF-16)'
+        self.do_test(encoded_input, expected_output)

--- a/plugin/core/test_process.py
+++ b/plugin/core/test_process.py
@@ -5,7 +5,6 @@ from io import StringIO
 from subprocess import Popen
 from unittest import TestCase
 from unittest.mock import MagicMock
-import locale
 import os
 import sys
 
@@ -38,29 +37,4 @@ class ProcessTests(TestCase):
         with captured_output() as (out, err):
             log_stream(process, BytesIO(text.encode(encoding)))
         self.assertEqual(out.getvalue().strip(), 'server: {}'.format(text))
-        self.assertEqual(err.getvalue().strip(), '')
-
-    def test_log_stream_encoding_preferred_locale(self):
-        encoding = locale.getpreferredencoding()
-        process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
-        process.poll = MagicMock(return_value=None)  # type: ignore
-        text = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ'
-        with captured_output() as (out, err):
-            log_stream(process, BytesIO(text.encode(encoding)))
-        self.assertEqual(out.getvalue().strip(), 'server: {}'.format(text))
-        self.assertEqual(err.getvalue().strip(), '')
-
-    def test_log_stream_encoding_failure(self):
-        encoding = locale.getpreferredencoding()
-        if encoding == "UTF-32-BE":
-            self.skipTest("this test doesn't work when the preferred encoding is UTF-32-BE")
-        process = Popen(args=['cmd.exe' if os.name == 'nt' else 'bash'], bufsize=1024)
-        process.poll = MagicMock(return_value=None)  # type: ignore
-        with captured_output() as (out, err):
-            log_stream(process, BytesIO(bytes((0x00, 0x10, 0xFF, 0xFF))))  # U+10FFFF in UTF-32-BE
-        if encoding == "UTF-8":
-            expected = 'server: Unable to decode bytes! (tried UTF-8)'
-        else:
-            expected = 'server: Unable to decode bytes! (tried UTF-8 and {})'.format(encoding)
-        self.assertEqual(out.getvalue().strip(), expected)
         self.assertEqual(err.getvalue().strip(), '')


### PR DESCRIPTION
There's nothing in the LSP spec about the encoding of the stderr stream (or in the case of the TCP transport the stdout stream). We're assuming UTF-8, which is a good choice I think, but if the encoding fails we can try UTF-16 as a last resort.

Related: #249 