### PR TITLE
fix: remove reference to obsolete setting

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -75,7 +75,6 @@ Add these settings to your Sublime settings, Syntax-specific settings and/or in 
 * `completion_hint_type` `"auto"` *override automatic completion hints with "detail", "kind" or "none"*
 * `show_references_in_quick_panel` `false` *show symbol references in Sublime's quick panel instead of the bottom panel*
 * `quick_panel_monospace_font` `false` *use monospace font for the quick panel*
-* `show_status_messages` `true` *show messages in the status bar for a few seconds*
 * `show_view_status` `true` *show permanent language server status in the status bar*
 * `auto_show_diagnostics_panel` `always` (`never`, `saved`) *open the diagnostics panel automatically if there are diagnostics*
 * `show_diagnostics_count_in_view_status` `false` *show errors and warnings count in the status bar*

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -23,7 +23,7 @@ def startup() -> None:
     popups.load_css()
     windows.set_diagnostics_ui(DiagnosticsPresenter)
     load_handlers()
-    if settings.show_status_messages:
+    if settings.show_view_status:
         sublime.status_message("LSP initialized")
     start_active_window()
 

--- a/plugin/core/main.py
+++ b/plugin/core/main.py
@@ -23,8 +23,7 @@ def startup() -> None:
     popups.load_css()
     windows.set_diagnostics_ui(DiagnosticsPresenter)
     load_handlers()
-    if settings.show_view_status:
-        sublime.status_message("LSP initialized")
+    sublime.status_message("LSP initialized")
     start_active_window()
 
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -10,7 +10,6 @@ except ImportError:
 class Settings(object):
 
     def __init__(self) -> None:
-        self.show_status_messages = True
         self.show_view_status = True
         self.auto_show_diagnostics_panel = 'always'
         self.auto_show_diagnostics_panel_level = 2


### PR DESCRIPTION
While debugging, I found a reference to a removed setting.
I think it's nice to have this setting, so instead of removing it, I used the show_view_status setting. Let me know if I should just remove it altogether.