### PR TITLE
Add debug note if there's no matching config for a file

### DIFF
--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -399,7 +399,8 @@ class WindowManager(object):
                         debug("window {} requests {} for {}".format(self._window.id(), config.name, view.file_name()))
                         self._start_client(config)
                 else:
-                    debug("no startable configs found in window {} for file {} with syntax {}".format(self._window.id(), view.file_name(), view.settings().get("syntax")))
+                    debug("no startable configs found in window {} for file {} with syntax {}"
+                        .format(self._window.id(), view.file_name(), view.settings().get("syntax")))
 
     def _start_client(self, config: ClientConfig) -> None:
         workspace = self._ensure_workspace()

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -392,7 +392,7 @@ class WindowManager(object):
                 startable_configs = filter(lambda c: c.name not in self._sessions,
                                            self._configs.syntax_configs(view))
 
-                config_list = list(startable_configs);
+                config_list = list(startable_configs)
 
                 if any(config_list):
                     for config in config_list:
@@ -400,7 +400,7 @@ class WindowManager(object):
                         self._start_client(config)
                 else:
                     debug("no startable configs found in window {} for file {} with syntax {}"
-                        .format(self._window.id(), view.file_name(), view.settings().get("syntax")))
+                          .format(self._window.id(), view.file_name(), view.settings().get("syntax")))
 
     def _start_client(self, config: ClientConfig) -> None:
         workspace = self._ensure_workspace()

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -392,9 +392,14 @@ class WindowManager(object):
                 startable_configs = filter(lambda c: c.name not in self._sessions,
                                            self._configs.syntax_configs(view))
 
-                for config in startable_configs:
-                    debug("window {} requests {} for {}".format(self._window.id(), config.name, view.file_name()))
-                    self._start_client(config)
+                config_list = list(startable_configs);
+
+                if any(config_list):
+                    for config in config_list:
+                        debug("window {} requests {} for {}".format(self._window.id(), config.name, view.file_name()))
+                        self._start_client(config)
+                else:
+                    debug("no startable configs found in window {} for file {} with syntax {}".format(self._window.id(), view.file_name(), view.settings().get("syntax")))
 
     def _start_client(self, config: ClientConfig) -> None:
         workspace = self._ensure_workspace()


### PR DESCRIPTION
While failing to set up a config for a custom client, I was confused by LSP's silence. I finally tracked down the error to an incorrect syntax setting. 
This debug message should help others to find out where exactly LSP was missing something.

Note that I had to create a list from the filter - I suspect that any does not handle filter objects well (even though they are iterable). In my tests, any would return False for the filter object.