### PR TITLE
Multiple-folder project support

### DIFF
--- a/plugin/configuration.py
+++ b/plugin/configuration.py
@@ -67,7 +67,7 @@ class LspDisableLanguageServerGloballyCommand(sublime_plugin.WindowCommand):
             config_name = self._items[index][0]
             client_configs.disable(config_name)
             wm = windows.lookup(self.window)
-            sublime.set_timeout_async(lambda: wm.end_session(config_name), 500)
+            sublime.set_timeout_async(lambda: wm.end_config_sessions(config_name), 500)
             self.window.status_message("{} disabled, shutting down server...".format(config_name))
 
 

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -4,8 +4,9 @@ from .sessions import create_session, Session
 
 # typing only
 from .rpc import Client
+from .protocol import WorkspaceFolder
 from .settings import ClientConfig, settings
-assert Client and ClientConfig
+assert Client and ClientConfig and WorkspaceFolder
 
 
 try:
@@ -37,7 +38,7 @@ def get_window_env(window: sublime.Window, config: ClientConfig) -> 'Tuple[List[
 
 
 def start_window_config(window: sublime.Window,
-                        workspace_folders: 'List[str]',
+                        workspace_folders: 'List[WorkspaceFolder]',
                         config: ClientConfig,
                         on_pre_initialize: 'Callable[[Session], None]',
                         on_post_initialize: 'Callable[[Session], None]',

--- a/plugin/core/clients.py
+++ b/plugin/core/clients.py
@@ -37,7 +37,7 @@ def get_window_env(window: sublime.Window, config: ClientConfig) -> 'Tuple[List[
 
 
 def start_window_config(window: sublime.Window,
-                        project_path: str,
+                        workspace_folders: 'List[str]',
                         config: ClientConfig,
                         on_pre_initialize: 'Callable[[Session], None]',
                         on_post_initialize: 'Callable[[Session], None]',
@@ -45,7 +45,7 @@ def start_window_config(window: sublime.Window,
     args, env = get_window_env(window, config)
     config.binary_args = args
     return create_session(config=config,
-                          project_path=project_path,
+                          workspace_folders=workspace_folders,
                           env=env,
                           settings=settings,
                           on_pre_initialize=on_pre_initialize,

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -98,6 +98,6 @@ class DocumentSyncListener(LSPViewEventListener):
         self.manager.documents.handle_view_saved(self.view)
 
     def on_close(self) -> None:
-        if self.view.file_name() and self.view.is_primary():
+        if self.view.file_name() and self.view.is_primary() and self.has_manager():
             self.manager.handle_view_closed(self.view)
             self.manager.documents.handle_view_closed(self.view)

--- a/plugin/core/process.py
+++ b/plugin/core/process.py
@@ -32,7 +32,7 @@ def add_extension_if_missing(server_binary_args: 'List[str]') -> 'List[str]':
     return server_binary_args
 
 
-def start_server(server_binary_args: 'List[str]', working_dir: str,
+def start_server(server_binary_args: 'List[str]', working_dir: 'Optional[str]',
                  env: 'Dict[str,str]', attach_stderr: bool) -> 'Optional[subprocess.Popen]':
     si = None
     if os.name == "nt":

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -241,6 +241,10 @@ class Notification:
         return Notification("workspace/didChangeConfiguration", params)
 
     @classmethod
+    def didChangeWorkspaceFolders(cls, params: dict) -> 'Notification':
+        return Notification("workspace/didChangeWorkspaceFolders", params)
+
+    @classmethod
     def exit(cls) -> 'Notification':
         return Notification("exit")
 
@@ -436,7 +440,7 @@ class WorkspaceFolder:
             return self.name == other.name and self.path == other.path
         return False
 
-    def to_dict(self) -> 'Dict[str, str]':
+    def to_lsp(self) -> 'Dict[str, str]':
         return {"name": self.name, "uri": self.uri()}
 
     def uri(self) -> str:

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -423,7 +423,7 @@ class WorkspaceFolder:
     def from_path(cls, path: str) -> 'WorkspaceFolder':
         assert os.path.isdir(path)
         assert os.path.isabs(path)
-        return cls(os.path.basename(path), path)
+        return cls(os.path.basename(path) or path, path)
 
     def __repr__(self) -> str:
         return "{}('{}', '{}')".format(self.__class__.__name__, self.name, self.path)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -46,6 +46,9 @@ class LSPViewEventListener(sublime_plugin.ViewEventListener):
         assert self._manager
         return self._manager
 
+    def has_manager(self) -> bool:
+        return self._manager is not None
+
 
 class LanguageHandlerDispatcher(object):
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -109,7 +109,7 @@ def _sessions_for_view_and_window(view: sublime.View, window: 'Optional[sublime.
 
     file_path = view.file_name()
     if not file_path:
-        debug("no session for unsaved file")
+        # debug("no session for unsaved file")
         return []
 
     manager = windows.lookup(window)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -104,9 +104,14 @@ def _sessions_for_view_and_window(view: sublime.View, window: 'Optional[sublime.
         debug("no window for view", view.file_name())
         return []
 
+    file_path = view.file_name()
+    if not file_path:
+        debug("no session for unsaved file")
+        return []
+
     manager = windows.lookup(window)
     scope_configs = manager._configs.scope_configs(view, point)
-    sessions = (manager.get_session(config.name) for config in scope_configs)
+    sessions = (manager.get_session(config.name, file_path) for config in scope_configs)
     ready_sessions = (session for session in sessions if session and session.state == ClientStates.READY)
     return ready_sessions
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -3,13 +3,12 @@ from .protocol import Request
 from .transports import start_tcp_transport, start_tcp_listener, TCPTransport, Transport
 from .rpc import Client, attach_stdio_client
 from .process import start_server
-from .url import filename_to_uri
 from .logging import debug
 import os
 from .protocol import completion_item_kinds, symbol_kinds, WorkspaceFolder
 try:
     from typing import Callable, Dict, Any, Optional, List
-    assert Callable and Dict and Any and Optional and Transport and List
+    assert Callable and Dict and Any and Optional and Transport and List and WorkspaceFolder
 except ImportError:
     pass
 

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -176,7 +176,7 @@ class Session(object):
         self._on_post_exit = on_post_exit
         self.capabilities = dict()  # type: Dict[str, Any]
         self.client = client
-        self._workspace_folders = workspace_folders  # TODO: perhaps not until initialized?
+        self._workspace_folders = workspace_folders
         if on_pre_initialize:
             on_pre_initialize(self)
         self._initialize()
@@ -216,15 +216,14 @@ class Session(object):
             lambda result: self._handle_initialize_result(result))
 
     def _supports_workspace_folders(self) -> bool:
-        # 'capabilities': {'workspace': {'workspaceFolders': {'supported': True
         workspace_cap = self.capabilities.get("workspace", {})
         workspace_folder_cap = workspace_cap.get("workspaceFolders", {})
         return workspace_folder_cap.get("supported")
 
     def _handle_initialize_result(self, result: 'Any') -> None:
-        # only keep supported amount of folders
         self.capabilities = result.get('capabilities', dict())
 
+        # only keep supported amount of folders
         if self._supports_workspace_folders():
             debug('multi folder session:', self._workspace_folders)
         else:

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -211,6 +211,7 @@ class Session(object):
             }
             notification = Notification.didChangeWorkspaceFolders(params)
             self.client.send_notification(notification)
+            self._workspace_folders = folders
 
     def _initialize(self) -> None:
         params = get_initialize_params(self._workspace_folders, self.config)

--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -160,6 +160,7 @@ class Session(object):
         self._on_post_exit = on_post_exit
         self.capabilities = dict()  # type: Dict[str, Any]
         self.client = client
+        self._workspace_folders = [project_path]
         if on_pre_initialize:
             on_pre_initialize(self)
         self._initialize(project_path)
@@ -169,6 +170,16 @@ class Session(object):
 
     def get_capability(self, capability: str) -> 'Optional[Any]':
         return self.capabilities.get(capability)
+
+    def handles_path(self, file_path: 'Optional[str]') -> bool:
+        if not file_path:
+            return False
+
+        for folder in self._workspace_folders:
+            if file_path.startswith(folder):
+                return True
+
+        return False
 
     def _initialize(self, project_path: str) -> None:
         params = get_initialize_params(project_path, self.config)

--- a/plugin/core/test_documents.py
+++ b/plugin/core/test_documents.py
@@ -1,4 +1,5 @@
 from . import test_sublime as test_sublime
+from .protocol import WorkspaceFolder
 from .sessions import create_session
 from .sessions import Session
 from .test_mocks import MockClient
@@ -30,11 +31,13 @@ class WindowDocumentHandlerTests(unittest.TestCase):
     def test_sends_did_open_to_session(self):
         view = MockView(__file__)
         window = MockWindow([[view]])
+        project_path = "/"
+        folders = [WorkspaceFolder.from_path(project_path)]
         view.set_window(window)
         handler = WindowDocumentHandler(test_sublime, MockSettings(), window, MockConfigs())
         client = MockClient()
         session = self.assert_if_none(
-            create_session(TEST_CONFIG, "", dict(), MockSettings(),
+            create_session(TEST_CONFIG, folders, dict(), MockSettings(),
                            bootstrap_client=client))
         handler.add_session(session)
 
@@ -90,16 +93,18 @@ class WindowDocumentHandlerTests(unittest.TestCase):
     def test_sends_did_open_to_multiple_sessions(self):
         view = MockView(__file__)
         window = MockWindow([[view]])
+        project_path = "/"
+        folders = [WorkspaceFolder.from_path(project_path)]
         view.set_window(window)
         handler = WindowDocumentHandler(test_sublime, MockSettings(), window, MockConfigs())
         client = MockClient()
         session = self.assert_if_none(
-            create_session(TEST_CONFIG, "", dict(), MockSettings(),
+            create_session(TEST_CONFIG, folders, dict(), MockSettings(),
                            bootstrap_client=client))
         client2 = MockClient()
         test_config2 = ClientConfig("test2", [], None, languages=[TEST_LANGUAGE])
         session2 = self.assert_if_none(
-            create_session(test_config2, "", dict(), MockSettings(),
+            create_session(test_config2, folders, dict(), MockSettings(),
                            bootstrap_client=client2))
 
         handler.add_session(session)

--- a/plugin/core/test_mocks.py
+++ b/plugin/core/test_mocks.py
@@ -122,6 +122,7 @@ class MockWindow(object):
         self._folders = folders
         self._default_view = MockView(None)
         self._project_data = None  # type: Optional[Dict[str, Any]]
+        self._project_file_name = None  # type: Optional[str]
         self.commands = []  # type: List[Tuple[str, Dict[str, Any]]]
 
     def id(self):
@@ -144,6 +145,9 @@ class MockWindow(object):
 
     def set_project_data(self, data: 'Optional[dict]'):
         self._project_data = data
+
+    def project_file_name(self) -> 'Optional[str]':
+        return self._project_file_name
 
     def active_view(self) -> 'Optional[ViewLike]':
         return self.active_view_in_group(0)

--- a/plugin/core/test_mocks.py
+++ b/plugin/core/test_mocks.py
@@ -274,7 +274,6 @@ class MockDocuments(object):
         pass
 
     def has_document_state(self, file_name: str) -> bool:
-        debug(self._documents)
         return file_name in self._documents
 
 

--- a/plugin/core/test_mocks.py
+++ b/plugin/core/test_mocks.py
@@ -273,6 +273,10 @@ class MockDocuments(object):
     def handle_view_closed(self, view: ViewLike) -> None:
         pass
 
+    def has_document_state(self, file_name: str) -> bool:
+        debug(self._documents)
+        return file_name in self._documents
+
 
 class TestDocumentHandlerFactory(object):
     def for_window(self, window, configs):

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -1,3 +1,4 @@
+from .protocol import WorkspaceFolder
 from .sessions import create_session, Session
 from .test_mocks import MockClient
 from .test_mocks import TEST_CONFIG
@@ -26,8 +27,9 @@ class SessionTest(unittest.TestCase):
 
         config = ClientConfig("test", ["ls"], None, [], [], None, [TEST_LANGUAGE])
         project_path = "/"
+        folders = [WorkspaceFolder.from_path(project_path)]
         session = self.assert_if_none(
-            create_session(config, project_path, dict(), Settings()))
+            create_session(config, folders, dict(), Settings()))
 
         self.assertEqual(session.state, ClientStates.STARTING)
         session.end()
@@ -35,10 +37,11 @@ class SessionTest(unittest.TestCase):
 
     def test_can_get_started_session(self):
         project_path = "/"
+        folders = [WorkspaceFolder.from_path(project_path)]
         post_initialize_callback = unittest.mock.Mock()
         session = self.assert_if_none(
             create_session(config=TEST_CONFIG,
-                           project_path=project_path,
+                           workspace_folders=folders,
                            env=dict(),
                            settings=Settings(),
                            bootstrap_client=MockClient(),
@@ -51,11 +54,12 @@ class SessionTest(unittest.TestCase):
 
     def test_pre_initialize_callback_is_invoked(self):
         project_path = "/"
+        folders = [WorkspaceFolder.from_path(project_path)]
         pre_initialize_callback = unittest.mock.Mock()
         post_initialize_callback = unittest.mock.Mock()
         session = self.assert_if_none(
             create_session(config=TEST_CONFIG,
-                           project_path=project_path,
+                           workspace_folders=folders,
                            env=dict(),
                            settings=Settings(),
                            bootstrap_client=MockClient(),
@@ -70,11 +74,12 @@ class SessionTest(unittest.TestCase):
 
     def test_can_shutdown_session(self):
         project_path = "/"
+        folders = [WorkspaceFolder.from_path(project_path)]
         post_initialize_callback = unittest.mock.Mock()
         post_exit_callback = unittest.mock.Mock()
         session = self.assert_if_none(
             create_session(config=TEST_CONFIG,
-                           project_path=project_path,
+                           workspace_folders=folders,
                            env=dict(),
                            settings=Settings(),
                            bootstrap_client=MockClient(),

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -212,3 +212,15 @@ class WindowManagerTests(unittest.TestCase):
 
         # client_start_listeners, client_initialization_listeners,
         self.assertTrue(TEST_CONFIG.name in dispatcher._initialized)
+
+    def test_returns_closest_workspace_folder(self):
+        docs = MockDocuments()
+        dispatcher = MockHandlerDispatcher()
+        file_path = __file__
+        top_folder = os.path.dirname(__file__)
+        parent_folder = os.path.dirname(top_folder)
+        wm = WindowManager(MockWindow([[MockView(__file__)]], [top_folder, parent_folder]), MockConfigs(), docs,
+                           DiagnosticsStorage(None), mock_start_session, test_sublime,
+                           dispatcher)
+        wm.start_active_views()
+        self.assertEqual(top_folder, wm.get_project_path(file_path))

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -18,24 +18,26 @@ from .windows import WindowManager
 from .windows import WindowRegistry
 import tempfile
 import unittest
+import os
 
 try:
+    from .protocol import WorkspaceFolder
     from typing import Callable, List, Optional, Set, Dict, Any, Tuple
     assert Callable and List and Optional and Set and Session and Dict and Any and Tuple
-    assert ClientConfig and LanguageConfig
+    assert ClientConfig and LanguageConfig and WorkspaceFolder
 except ImportError:
     pass
 
 
 def mock_start_session(window: MockWindow,
-                       project_path: str,
+                       workspace_folders: 'List[WorkspaceFolder]',
                        config: ClientConfig,
                        on_pre_initialize: 'Callable[[Session], None]',
                        on_post_initialize: 'Callable[[Session], None]',
                        on_post_exit: 'Callable[[str], None]') -> 'Optional[Session]':
     return create_session(
         config=TEST_CONFIG,
-        project_path=project_path,
+        workspace_folders=workspace_folders,
         env=dict(),
         settings=MockSettings(),
         bootstrap_client=MockClient(),
@@ -56,6 +58,7 @@ class WindowRegistryTests(unittest.TestCase):
 
     def test_removes_window_state(self):
         test_window = MockWindow([[MockView(__file__)]])
+        print(__file__)
         windows = WindowRegistry(TestGlobalConfigs(), TestDocumentHandlerFactory(),
                                  mock_start_session,
                                  test_sublime, MockHandlerDispatcher())
@@ -81,7 +84,7 @@ class WindowManagerTests(unittest.TestCase):
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
         self.assertListEqual(docs._documents, [__file__])
 
     def test_can_open_supported_view(self):
@@ -91,7 +94,7 @@ class WindowManagerTests(unittest.TestCase):
                            MockHandlerDispatcher())
 
         wm.start_active_views()
-        self.assertIsNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNone(wm.get_session(TEST_CONFIG.name, __file__))
         self.assertListEqual(docs._documents, [])
 
         # session must be started (todo: verify session is ready)
@@ -101,7 +104,7 @@ class WindowManagerTests(unittest.TestCase):
         window._files_in_groups = [[view]]
 
         wm.activate_view(view)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
         self.assertEqual(len(docs._sessions), 1)
 
     def test_can_restart_sessions(self):
@@ -111,7 +114,7 @@ class WindowManagerTests(unittest.TestCase):
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
 
         # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])
@@ -119,7 +122,7 @@ class WindowManagerTests(unittest.TestCase):
         wm.restart_sessions()
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
 
         # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])
@@ -132,7 +135,7 @@ class WindowManagerTests(unittest.TestCase):
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
 
         # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])
@@ -152,15 +155,16 @@ class WindowManagerTests(unittest.TestCase):
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
 
         # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])
 
         # change project_path
         new_project_path = tempfile.gettempdir()
+        file_path = os.path.join(new_project_path, "testfile.py")
         test_window.set_folders([new_project_path])
-        another_view = MockView(None)
+        another_view = MockView(file_path)
         another_view.settings().set("syntax", "Unsupported Syntax")
         test_window._files_in_groups[0][0] = another_view
         wm.activate_view(another_view)
@@ -169,7 +173,7 @@ class WindowManagerTests(unittest.TestCase):
         self.assertEqual(len(docs._sessions), 0)
 
         # don't forget to check or we'll keep restarting sessions!
-        self.assertEqual(wm.get_project_path(), new_project_path)
+        self.assertEqual(wm.get_project_path(file_path), new_project_path)
 
     def test_offers_restart_on_crash(self):
         docs = MockDocuments()
@@ -179,7 +183,7 @@ class WindowManagerTests(unittest.TestCase):
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
 
         # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])
@@ -187,7 +191,7 @@ class WindowManagerTests(unittest.TestCase):
         wm._handle_server_crash(TEST_CONFIG)
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
 
         # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])
@@ -201,7 +205,7 @@ class WindowManagerTests(unittest.TestCase):
         wm.start_active_views()
 
         # session must be started (todo: verify session is ready)
-        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name))
+        self.assertIsNotNone(wm.get_session(TEST_CONFIG.name, __file__))
 
         # our starting document must be loaded
         self.assertListEqual(docs._documents, [__file__])

--- a/plugin/core/test_windows.py
+++ b/plugin/core/test_windows.py
@@ -149,7 +149,7 @@ class WindowManagerTests(unittest.TestCase):
 
     def test_ends_sessions_when_quick_switching(self):
         docs = MockDocuments()
-        test_window = MockWindow([[MockView(__file__)]])
+        test_window = MockWindow([[MockView(__file__)]], folders=[os.path.dirname(__file__)])
         wm = WindowManager(test_window, MockConfigs(), docs,
                            DiagnosticsStorage(None), mock_start_session, test_sublime, MockHandlerDispatcher())
         wm.start_active_views()

--- a/plugin/core/test_workspace.py
+++ b/plugin/core/test_workspace.py
@@ -1,5 +1,6 @@
 from .test_mocks import MockWindow
-from .workspace import WorkspaceFolder, get_workspace_folders, WorkspaceFolders
+from .workspace import get_workspace_folders, ProjectFolders
+from .protocol import WorkspaceFolder
 import os
 from unittest import mock
 import unittest
@@ -51,7 +52,7 @@ class WorkspaceFoldersTest(unittest.TestCase):
         on_switched = mock.Mock()
         window = MockWindow(folders=[])
 
-        wf = WorkspaceFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window, on_changed, on_switched)
         window.set_folders([os.path.dirname(__file__)])
         wf.update(__file__)
         assert on_changed.call_count == 1
@@ -64,7 +65,7 @@ class WorkspaceFoldersTest(unittest.TestCase):
         parent_folder = os.path.dirname(folder)
         window = MockWindow(folders=[folder])
 
-        wf = WorkspaceFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window, on_changed, on_switched)
 
         window.set_folders([folder, parent_folder])
         wf.update(__file__)
@@ -78,7 +79,7 @@ class WorkspaceFoldersTest(unittest.TestCase):
         parent_folder = os.path.dirname(folder)
         window = MockWindow(folders=[folder])
 
-        wf = WorkspaceFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window, on_changed, on_switched)
 
         window.set_folders([parent_folder])
         wf.update(__file__)
@@ -96,7 +97,7 @@ class WorkspaceFoldersTest(unittest.TestCase):
 
         window = MockWindow(folders=[])
 
-        wf = WorkspaceFolders(window, on_changed, on_switched)
+        wf = ProjectFolders(window, on_changed, on_switched)
 
         wf.update(first_file)
 
@@ -108,4 +109,4 @@ class WorkspaceFoldersTest(unittest.TestCase):
         assert on_changed.call_count == 0
         assert on_switched.call_count == 0
 
-        self.assertEqual(wf._folders, [])
+        self.assertEqual(wf.folders, [])

--- a/plugin/core/test_workspace.py
+++ b/plugin/core/test_workspace.py
@@ -1,33 +1,33 @@
 from .test_mocks import MockWindow
-from .workspace import WorkspaceFolder, get_workspace_folders, get_workspace, WorkspaceManager, Workspace
+from .workspace import WorkspaceFolder, get_workspace_folders, WorkspaceFolders
 import os
 from unittest import mock
 import unittest
 import tempfile
 
 
-class WorkspaceFolderTest(unittest.TestCase):
+class GetWorkspaceFoldersTest(unittest.TestCase):
 
     def test_get_workspace_from_single_folder_project(self) -> None:
         project_folder = os.path.dirname(__file__)
         folders = get_workspace_folders(MockWindow(folders=[project_folder]), __file__)
-        folder = WorkspaceFolder.from_path(project_folder)
-        self.assertEqual(folders[0], folder)
+        self.assertEqual(folders[0], project_folder)
 
     def test_get_workspace_from_multi_folder_project(self) -> None:
         first_project_path = os.path.dirname(__file__)
         second_project_path = tempfile.gettempdir()
         folders = get_workspace_folders(MockWindow(folders=[second_project_path, first_project_path]), __file__)
-        first_folder = WorkspaceFolder.from_path(first_project_path)
-        second_folder = WorkspaceFolder.from_path(second_project_path)
-        self.assertEqual(folders[0], first_folder)
-        self.assertEqual(folders[1], second_folder)
+        # first_folder = WorkspaceFolder.from_path(first_project_path)
+        # second_folder = WorkspaceFolder.from_path(second_project_path)
+        self.assertEqual(folders[0], first_project_path)
+        self.assertEqual(folders[1], second_project_path)
 
     def test_get_workspace_without_folders(self) -> None:
-        project_folder = os.path.dirname(__file__)
         folders = get_workspace_folders(MockWindow(), __file__)
-        folder = WorkspaceFolder.from_path(project_folder)
-        self.assertEqual(folders[0], folder)
+        self.assertEqual(folders, [])
+
+
+class WorkspaceFolderTest(unittest.TestCase):
 
     def test_workspace_str(self) -> None:
         workspace = WorkspaceFolder("LSP", "/foo/bar/baz")
@@ -44,49 +44,16 @@ class WorkspaceFolderTest(unittest.TestCase):
         self.assertEqual(lsp_dict, {"name": "LSP", "uri": "file:///foo/bar/baz"})
 
 
-class WorkspaceTests(unittest.TestCase):
-
-    def test_get_workspace_from_single_folder_project(self) -> None:
-        project_folder = os.path.dirname(__file__)
-
-        workspace = get_workspace(MockWindow(folders=[project_folder]), __file__)
-
-        self.assertEqual(workspace.folders, [project_folder])
-        self.assertEqual(workspace.working_directory, project_folder)
-
-    def test_get_workspace_from_multi_folder_project(self) -> None:
-        first_project_path = os.path.dirname(__file__)
-        second_project_path = tempfile.gettempdir()
-
-        workspace = get_workspace(MockWindow(folders=[second_project_path, first_project_path]), __file__)
-
-        self.assertEqual(workspace.folders, [first_project_path, second_project_path])
-        self.assertEqual(workspace.working_directory, first_project_path)
-
-    def test_get_workspace_without_folders(self) -> None:
-        project_folder = os.path.dirname(__file__)
-        workspace = get_workspace(MockWindow(), __file__)
-
-        self.assertEqual([project_folder], workspace.folders)
-        self.assertEqual(workspace.working_directory, project_folder)
-
-    def test_workspace_equals(self) -> None:
-        project_folder = os.path.dirname(__file__)
-
-        self.assertEqual(Workspace([]), Workspace([]))
-        self.assertEqual(Workspace([project_folder]), Workspace([project_folder]))
-
-
-class WorkspaceManagerTests(unittest.TestCase):
+class WorkspaceFoldersTest(unittest.TestCase):
 
     def test_load_project_from_empty(self) -> None:
         on_changed = mock.Mock()
         on_switched = mock.Mock()
         window = MockWindow(folders=[])
 
-        manager = WorkspaceManager(window, on_changed, on_switched)
-
-        manager.update(__file__)
+        wf = WorkspaceFolders(window, on_changed, on_switched)
+        window.set_folders([os.path.dirname(__file__)])
+        wf.update(__file__)
         assert on_changed.call_count == 1
         on_switched.assert_not_called()
 
@@ -97,10 +64,10 @@ class WorkspaceManagerTests(unittest.TestCase):
         parent_folder = os.path.dirname(folder)
         window = MockWindow(folders=[folder])
 
-        manager = WorkspaceManager(window, on_changed, on_switched)
+        wf = WorkspaceFolders(window, on_changed, on_switched)
 
         window.set_folders([folder, parent_folder])
-        manager.update(__file__)
+        wf.update(__file__)
         assert on_changed.call_count == 1
         on_switched.assert_not_called()
 
@@ -111,10 +78,10 @@ class WorkspaceManagerTests(unittest.TestCase):
         parent_folder = os.path.dirname(folder)
         window = MockWindow(folders=[folder])
 
-        manager = WorkspaceManager(window, on_changed, on_switched)
+        wf = WorkspaceFolders(window, on_changed, on_switched)
 
         window.set_folders([parent_folder])
-        manager.update(__file__)
+        wf.update(__file__)
         on_changed.assert_not_called()
         assert on_switched.call_count == 1
 
@@ -129,19 +96,16 @@ class WorkspaceManagerTests(unittest.TestCase):
 
         window = MockWindow(folders=[])
 
-        manager = WorkspaceManager(window, on_changed, on_switched)
+        wf = WorkspaceFolders(window, on_changed, on_switched)
 
-        manager.update(first_file)
+        wf.update(first_file)
 
-        assert on_changed.call_count == 1
+        assert on_changed.call_count == 0
         on_switched.assert_not_called()
 
-        manager.update(file_in_parent_folder)
+        wf.update(file_in_parent_folder)
 
-        assert on_changed.call_count == 1
-        assert on_switched.call_count == 1
+        assert on_changed.call_count == 0
+        assert on_switched.call_count == 0
 
-        self.assertEqual(manager.current.folders, [parent_folder])
-
-        # TODO: if we want to merge ad-hoc workspaces
-        # self.assertEqual(manager.current.folders, [folder, parent_folder])
+        self.assertEqual(wf._folders, [])

--- a/plugin/core/test_workspace.py
+++ b/plugin/core/test_workspace.py
@@ -87,7 +87,7 @@ class WorkspaceManagerTests(unittest.TestCase):
         manager = WorkspaceManager(window, on_changed, on_switched)
 
         manager.update(__file__)
-        on_changed.assert_called_once()
+        assert on_changed.call_count == 1
         on_switched.assert_not_called()
 
     def test_add_folder(self) -> None:
@@ -101,7 +101,7 @@ class WorkspaceManagerTests(unittest.TestCase):
 
         window.set_folders([folder, parent_folder])
         manager.update(__file__)
-        on_changed.assert_called_once()
+        assert on_changed.call_count == 1
         on_switched.assert_not_called()
 
     def test_switch_project(self) -> None:
@@ -116,7 +116,7 @@ class WorkspaceManagerTests(unittest.TestCase):
         window.set_folders([parent_folder])
         manager.update(__file__)
         on_changed.assert_not_called()
-        on_switched.assert_called_once()
+        assert on_switched.call_count == 1
 
     def test_open_files_without_project(self) -> None:
         on_changed = mock.Mock()
@@ -133,13 +133,13 @@ class WorkspaceManagerTests(unittest.TestCase):
 
         manager.update(first_file)
 
-        on_changed.assert_called_once()
+        assert on_changed.call_count == 1
         on_switched.assert_not_called()
 
         manager.update(file_in_parent_folder)
 
-        on_changed.assert_called_once()
-        on_switched.assert_called_once()
+        assert on_changed.call_count == 1
+        assert on_switched.call_count == 1
 
         self.assertEqual(manager.current.folders, [parent_folder])
 

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -150,6 +150,9 @@ class WindowLike(Protocol):
     def project_data(self) -> 'Optional[dict]':
         ...
 
+    def project_file_name(self) -> 'Optional[str]':
+        ...
+
     def active_view(self) -> 'Optional[ViewLike]':
         ...
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -8,7 +8,7 @@ from .edit import parse_workspace_edit
 from .sessions import Session
 from .url import filename_to_uri
 from .workspace import (
-    enable_in_project, disable_in_project, WorkspaceFolders
+    enable_in_project, disable_in_project, ProjectFolders
 )
 
 from .rpc import Client
@@ -335,15 +335,14 @@ class WindowManager(object):
         self._on_closed = on_closed
         self._is_closing = False
         self._initialization_lock = threading.Lock()
-        # TODO: name member something other than "workspace".
-        self._workspace = WorkspaceFolders(self._window, self._on_workspace_changed, self._on_workspace_switched)
+        self._workspace = ProjectFolders(self._window, self._on_project_changed, self._on_project_switched)
 
-    def _on_workspace_changed(self, folders: 'List[str]') -> None:
+    def _on_project_changed(self, folders: 'List[str]') -> None:
         for config_name in self._sessions:
             for session in self._sessions[config_name]:
                 session.update_folders(self._workspace.workspace_folders)
 
-    def _on_workspace_switched(self, folders: 'List[str]') -> None:
+    def _on_project_switched(self, folders: 'List[str]') -> None:
         debug('project switched - ending all sessions')
         self.end_sessions()
 
@@ -488,7 +487,7 @@ class WindowManager(object):
 
     def get_project_path(self, file_path: str) -> 'Optional[str]':
         candidate = None  # type: Optional[str]
-        for folder in self._workspace._folders:
+        for folder in self._workspace.folders:
             if file_path.startswith(folder):
                 if candidate is None or len(folder) > len(candidate):
                     candidate = folder

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -482,10 +482,12 @@ class WindowManager(object):
             session.end()
 
     def get_project_path(self, file_path: str) -> 'Optional[str]':
+        candidate = None  # type: Optional[str]
         for folder in self._workspace_folders:
             if file_path.startswith(folder.path):
-                return folder.path
-        return None
+                if candidate is None or len(folder.path) > len(candidate):
+                    candidate = folder.path
+        return candidate
 
     def _end_old_sessions(self) -> None:
         # TODO make this a set (of strings?) for better comparing.

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -68,6 +68,9 @@ class DocumentHandler(Protocol):
     def handle_view_closed(self, view: ViewLike) -> None:
         ...
 
+    def has_document_state(self, file_name: str) -> bool:
+        ...
+
 
 def get_active_views(window: WindowLike) -> 'List[ViewLike]':
     views = list()  # type: List[ViewLike]
@@ -389,8 +392,9 @@ class WindowManager(object):
                 self.documents.handle_view_opened(view)
 
     def activate_view(self, view: ViewLike) -> None:
-        if not view.settings().get("lsp_active", False):
-            self._workspace.update(view.file_name() or "")
+        file_name = view.file_name() or ""
+        if not self.documents.has_document_state(file_name):
+            self._workspace.update(file_name)
             self._initialize_on_open(view)
 
     def _initialize_on_open(self, view: ViewLike) -> None:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -475,11 +475,12 @@ class WindowManager(object):
         for config_name in list(self._sessions):
             self.end_session(config_name)
 
+    # TODO: this should probably only end 1 session
     def end_session(self, config_name: str) -> None:
-        for config_name, sessions in self._sessions.items():
-            for session in sessions:
-                debug("unloading session", config_name)
-                session.end()
+        config_sessions = self._sessions[config_name] or []
+        for session in config_sessions:
+            debug("unloading session", config_name)
+            session.end()
 
     def get_project_path(self, file_path: str) -> 'Optional[str]':
         for folder in self._workspace_folders:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -367,7 +367,7 @@ class WindowManager(object):
     def disable_config(self, config_name: str) -> None:
         disable_in_project(self._window, config_name)
         self.update_configs()
-        self.end_session(config_name)
+        self.end_config_sessions(config_name)
 
     def start_active_views(self) -> None:
         active_views = get_active_views(self._window)
@@ -473,10 +473,9 @@ class WindowManager(object):
     def end_sessions(self) -> None:
         self.documents.reset()
         for config_name in list(self._sessions):
-            self.end_session(config_name)
+            self.end_config_sessions(config_name)
 
-    # TODO: this should probably only end 1 session
-    def end_session(self, config_name: str) -> None:
+    def end_config_sessions(self, config_name: str) -> None:
         config_sessions = self._sessions[config_name] or []
         for session in config_sessions:
             debug("unloading session", config_name)

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -323,8 +323,6 @@ class WindowManager(object):
                  diagnostics: DiagnosticsStorage, session_starter: 'Callable', sublime: 'Any',
                  handler_dispatcher: LanguageHandlerListener, on_closed: 'Optional[Callable]' = None) -> None:
 
-        # to move here:
-        # configurations.py: window_client_configs and all references
         self._window = window
         self._configs = configs
         self.diagnostics = diagnostics
@@ -382,7 +380,6 @@ class WindowManager(object):
         self.end_config_sessions(config_name)
 
     def start_active_views(self) -> None:
-        debug('folders', self._window.folders(), ' project file', self._window.project_file_name())
         active_views = get_active_views(self._window)
         debug('window {} starting {} initial views'.format(self._window.id(), len(active_views)))
         for view in active_views:
@@ -413,8 +410,6 @@ class WindowManager(object):
         # have all sessions for this document been started?
         with self._initialization_lock:
             new_configs = needed_configs(self._configs.syntax_configs(view, include_disabled=True))
-            # filter(lambda c: c.name not in self._sessions,
-            #                  self._configs.syntax_configs(view, include_disabled=True))
 
             if any(new_configs):
                 # TODO: cannot observe project setting changes
@@ -557,7 +552,6 @@ class WindowManager(object):
         self._handlers.on_initialized(session.config.name, self._window, client)
 
         client.send_notification(Notification.initialized())
-        # from LSP import rpdb; rpdb.set_trace()
 
         document_sync = session.capabilities.get("textDocumentSync")
         if document_sync:
@@ -582,9 +576,6 @@ class WindowManager(object):
                     self._sublime.set_timeout_async(lambda: self._check_window_closed(), 100)
 
     def _check_window_closed(self) -> None:
-        # debug('window {} check window closed closing={}, valid={}'.format(
-        # self._window.id(), self._is_closing, self._window.is_valid()))
-
         if not self._is_closing and not self._window.is_valid():
             self._handle_window_closed()
 

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -9,7 +9,7 @@ from .sessions import Session
 from .url import filename_to_uri
 from .workspace import (
     enable_in_project, disable_in_project, maybe_get_first_workspace_from_window,
-    maybe_get_workspace_from_view, WorkspaceFolder
+    maybe_get_workspace_from_view, WorkspaceFolder, get_workspace_folders
 )
 
 from .rpc import Client
@@ -424,31 +424,22 @@ class WindowManager(object):
         if not self._handlers.on_start(config.name, self._window):
             return
 
-        # workspace = self._ensure_workspace()
+        workspace_folders = get_workspace_folders(self._window, file_path)
+
+        # TODO: fix
+        workspace = self._ensure_workspace()
 
         # if workspace is None:
         #     debug('Cannot start without a project folder')
         #     return
 
-        # project_path = workspace.path
-        folders = self._window.folders()
-        sorted_folders = []  # type: List[str]
-        if not folders:
-            sorted_folders.append(os.path.basename(file_path))
-        else:
-            for folder in folders:
-                if file_path.startswith(folder):
-                    sorted_folders.insert(0, folder)
-                else:
-                    sorted_folders.append(folder)
-
         self._window.status_message("Starting " + config.name + "...")
-        debug("starting in", sorted_folders[0])
+        debug("starting in", workspace_folders[0].path)
         session = None  # type: Optional[Session]
         try:
             session = self._start_session(
                 self._window,                  # window
-                sorted_folders,                # workspace_folders
+                workspace_folders,                # workspace_folders
                 config,                        # config
                 self._handle_pre_initialize,   # on_pre_initialize
                 self._handle_post_initialize,  # on_post_initialize

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -30,7 +30,7 @@ class ProjectFolders(object):
                 self._on_switched(new_folders)
 
     def _set_folders(self, folders: 'List[str]') -> None:
-        self.folders = get_workspace_folders(self._window)
+        self.folders = folders
         self.workspace_folders = [WorkspaceFolder.from_path(f) for f in self.folders]
 
     def _can_update_to(self, new_folders: 'List[str]') -> bool:

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -20,7 +20,7 @@ def get_workspace_folders(window: WindowLike, file_path: 'Optional[str]' = None)
             else:
                 sorted_folders.append(folder)
     elif file_path:
-        sorted_folders.append(os.path.basename(file_path))
+        sorted_folders.append(os.path.dirname(file_path))
 
     return [WorkspaceFolder.from_path(folder) for folder in sorted_folders]
 

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -1,7 +1,6 @@
 from .logging import debug
 from .protocol import WorkspaceFolder
 from .types import WindowLike
-import os
 
 try:
     from typing import List, Optional, Any, Dict, Iterable, Union, Callable

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -34,6 +34,21 @@ def maybe_get_workspace_from_view(view_or_window: 'Any') -> 'Optional[WorkspaceF
     return None
 
 
+def get_workspace_folders(window: 'WindowLike', file_path: str) -> 'List[WorkspaceFolder]':
+    folders = window.folders()
+    sorted_folders = []  # type: List[str]
+    if not folders:
+        sorted_folders.append(os.path.basename(file_path))
+    else:
+        for folder in folders:
+            if file_path.startswith(folder):
+                sorted_folders.insert(0, folder)
+            else:
+                sorted_folders.append(folder)
+
+    return [WorkspaceFolder.from_path(folder) for folder in sorted_folders]
+
+
 def enable_in_project(window: 'Any', config_name: str) -> None:
     project_data = window.project_data()
     if isinstance(project_data, dict):

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -4,10 +4,90 @@ from .types import WindowLike
 import os
 
 try:
-    from typing import List, Optional, Any, Dict, Iterable, Union
-    assert List and Optional and Any and Dict and Iterable and Union
+    from typing import List, Optional, Any, Dict, Iterable, Union, Callable
+    assert List and Optional and Any and Dict and Iterable and Union and Callable
 except ImportError:
     pass
+
+
+class Workspace(object):
+
+    def __init__(self, folders: 'List[str]') -> None:
+        self.folders = folders
+        self._workspace_folders = [WorkspaceFolder.from_path(f) for f in self.folders]
+
+    def is_empty(self) -> bool:
+        return not any(self.folders)
+
+    @property
+    def workspace_folders(self) -> 'List[WorkspaceFolder]':
+        return self._workspace_folders
+
+    @property
+    def working_directory(self) -> 'Optional[str]':
+        return self.folders[0] if self.folders else None
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Workspace):
+            return self.folders == other.folders
+        else:
+            raise NotImplementedError()
+
+
+class WorkspaceManager(object):
+
+    def __init__(self, window: WindowLike, on_changed: 'Callable[[Workspace], None]',
+                 on_switched: 'Callable[[Workspace], None]') -> None:
+        self._window = window
+        self._on_changed = on_changed
+        self._on_switched = on_switched
+        self._workspace = get_workspace(self._window, None)
+        self._current_project_file_name = self._window.project_file_name()
+
+    @property
+    def current(self) -> 'Workspace':
+        return self._workspace
+
+    def update(self, file_path: str) -> None:
+        new_workspace = get_workspace(self._window, file_path)
+        if new_workspace != self._workspace:
+            if self._can_update_to(new_workspace):
+                self._workspace = new_workspace
+                self._on_changed(new_workspace)
+            else:
+                self._workspace = new_workspace
+                self._on_switched(new_workspace)
+
+    def _can_update_to(self, workspace: Workspace) -> bool:
+        if self._workspace.is_empty():
+            return True
+
+        if self._current_project_file_name and self._window.project_file_name() == self._current_project_file_name:
+            return True
+
+        for folder in self._workspace.folders:
+            if folder in workspace.folders:
+                return True
+
+        return False
+
+
+def get_workspace(window: WindowLike, file_path: 'Optional[str]' = None) -> Workspace:
+    folders = window.folders()
+    if file_path:
+        sorted_folders = []  # type: List[str]
+        if folders:
+            for folder in folders:
+                if file_path and file_path.startswith(folder):
+                    sorted_folders.insert(0, folder)
+                else:
+                    sorted_folders.append(folder)
+        else:
+            sorted_folders = [os.path.dirname(file_path)]
+
+        return Workspace(sorted_folders)
+    else:
+        return Workspace(folders)
 
 
 def get_workspace_folders(window: WindowLike, file_path: 'Optional[str]' = None) -> 'List[WorkspaceFolder]':

--- a/plugin/core/workspace.py
+++ b/plugin/core/workspace.py
@@ -10,41 +10,17 @@ except ImportError:
     pass
 
 
-def maybe_get_first_workspace_from_window(window: WindowLike) -> 'Optional[WorkspaceFolder]':
-    folders = window.folders()
-    if not folders:
-        return None
-    return WorkspaceFolder.from_path(folders[0])
-
-
-def maybe_get_workspace_from_view(view_or_window: 'Any') -> 'Optional[WorkspaceFolder]':
-    if hasattr(view_or_window, 'file_name'):
-        filename = view_or_window.file_name()
-    elif hasattr(view_or_window, 'active_view'):
-        view = view_or_window.active_view()
-        if not view:
-            return None
-        filename = view.file_name()
-    else:
-        return None
-    if filename and os.path.exists(filename):  # https://github.com/tomv564/LSP/issues/644
-        path = os.path.dirname(filename)
-        return WorkspaceFolder.from_path(path)
-    debug("the current file isn't saved to disk.")
-    return None
-
-
-def get_workspace_folders(window: 'WindowLike', file_path: str) -> 'List[WorkspaceFolder]':
+def get_workspace_folders(window: WindowLike, file_path: 'Optional[str]' = None) -> 'List[WorkspaceFolder]':
     folders = window.folders()
     sorted_folders = []  # type: List[str]
-    if not folders:
-        sorted_folders.append(os.path.basename(file_path))
-    else:
+    if folders:
         for folder in folders:
-            if file_path.startswith(folder):
+            if file_path and file_path.startswith(folder):
                 sorted_folders.insert(0, folder)
             else:
                 sorted_folders.append(folder)
+    elif file_path:
+        sorted_folders.append(os.path.basename(file_path))
 
     return [WorkspaceFolder.from_path(folder) for folder in sorted_folders]
 

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -159,7 +159,6 @@ class DiagnosticsPhantoms(object):
     def set_diagnostic(self, file_diagnostic: 'Optional[Tuple[str, Diagnostic]]') -> None:
         self.clear()
 
-        self._base_dir = windows.lookup(self._window).get_project_path()
         if file_diagnostic:
             file_path, diagnostic = file_diagnostic
             view = self._window.open_file(file_path, sublime.TRANSIENT)
@@ -203,9 +202,10 @@ class DiagnosticsPhantoms(object):
     # TODO: share with hover?
     def format_diagnostic_related_info(self, info: DiagnosticRelatedInformation) -> str:
         file_path = info.location.file_path
-        if self._base_dir and file_path.startswith(self._base_dir):
-            file_path = os.path.relpath(file_path, self._base_dir)
-        location = "{}:{}:{}".format(file_path, info.location.range.start.row+1, info.location.range.start.col+1)
+        base_dir = windows.lookup(self._window).get_project_path(file_path)
+        if base_dir:
+            file_path = os.path.relpath(file_path, base_dir)
+        location = "{}:{}:{}".format(info.location.file_path, info.location.range.start.row+1, info.location.range.start.col+1)
         return "<a href='location:{}'>{}</a>: {}".format(location, location, html.escape(info.message))
 
     def navigate(self, href: str) -> None:
@@ -218,7 +218,6 @@ class DiagnosticsPhantoms(object):
         elif href.startswith("location"):
             # todo: share with hover?
             _, file_path, location = href.split(":", 2)
-            file_path = os.path.join(self._base_dir, file_path) if self._base_dir else file_path
             self._window.open_file(file_path + ":" + location, sublime.ENCODED_POSITION | sublime.TRANSIENT)
 
     def create_phantom_html(self, content: str, severity: str) -> str:
@@ -322,11 +321,11 @@ class DiagnosticOutputPanel(DiagnosticsUpdateWalk):
         self._panel = ensure_diagnostics_panel(self._window)
 
     def begin(self) -> None:
-        self._base_dir = windows.lookup(self._window).get_project_path()
         self._to_render = []
         self._file_content = ""
 
     def begin_file(self, file_path: str) -> None:
+        self._base_dir = windows.lookup(self._window).get_project_path(file_path)
         self._file_content = ""
 
     def diagnostic(self, diagnostic: Diagnostic) -> None:

--- a/plugin/diagnostics.py
+++ b/plugin/diagnostics.py
@@ -205,7 +205,8 @@ class DiagnosticsPhantoms(object):
         base_dir = windows.lookup(self._window).get_project_path(file_path)
         if base_dir:
             file_path = os.path.relpath(file_path, base_dir)
-        location = "{}:{}:{}".format(info.location.file_path, info.location.range.start.row+1, info.location.range.start.col+1)
+        location = "{}:{}:{}".format(info.location.file_path, info.location.range.start.row + 1,
+                                     info.location.range.start.col + 1)
         return "<a href='location:{}'>{}</a>: {}".format(location, location, html.escape(info.message))
 
     def navigate(self, href: str) -> None:

--- a/plugin/hover.py
+++ b/plugin/hover.py
@@ -85,7 +85,7 @@ class LspHoverCommand(LspTextCommand):
 
     def run(self, edit: sublime.Edit, point: 'Optional[int]' = None) -> None:
         hover_point = point or self.view.sel()[0].begin()
-        self._base_dir = windows.lookup(self.view.window()).get_project_path()
+        self._base_dir = windows.lookup(self.view.window()).get_project_path(self.view.file_name() or "")
 
         self._hover = None  # type: Optional[Any]
         self._actions_by_config = {}  # type: Dict[str, List[CodeActionOrCommand]]

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -47,7 +47,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
             self.word = self.view.substr(self.word_region)
 
             # use relative paths if file on the same root.
-            base_dir = windows.lookup(window).get_project_path()
+            base_dir = windows.lookup(window).get_project_path(file_path)
             if base_dir:
                 if os.path.commonprefix([base_dir, file_path]):
                     self.base_dir = base_dir
@@ -139,7 +139,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
                 # append a new line after each file name
                 text += '\n'
 
-            base_dir = windows.lookup(window).get_project_path()
+            base_dir = windows.lookup(window).get_project_path(self.view.file_name() or "")
             panel.settings().set("result_base_dir", base_dir)
 
             panel.set_read_only(False)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -47,8 +47,8 @@ def remove_config(config):
 
 
 def inject_session(wm, config, client) -> Session:
-    session = Session(config, "", client, wm._handle_pre_initialize, wm._handle_post_initialize)
-    wm._sessions[config.name] = session
+    session = Session(config, workspace_folders, client, wm._handle_pre_initialize, wm._handle_post_initialize)
+    wm._sessions[config.name] = [session]
     wm.update_configs()
     wm._workspace_folders = workspace_folders
     return session

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -10,11 +10,14 @@ from LSP.plugin.core.test_mocks import basic_responses
 from LSP.plugin.core.settings import client_configs
 from LSP.plugin.core.rpc import Client
 from LSP.plugin.core.transports import Transport
+from LSP.plugin.core.protocol import WorkspaceFolder
 from os.path import dirname
 from LSP.plugin.core.registry import windows
 from unittesting import DeferrableTestCase
 
-test_file_path = dirname(__file__) + "/testfile.txt"
+project_path = dirname(__file__)
+test_file_path = project_path + "/testfile.txt"
+workspace_folders = [WorkspaceFolder.from_path(project_path)]
 
 SUPPORTED_SCOPE = "text.plain"
 SUPPORTED_SYNTAX = "Packages/Text/Plain text.tmLanguage"
@@ -47,6 +50,7 @@ def inject_session(wm, config, client) -> Session:
     session = Session(config, "", client, wm._handle_pre_initialize, wm._handle_post_initialize)
     wm._sessions[config.name] = session
     wm.update_configs()
+    wm._workspace_folders = workspace_folders
     return session
 
 


### PR DESCRIPTION
Closes #443 - if people are satisfied they can setup multiple project folders into their monorepo-style workspace
Closes #785 - if someone can confirm this makes the "module in wrong path" error from Go go away.

**Implementation details**
* A window now stores a list of sessions per configuration, instead of just one session per config.
* Each session has a list of paths it handles, which can be queried with `session.handles_path(file_path)`
* Servers are sent all folders at startup, the first folder being the one a file was originally opened in.
  * If the server confirms support for multiple folders, the session keeps all folders. 
  * If not, only the folder with the opened file is kept. 
* We can send `didChangeWorkspaceFolders` when opening a file in a newly added folder. Added in https://github.com/tomv564/LSP/pull/809/commits/f765ea193c53c451f3cdcffcdcf6a0f3f5c22f49

**Not solved**

* <strike>We won't send `workspace/didChangeWorkspaceFolders` yet, need a reliable way to detect folders changing.</strike> See above
* Unsure if some servers do not support overlapping folders (and solve it in their VS Code extension). 

**To do:**

- [x] Support `workspace/workspaceFolders` request
- [x] Testing and fixing of projects that have child folders of another folder.
- [x] Review of TODOs and debug logging in code
- [x] Remove fake directory for folderless sessions (send `None` for rootUri as VS Code does)
- [x] Manual testing of quick switch project
- [x] Manual review of places relative paths are shown and navigated to (hover, diagnostics, references)