### PR TITLE
Upgrade python and tools to recent version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 before_install:
     - pip install "mypy==0.750"
     - pip install "flake8==3.7.9"
-    - pip install yapf
+    - pip install "yapf==0.29.0"
     - pip install python-coveralls
     - curl -OL https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/travis.sh
     # enable gui, see https://docs.travis-ci.com/user/gui-and-headless-browsers

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ env:
         - SUBLIME_TEXT_VERSION="3"
 language: python
 python:
-    - "3.3"  # sublime text 3 has 3.3
+    - "3.5"  # sublime text 3 has 3.3
 before_install:
-    - pip install "mypy==0.570"
-    - pip install "flake8==3.5.0"
-    # - pip install yapf
+    - pip install "mypy==0.750"
+    - pip install "flake8==3.7.9"
+    - pip install yapf
     - pip install python-coveralls
     - curl -OL https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/travis.sh
     # enable gui, see https://docs.travis-ci.com/user/gui-and-headless-browsers
@@ -28,6 +28,6 @@ script:
     - flake8 plugin tests
     - coverage run -m unittest discover
     - sh travis.sh run_tests
-    # - yapf --diff plugin/core/main.py
+    - yapf --diff plugin/core/main.py
 after_success:
     - coveralls

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -36,7 +36,7 @@ class CompletionHelper(sublime_plugin.EventListener):
 
 class LspTrimCompletionCommand(sublime_plugin.TextCommand):
 
-    def run(self, edit: sublime.Edit, range: 'Optional[Tuple[int, int]]'=None) -> None:
+    def run(self, edit: sublime.Edit, range: 'Optional[Tuple[int, int]]' = None) -> None:
         if range:
             start, end = range
             region = sublime.Region(start, end)

--- a/plugin/core/configurations.py
+++ b/plugin/core/configurations.py
@@ -122,7 +122,7 @@ class WindowConfigManager(object):
     def scope_configs(self, view: 'Any', point: 'Optional[int]' = None) -> 'Iterator[ClientConfig]':
         return get_scope_client_configs(view, self.all, point)
 
-    def syntax_configs(self, view: 'Any', include_disabled: bool=False) -> 'List[ClientConfig]':
+    def syntax_configs(self, view: 'Any', include_disabled: bool = False) -> 'List[ClientConfig]':
         syntax = view.settings().get("syntax")
         return list(filter(lambda c: config_supports_syntax(c, syntax) and (c.enabled or include_disabled), self.all))
 

--- a/plugin/core/protocol.py
+++ b/plugin/core/protocol.py
@@ -316,7 +316,7 @@ class Range(object):
 
 
 class ContentChange(object):
-    def __init__(self, text: str, range: 'Optional[Range]'=None, range_length: 'Optional[int]'=None) -> None:
+    def __init__(self, text: str, range: 'Optional[Range]' = None, range_length: 'Optional[int]' = None) -> None:
         """
 
         [description]

--- a/plugin/core/rpc.py
+++ b/plugin/core/rpc.py
@@ -121,7 +121,7 @@ class Client(object):
                 # We go to sleep. We wake up once another thread calls .notify() on this condition variable.
                 self._sync_request_cvar.wait_for(lambda: request_id in self._sync_request_results, timeout)
                 result = self._sync_request_results.pop(request_id)
-        except KeyError as e:
+        except KeyError:
             debug('timeout on', request.method)
             return None
         return result

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -116,10 +116,10 @@ class DiagnosticsWalkerTests(unittest.TestCase):
         walker = DiagnosticsWalker([walk])
         walker.walk({})
 
-        walk.begin.assert_called_once()
-        walk.begin_file.assert_not_called()
-        walk.diagnostic.assert_not_called()
-        walk.end.assert_called_once()
+        assert walk.begin.call_count == 1
+        assert walk.begin_file.call_count == 0
+        assert walk.diagnostic.call_count == 0
+        assert walk.end.call_count == 1
 
     def test_one_diagnosic(self):
 
@@ -130,10 +130,10 @@ class DiagnosticsWalkerTests(unittest.TestCase):
         diags[test_file_path]["test_server"] = [minimal_diagnostic]
         walker.walk(diags)
 
-        walk.begin.assert_called_once()
+        assert walk.begin.call_count == 1
         walk.begin_file.assert_called_with(test_file_path)
         walk.diagnostic.assert_called_with(minimal_diagnostic)
-        walk.end.assert_called_once()
+        assert walk.end.call_count == 1
 
 
 row1 = at_row(1)

--- a/plugin/core/test_diagnostics.py
+++ b/plugin/core/test_diagnostics.py
@@ -106,7 +106,7 @@ class DiagnosticsStorageTest(unittest.TestCase):
         ui.select.assert_called_with(-1)
 
         wd.select_none()
-        ui.deselect.assert_called()
+        assert ui.deselect.call_count > 0
 
 
 class DiagnosticsWalkerTests(unittest.TestCase):

--- a/plugin/core/test_mocks.py
+++ b/plugin/core/test_mocks.py
@@ -170,7 +170,7 @@ class MockWindow(object):
         pass
 
     def views(self):
-        views = []
+        views = []  # type: List[ViewLike]
         for views_in_group in self._files_in_groups:
             if len(views_in_group) < 1:
                 views.append(self._default_view)

--- a/plugin/core/test_mocks.py
+++ b/plugin/core/test_mocks.py
@@ -204,7 +204,7 @@ class MockConfigs(object):
         else:
             return [TEST_CONFIG]
 
-    def syntax_configs(self, view, include_disabled: bool=False):
+    def syntax_configs(self, view, include_disabled: bool = False):
         if view.settings().get("syntax") == "Plain Text":
             return [TEST_CONFIG]
         else:

--- a/plugin/core/test_session.py
+++ b/plugin/core/test_session.py
@@ -47,7 +47,7 @@ class SessionTest(unittest.TestCase):
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
-        post_initialize_callback.assert_called_once()
+        assert post_initialize_callback.call_count == 1
 
     def test_pre_initialize_callback_is_invoked(self):
         project_path = "/"
@@ -65,8 +65,8 @@ class SessionTest(unittest.TestCase):
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
         self.assertTrue(session.get_capability("testing"))
-        pre_initialize_callback.assert_called_once()
-        post_initialize_callback.assert_called_once()
+        assert pre_initialize_callback.call_count == 1
+        assert post_initialize_callback.call_count == 1
 
     def test_can_shutdown_session(self):
         project_path = "/"
@@ -83,10 +83,10 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(session.state, ClientStates.READY)
         self.assertIsNotNone(session.client)
         self.assertTrue(session.has_capability("testing"))
-        post_initialize_callback.assert_called_once()
+        assert post_initialize_callback.call_count == 1
         session.end()
         self.assertEqual(session.state, ClientStates.STOPPING)
         self.assertIsNone(session.client)
         self.assertFalse(session.has_capability("testing"))
         self.assertIsNone(session.get_capability("testing"))
-        post_exit_callback.assert_called_once()
+        assert post_exit_callback.call_count == 1

--- a/plugin/core/transports.py
+++ b/plugin/core/transports.py
@@ -48,7 +48,7 @@ StateStrings = {STATE_HEADERS: 'STATE_HEADERS',
 
 
 def state_to_string(state: int) -> str:
-    return StateStrings.get(state, '<unknown state: %d>'.format(state))
+    return StateStrings.get(state, '<unknown state: {}>'.format(state))
 
 
 def start_tcp_listener(tcp_port: int) -> socket.socket:

--- a/plugin/core/types.py
+++ b/plugin/core/types.py
@@ -173,7 +173,7 @@ class ConfigRegistry(Protocol):
     def scope_configs(self, view: ViewLike, point: 'Optional[int]' = None) -> 'Iterator[ClientConfig]':
         ...
 
-    def syntax_configs(self, view: ViewLike, include_disabled: bool=False) -> 'List[ClientConfig]':
+    def syntax_configs(self, view: ViewLike, include_disabled: bool = False) -> 'List[ClientConfig]':
         ...
 
     def syntax_supported(self, view: ViewLike) -> bool:

--- a/plugin/core/windows.py
+++ b/plugin/core/windows.py
@@ -140,7 +140,7 @@ class WindowDocumentHandler(object):
     def has_document_state(self, path: str) -> bool:
         return path in self._document_states
 
-    def _get_applicable_sessions(self, view: ViewLike, notification_type: 'Optional[str]'=None) -> 'List[Session]':
+    def _get_applicable_sessions(self, view: ViewLike, notification_type: 'Optional[str]' = None) -> 'List[Session]':
         sessions = []  # type: List[Session]
         syntax = view.settings().get("syntax")
         for config_name, session in self._sessions.items():

--- a/plugin/references.py
+++ b/plugin/references.py
@@ -114,7 +114,7 @@ class LspSymbolReferencesCommand(LspTextCommand):
     def on_ref_highlight(self, index: int) -> None:
         self.open_ref_index(index, transient=True)
 
-    def open_ref_index(self, index: int, transient: bool=False) -> None:
+    def open_ref_index(self, index: int, transient: bool = False) -> None:
         if index != -1:
             flags = sublime.ENCODED_POSITION | sublime.TRANSIENT if transient else sublime.ENCODED_POSITION
             window = self.view.window()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py33
+envlist = py35
 skipsdist = True
 
 [pycodestyle]
@@ -18,9 +18,11 @@ deps =
     pytest
     coverage
     pytest-cov
-    flake8==3.5.0
-    mypy==0.570
+    flake8==3.7.9
+    mypy==0.750
+    yapf==0.29.0
 commands =
     mypy plugin
     flake8 plugin tests
     pytest --quiet plugin
+    yapf --diff plugin/core/main.py


### PR DESCRIPTION
Unsure if we really want to do this for ST3, but this PR will track the impact:

- [x] flake8: `E252 missing whitespace around parameter equals` on argument default values.
- [x] mypy: two small issues (incorrect format() call and new need for a type annotation.
- [x] unittest (mock) was using non-existing methods "assert_called_once" and "assert_not_called" (and silently passing)
- [x] Checking formatting correctness with `yapf --diff` works