### PR TITLE
Closes #812 added R to default config and to documentation

### DIFF
--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -494,12 +494,37 @@
       // },
     },
     "vscode-css":
-      {
-        "command": ["css-languageserver", "--stdio"],
-        "scopes": ["source.css"],
-        "syntaxes": ["Packages/CSS/CSS.sublime-syntax"],
-        "languageId": "css"
-      },
+    {
+      "command": 
+      [
+        "css-languageserver", "--stdio"
+      ],
+      "scopes": 
+      [
+        "source.css"
+      ],
+      "syntaxes": 
+      [
+        "Packages/CSS/CSS.sublime-syntax"
+      ],
+      "languageId": "css"
+    },
+    "rlang":
+    {
+      "command":
+      [
+        "R", "--slave", "-e", "languageserver::run()"
+      ],
+      "scopes":
+      [
+        "source.r"
+      ],
+      "syntaxes":
+      [
+        "Packages/R/R.sublime-syntax"
+      ],
+      "languageId": "r"
+    }
 
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,15 +100,7 @@ Requires installation of the `languageserver` package from CRAN:
 
 See the [CRAN mirrored package on GitHub](https://github.com/cran/languageserver) for more information and up-to-date installation instructions.
 
-```json
-"rlang":
-{
-  "command": ["R", "--slave", "-e", "languageserver::run()"],
-  "scopes": ["source.r"],
-  "syntaxes": ["Packages/R/R.sublime-syntax"],
-  "languageId": "r"
-}
-```
+Once this has been done the language server need only be enabled to work, as it is included amongst the default clients.
 
 
 ### Scala<a name="scala"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,25 @@ Goes well with the [Rust Enhanced package](https://github.com/rust-lang/rust-enh
 Alternatively, a newer [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer) server is under development, also supported by LSP.
 
 
+### R<a name="r"></a>
+
+Requires installation of the `languageserver` package from CRAN:
+
+`install.packages("languageserver")`
+
+See the [CRAN mirrored package on GitHub](https://github.com/cran/languageserver) for more information and up-to-date installation instructions.
+
+```json
+"rlang":
+{
+  "command": ["R", "--slave", "-e", "languageserver::run()"],
+  "scopes": ["source.r"],
+  "syntaxes": ["Packages/R/R.sublime-syntax"],
+  "languageId": "r"
+}
+```
+
+
 ### Scala<a name="scala"></a>
 
 *  **[Metals](https://scalameta.org/metals/)**: Most complete LSP server for Scala, see instructions [here](https://scalameta.org/metals/docs/editors/sublime.html) for installation.


### PR DESCRIPTION
Following on from issue #812 have added R to the default list of clients in `LSP.sublime-settings` and added a note to the docs to install `languageserver` from CRAN first.