### PR TITLE
Completion filtering fixes

### DIFF
--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -121,11 +121,6 @@ class CompletionHandler(LSPViewEventListener):
         if self.last_location < 0:
             return False
 
-        # issue 745, some servers return nothing until some chars into a word are returned
-        # Don't cache these empty responses.
-        if prefix and self.last_prefix == "" and not self.completions:
-            return False
-
         # completion requests from the same location with the same prefix are cached.
         current_start = locations[0] - len(prefix)
         last_start = self.last_location - len(self.last_prefix)

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -13,7 +13,7 @@ from .core.logging import debug
 from .core.completion import parse_completion_response, format_completion
 from .core.registry import session_for_view, client_from_session, LSPViewEventListener
 from .core.configurations import is_supported_syntax
-from .core.documents import get_document_position, is_at_word
+from .core.documents import get_document_position, position_is_word
 from .core.sessions import Session
 from .core.edit import parse_text_edit
 
@@ -176,8 +176,11 @@ class CompletionHandler(LSPViewEventListener):
 
     def on_completion_inserted(self) -> None:
         # get text inserted from last completion
-        word = self.view.word(self.last_location)
-        begin = word.begin()
+        begin = self.last_location
+        if position_is_word(self.view, begin):
+            word = self.view.word(self.last_location)
+            begin = word.begin()
+
         region = sublime.Region(begin, self.view.sel()[0].end())
         inserted = self.view.substr(region)
 
@@ -246,7 +249,7 @@ class CompletionHandler(LSPViewEventListener):
         return None
 
     def on_text_command(self, command_name: str, args: 'Optional[Any]') -> None:
-        self.committing = command_name in ('commit_completion', 'insert_best_completion', 'auto_complete')
+        self.committing = command_name in ('commit_completion', 'auto_complete')
 
     def do_request(self, prefix: str, locations: 'List[int]') -> None:
         self.next_request = None

--- a/plugin/completion.py
+++ b/plugin/completion.py
@@ -238,8 +238,9 @@ class CompletionHandler(LSPViewEventListener):
                     self.completions = []
 
             elif self.state in (CompletionState.REQUESTING, CompletionState.CANCELLING):
-                self.next_request = (prefix, locations)
-                self.state = CompletionState.CANCELLING
+                if not reuse_completion:
+                    self.next_request = (prefix, locations)
+                    self.state = CompletionState.CANCELLING
 
             elif self.state == CompletionState.APPLYING:
                 self.state = CompletionState.IDLE

--- a/plugin/core/documents.py
+++ b/plugin/core/documents.py
@@ -40,7 +40,11 @@ def get_position(view: sublime.View, event: 'Optional[dict]' = None) -> int:
 
 def is_at_word(view: sublime.View, event: 'Optional[dict]') -> bool:
     pos = get_position(view, event)
-    point_classification = view.classify(pos)
+    return position_is_word(view, pos)
+
+
+def position_is_word(view: sublime.View, position: int) -> bool:
+    point_classification = view.classify(position)
     if point_classification & SUBLIME_WORD_MASK:
         return True
     else:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -95,11 +95,11 @@ edit_after_nonword = [
              'range': {
                  'start': {
                      'line': 0,
-                     'character': 6
+                     'character': 5
                  },
                  'end': {
                      'line': 0,
-                     'character': 6
+                     'character': 5
                  }
              }
          })
@@ -164,7 +164,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             # todo: want to test trigger chars instead?
             # self.view.run_command('insert', {"characters": '.'})
-            result = handler.on_query_completions("", [1])
+            result = handler.on_query_completions("", [0])
 
             # synchronous response
             self.assertTrue(handler.initialized)
@@ -191,7 +191,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)
         if handler:
-            handler.on_query_completions("", [1])
+            handler.on_query_completions("", [0])
             yield 100
             self.view.run_command("commit_completion")
             self.assertEquals(
@@ -264,7 +264,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)
         if handler:
-            handler.on_query_completions("", [1])
+            handler.on_query_completions("", [0])
             yield 100
             self.view.run_command("commit_completion")
             self.assertEquals(
@@ -331,7 +331,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)
         if handler:
-            handler.on_query_completions("", [6])
+            handler.on_query_completions("", [5])
             yield 100
             # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('commit_completion', {})
@@ -369,7 +369,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)
         if handler:
-            handler.on_query_completions("", [1])
+            handler.on_query_completions("", [0])
             yield 100
             # note: invoking on_text_command manually as sublime doesn't call it.
             handler.on_text_command('commit_completion', {})
@@ -388,7 +388,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         handler = self.get_view_event_listener("on_query_completions")
         self.assertIsNotNone(handler)
         if handler:
-            handler.on_query_completions("", [1])
+            handler.on_query_completions("", [0])
 
             # note: ideally the handler is initialized with resolveProvider capability
             handler.resolve = True

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -180,7 +180,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
             self.assertEquals(len(handler.completions), 2)
 
             # verify insertion works
-            self.view.run_command("insert_best_completion")
+            self.view.run_command("commit_completion")
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())), 'asdf')
 
@@ -193,7 +193,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
             yield 100
-            self.view.run_command("insert_best_completion")
+            self.view.run_command("commit_completion")
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
                 insert_text_completions[0]["insertText"])
@@ -209,7 +209,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
             yield 100
-            self.view.run_command("insert_best_completion")
+            self.view.run_command("commit_completion")
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())), '$what')
 
@@ -229,7 +229,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
             yield 100
-            self.view.run_command("insert_best_completion")
+            self.view.run_command("commit_completion")
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())), '$what')
 
@@ -249,7 +249,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
             yield 100
-            self.view.run_command("insert_best_completion")
+            self.view.run_command("commit_completion")
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())), '$what')
 
@@ -266,7 +266,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
             yield 100
-            self.view.run_command("insert_best_completion")
+            self.view.run_command("commit_completion")
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())), 'const')
 
@@ -287,7 +287,7 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
             yield 100
-            self.view.run_command("insert_best_completion")
+            self.view.run_command("commit_completion")
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
                 '-UniqueId')
@@ -309,8 +309,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
             handler.on_query_completions("myF", [7])
             yield 100
             # note: invoking on_text_command manually as sublime doesn't call it.
-            handler.on_text_command('insert_best_completion', {})
-            self.view.run_command("insert_best_completion", {})
+            handler.on_text_command('commit_completion', {})
+            self.view.run_command("commit_completion", {})
             yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
@@ -334,8 +334,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
             handler.on_query_completions("", [6])
             yield 100
             # note: invoking on_text_command manually as sublime doesn't call it.
-            handler.on_text_command('insert_best_completion', {})
-            self.view.run_command("insert_best_completion", {})
+            handler.on_text_command('commit_completion', {})
+            self.view.run_command("commit_completion", {})
             yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
@@ -355,8 +355,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
         if handler:
             handler.on_query_completions("", [1])
             yield 100
-            handler.on_text_command('insert_best_completion', {})
-            self.view.run_command('insert_best_completion', {})
+            handler.on_text_command('commit_completion', {})
+            self.view.run_command('commit_completion', {})
             yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
@@ -372,8 +372,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
             handler.on_query_completions("", [1])
             yield 100
             # note: invoking on_text_command manually as sublime doesn't call it.
-            handler.on_text_command('insert_best_completion', {})
-            self.view.run_command("insert_best_completion", {})
+            handler.on_text_command('commit_completion', {})
+            self.view.run_command("commit_completion", {})
             yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),
@@ -395,8 +395,8 @@ class QueryCompletionsTests(TextDocumentTestCase):
 
             yield 100
             # note: invoking on_text_command manually as sublime doesn't call it.
-            handler.on_text_command('insert_best_completion', {})
-            self.view.run_command("insert_best_completion", {})
+            handler.on_text_command('commit_completion', {})
+            self.view.run_command("commit_completion", {})
             yield AFTER_INSERT_COMPLETION_DELAY
             self.assertEquals(
                 self.view.substr(sublime.Region(0, self.view.size())),


### PR DESCRIPTION
Testing with python language server, starting with 

```
view|
``` 

and typing `.settings()` quickly, resulted in _several_ completion requests, and the results shown when irrelevant:

<img width="398" alt="Screenshot 2019-12-10 at 22 53 22" src="https://user-images.githubusercontent.com/4395832/70572327-e3927e00-1b9f-11ea-805b-310fc1a83660.png">

This sequence should result in only 1 completion request of which the results are never shown.

This PR

* prevents showing completion results after crossing a word boundary (https://github.com/tomv564/LSP/commit/54c93d2067e02db7b6706c701c278e8a4660f545),
* prevents discarding requests (going to CANCELLING) when `is_same_completion` (https://github.com/tomv564/LSP/commit/173ea358dc8403a6345963d7831d0d3177699b0c)
* makes `is_same_completion` return True when going from `.` to `.s`  by undoing the fix for #745 (https://github.com/tomv564/LSP/commit/861b7e5dc3e838409430818b13323f6485e8c008)

Also fixes a related issue where pressing tab would dump a huge chunk of document in the console from the inadvertently triggered `on_completion_inserted` logic via `insert_best_completion` (https://github.com/tomv564/LSP/commit/d06e6cd291a278d27d50dfad27abb7dc1fbaa358)
